### PR TITLE
NLP-ENGINE-060 More fixes on replacing longs with the buffer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,26 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(gbd) nlp DOJ",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/nlp.exe",
-            "args": ["-ANA","/home/dehilster/analyzers/DOJ-Quick","-WORK","/home/dehilster/nlp-engine","/home/dehilster/analyzers/DOJ-Quick/input/Scrapy-New/article_12.txt","-DEV"],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                }
-            ]
-        },
-        {
-            "name": "(gbd) nlp Corporate",
+            "name": "(gbd) Corporate",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/nlp.exe",
@@ -46,7 +27,7 @@
             "name": "(gbd) test",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/test.exe",
+            "program": "${workspaceFolder}/test-nlp.exe",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/cs/include/qconsh/arg.h
+++ b/cs/include/qconsh/arg.h
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									ARG.H
 *
-* FILE:	conch.¹/arg.h
+* FILE:	conch.ï¿½/arg.h
 * SUBJ:	Declarations for command-line parsing.
 * CR:	8/20/95 AM.
 *
@@ -43,7 +43,8 @@ arg_get_str(
 extern LIBQCONSH_API void
 args_pp(
 	LIST *args,
-	_t_ostream *out
+	_t_ostream *out,
+	_TCHAR *buf
 	);
 extern LIBQCONSH_API bool
 args_read(

--- a/cs/libconsh/arg.cpp
+++ b/cs/libconsh/arg.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -124,6 +124,7 @@ LIST *end;						/* End of args list.		*/
 int len = 0;
 
 *args = end = LNULL;
+alist->list_add_buf(buf);
 
 #ifdef UNICODE
 cc = getutf8(fp);

--- a/cs/libconsh/cmd.cpp
+++ b/cs/libconsh/cmd.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -139,7 +139,6 @@ for (;;)		/* Execute commands till quit or abort. */
       continue;
       }
    list = args;
-   alist->list_add_buf(buf);
    str = ALIST::list_pop_buf(&args,buf);		/* Get first arg. */
    //str = ALIST::list_pop_buf(&args,alist->List_buffer);		/* Get first arg. */
 //	if (str && *str)							// 10/05/99 AM.
@@ -446,7 +445,7 @@ _TCHAR *name,
 long id;
 SYM *sym;
 CON *con;
-ALIST* alist = cg->alist_;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -454,7 +453,7 @@ if (!args)
    return(false);
    }
 
-name = (_TCHAR *)ALIST::list_pop(&args);
+name = ALIST::list_pop_buf(&args,buf);
 
 if (!args)
    {
@@ -462,7 +461,7 @@ if (!args)
    return(false);
    }
 
-idstr = ALIST::list_pop_buf(&args,alist->List_buffer);
+idstr = ALIST::list_pop_buf(&args,buf);
 
 if (args)
    {

--- a/cs/libconsh/ind.cpp
+++ b/cs/libconsh/ind.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									IND.C
 *
-* FILE:	consh.¹/ind.c
+* FILE:	consh.ï¿½/ind.c
 * SUBJ:	Higher-level knowledge addition commands.
 * CR:		10/15/95 AM.
 * NOTE:	Support multi-line addition commands, with some abstraction from kb.
@@ -254,9 +254,9 @@ for (;;)
 		return(false);
    
    if (!vals
-		 || (!_tcscmp(_T("end"), (_TCHAR *) vals->val)
+		 || (!_tcscmp(_T("end"), ALIST::list_str(&vals,buf))
 			  && vals->next										// PATCH	// 10/26/00 AM.
-			  && !_tcscmp(_T("ind"),(_TCHAR *)vals->next->val))	// PATCH	// 10/26/00 AM.
+			  && !_tcscmp(_T("ind"),ALIST::list_str(&vals->next,buf)))	// PATCH	// 10/26/00 AM.
 		)
       {
       alist->list_free(vals, LNULL);
@@ -273,7 +273,7 @@ for (;;)
       }
    else
       {
-      ok = cg->aptr_->s_to_pval((_TCHAR *) vals->val, p_kind, &p_val);
+      ok = cg->aptr_->s_to_pval(ALIST::list_str(&vals,buf), p_kind, &p_val);
       alist->list_free(vals, LNULL);
       if (!ok)
 			return(false);
@@ -378,9 +378,9 @@ for (;;)
 		return(false);
    
    if (!vals
-		 || (!_tcscmp(_T("end"), (_TCHAR *) vals->val)
+		 || (!_tcscmp(_T("end"), ALIST::list_str(&vals,buf))
 			  && vals->next										// PATCH	// 10/26/00 AM.
-			  && !_tcscmp(_T("ind"),(_TCHAR *)vals->next->val))	// PATCH	// 10/26/00 AM.
+			  && !_tcscmp(_T("ind"),ALIST::list_str(&vals->next,buf)))	// PATCH	// 10/26/00 AM.
 		)
       {
       alist->list_free(vals, LNULL);
@@ -415,7 +415,7 @@ for (;;)
       }
    else
       {
-      ok = cg->aptr_->s_to_pval((_TCHAR *) vals->val, p_kind, &p_val);
+      ok = cg->aptr_->s_to_pval(ALIST::list_str(&vals,buf), p_kind, &p_val);
       alist->list_free(vals, LNULL);
       if (!ok)
 			return(false);
@@ -512,9 +512,9 @@ for (;;)
 		return(false);
    
    if (!vals
-		 || (!_tcscmp(_T("end"), (_TCHAR *) vals->val)
+		 || (!_tcscmp(_T("end"), ALIST::list_str(&vals,buf))
 			  && vals->next										// PATCH	// 10/26/00 AM.
-			  && !_tcscmp(_T("ind"),(_TCHAR *)vals->next->val))	// PATCH	// 10/26/00 AM.
+			  && !_tcscmp(_T("ind"),ALIST::list_str(&vals->next,buf)))	// PATCH	// 10/26/00 AM.
 		)
       {
       alist->list_free(vals, LNULL);
@@ -531,7 +531,7 @@ for (;;)
       }
    else
       {
-      ok = cg->aptr_->s_to_pval((_TCHAR *) vals->val, p_kind, &p_val);
+      ok = cg->aptr_->s_to_pval(ALIST::list_str(&vals,buf), p_kind, &p_val);
       alist->list_free(vals, LNULL);
       if (!ok)
 			return(false);
@@ -596,13 +596,13 @@ if (!ok)
    return(false);
    }
 
-if (!ends || _tcscmp(_T("end"), (_TCHAR *) ends->val))
+if (!ends || _tcscmp(_T("end"), ALIST::list_str(&ends,buf)))
    *out << _T("ind childs: Missing 'end ind'.") << endl;
 alist->list_free(ends, LNULL);
 
 /* ADD CHILDREN TO HIERARCHY */
 save = names;
-while (str = (_TCHAR *) ALIST::list_pop(&names))
+while (str = ALIST::list_str(&names,nbuf))
    cg->acon_->con_add_basic(str, con);
 
 alist->list_free(save, LNULL);
@@ -667,7 +667,7 @@ for (;;)
    if (!ok) return(false);
    
    /* First word = "end" terminates the addition. */
-   if (!list || !_tcscmp(_T("end"), (_TCHAR *) list->val))
+   if (!list || !_tcscmp(_T("end"), ALIST::list_str(&list,buf)))
       {
       alist->list_free(list, LNULL);
       break;
@@ -680,7 +680,7 @@ for (;;)
       return(false);
       }
 
-   word = cg->kbm_->dict_add_word((_TCHAR *) list->val);
+   word = cg->kbm_->dict_add_word(ALIST::list_str(&list,buf));
    alist->list_free(list, LNULL);
    if (!word) return(false);
    elts[count++] = word;
@@ -779,7 +779,7 @@ for (;;)
 		return(false);
 		}
    
-   if (!list || !_tcscmp(_T("end"), (_TCHAR *) list->val))
+   if (!list || !_tcscmp(_T("end"), ALIST::list_str(&list,buf)))
       {
       alist->list_free(list, LNULL);
       break;
@@ -907,7 +907,7 @@ for (;;)
    ok  = args_read(in, out, silent,alist, buf,CMD_SIZE, &vals);
    if (!ok) return(false);
    
-   if (!vals || !_tcscmp(_T("end"), (_TCHAR *) vals->val))
+   if (!vals || !_tcscmp(_T("end"), ALIST::list_str(&vals,buf)))
       {
       alist->list_free(vals, LNULL);
       break;
@@ -922,7 +922,7 @@ for (;;)
       }
    else
       {
-      ok = s_to_pval((_TCHAR *) vals->val, p_kind, &p_val);
+      ok = s_to_pval(ALIST::list_str(&vals,buf), p_kind, &p_val);
       alist->list_free(vals, LNULL);
       if (!ok) return(false);
       }

--- a/cs/libprim/list.cpp
+++ b/cs/libprim/list.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									LIST.C
 *
-* FILE:	consh.¹/list.c
+* FILE:	consh.ï¿½/list.c
 * SUBJ:	Generic list data structures.
 * NOTE:	This is akin to a LISP subsystem, which substantial programs require.
 *		List element will have a generic value field, and pointer to next list
@@ -463,6 +463,17 @@ _TCHAR* ALIST::list_pop_buf(
 	*list = tmp->next;
 	return(&buf[tmp->val]);
 }
+
+_TCHAR* ALIST::list_str(
+	LIST** list,
+	_TCHAR* buf
+)
+{
+	LIST* tmp;
+	tmp = *list;
+	return(&buf[tmp->val]);
+}
+
 
 
 /**************************************************

--- a/cs/libqconsh/arg.cpp
+++ b/cs/libqconsh/arg.cpp
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									ARG.C
 *
-* FILE:	conch.¹/arg.c
+* FILE:	conch.ï¿½/arg.c
 * SUBJ:	Argument parser.
 * CR:	8/26/95 AM.
 * NOTE:	Parse arguments, C-style.
@@ -56,7 +56,8 @@ _TCHAR skip_b(_TCHAR cc, _t_istream *fp);		// 04/20/99 AM.
 LIBQCONSH_API void
 args_pp(
 	LIST *args,
-	_t_ostream *out
+	_t_ostream *out,
+   _TCHAR *buf;
 	)
 {
 _TCHAR *str;
@@ -65,7 +66,7 @@ _TCHAR *str;
 char *lpstr8;
 #endif
 
-while (str = (_TCHAR *) ALIST::list_pop(&args))						// 08/14/02 AM.
+while (str = ALIST::list_pop(&args,buf))						// 08/14/02 AM.
    {
 #ifdef UNICODE
 	u_to_mbcs((LPCWSTR)str, CP_UTF8, (LPCTSTR*&)lpstr8);
@@ -143,7 +144,7 @@ for (;;)						/* While getting args.		*/
 		case '\0':	// Using this in case skip_b found EOF.		// 12/16/01 AM.
 //    case EOF:	// Matches ANSI y-umlaut, so not using.		// 12/16/01 AM.
          if (!silent_f)		/* If echoing input. */
-            args_pp(*args, out);
+            args_pp(*args, out, buf);
          return(false);		// 05/02/99 AM. Unexpected eof.
       case '\n':
 		case '\r':				// FIX.  04/21/99 AM.
@@ -154,7 +155,7 @@ for (;;)						/* While getting args.		*/
 				cc = fp->get();	// 10/31/06 AM.
 #endif
          if (!silent_f)		/* If echoing input. */
-            args_pp(*args, out);
+            args_pp(*args, out, buf);
          return(true);
       case ';':					/* Get comment.				*/
 #ifdef UNICODE
@@ -183,7 +184,7 @@ for (;;)						/* While getting args.		*/
    }
 
 if (!silent_f)		/* If echoing input. */
-   args_pp(*args, out);
+   args_pp(*args, out, buf);
 return(ok);
 }
 

--- a/cs/libqconsh/cmd.cpp
+++ b/cs/libqconsh/cmd.cpp
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									CMD.C
 *
-* FILE:	consh.¹/cmd.c
+* FILE:	consh.ï¿½/cmd.c
 * SUBJ:	Command-line interface.
 * CR:	8/20/95 AM.
 * NOTE:	To support all the needed commands for Consh.
@@ -136,13 +136,13 @@ for (;;)		/* Execute commands till quit or abort. */
          return(false);
          }
       *out << _T("Bad command=");
-      args_pp(args, out);
+      args_pp(args, out, buf);
       alist->list_free(args, LNULL);
       if (!i_flag) return(false);
       continue;
       }
    list = args;
-   str = (_TCHAR *) ALIST::list_pop(&args);		/* Get first arg. */
+   str = ALIST::list_pop_buf(&args,buf);		/* Get first arg. */
 //	if (str && *str)							// 10/05/99 AM.
 //		{
 //		*cgerr << prompt << flush;
@@ -167,7 +167,7 @@ for (;;)		/* Execute commands till quit or abort. */
       ok = cmd_st(args, out,cg);		/* String table primitives. */
    else if (!_tcscmp(_T("help"), str)
          || !_tcscmp(_T("h"), str))
-      ok = cmd_help(args, out);
+      ok = cmd_help(args, out, buf);
    else if (!_tcscmp(_T("proxy"), str))
       ok = cmd_proxy(args, out,cg);
    else if (!_tcscmp(_T("show"), str))
@@ -189,7 +189,7 @@ for (;;)		/* Execute commands till quit or abort. */
    else if (Str_full(str))
       {
       *out << _T("Unknown command=");
-      args_pp(list, out);
+      args_pp(list, out, buf);
       ok = false;
       }
    /* else empty command. */
@@ -218,7 +218,8 @@ return(ok);
 LIBQCONSH_API bool
 cmd_help(
 	LIST *args,
-	_t_ostream *out
+	_t_ostream *out,
+   _TCHAR *buf
 	)
 {
 _TCHAR *str;
@@ -227,7 +228,7 @@ bool ok;
 ok = true;
 if (args)
    {
-   str = (_TCHAR *) ALIST::list_pop(&args);		/* Get first arg. */
+   str = ALIST::list_pop_buf(&args,buf);		/* Get first arg. */
    if (args)
       {
       *out << _T("Too many args in 'help' command.") << endl;
@@ -242,7 +243,7 @@ if (args)
    else if (Str_full(str))
       {
       *out << _T("Unknown command=");
-      args_pp(args, out);
+      args_pp(args, out, buf);
       return(false);
       }
    /* else empty command. */
@@ -295,6 +296,7 @@ cmd_add(
 	)
 {
 _TCHAR *str;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -302,7 +304,7 @@ if (!args)
    return(false);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 if (!_tcscmp(str, _T("root")))				/* Add root kb concept.			*/
    return(cmd_add_root(args, out,cg));
@@ -358,25 +360,25 @@ if (!args)
    *out << _T("Too few args in ADD ATTR command.") << endl;
    return(false);
    }
-s_con = (_TCHAR *) ALIST::list_pop(&args);
+s_con = ALIST::list_pop_buf(&args,buf);
 if (!args)
    {
    *out << _T("Too few args in ADD ATTR command.") << endl;
    return(false);
    }
-s_slot = (_TCHAR *) ALIST::list_pop(&args);
+s_slot = ALIST::list_pop_buf(&args,buf);
 if (!args)
    {
    *out << _T("Too few args in ADD ATTR command.") << endl;
    return(false);
    }
-s_val = (_TCHAR *) ALIST::list_pop(&args);
+s_val = ALIST::list_pop_buf(&args,buf);
 if (!args)
    {
    *out << _T("Too few args in ADD ATTR command.") << endl;
    return(false);
    }
-s_kind = (_TCHAR *) ALIST::list_pop(&args);
+s_kind = ALIST::list_pop_buf(&args,buf);
 
 /* VERIFY INPUTS. */
 /* Check appropriate values everywhere. */
@@ -457,7 +459,7 @@ if (!args)
    return(false);
    }
 
-name = (_TCHAR *) ALIST::list_pop(&args);
+name = ALIST::list_pop_buf(&args,buf);
 
 if (!args)
    {
@@ -465,7 +467,7 @@ if (!args)
    return(false);
    }
 
-idstr = (_TCHAR *) ALIST::list_pop(&args);
+idstr = ALIST::list_pop_buf(&args,buf);
 
 if (args)
    {
@@ -578,6 +580,7 @@ XCON_S *con,		// Hierarchy path built so far.
 CON_ID child_id;	// 02/15/07 AM.
 CON_ID cid;
 bool dirty = false;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -586,7 +589,7 @@ if (!args)
    }
 
 // Set up root of hierarchy.
-name = (_TCHAR *) ALIST::list_pop(&args);
+name = ALIST::list_pop_buf(&args,buf);
 if (_tcscmp(name, CON_ROOT_NAME))
    {
    *out << _T("add hier: Path must begin with '")
@@ -605,7 +608,7 @@ if (!con)
 // Find first path component not yet built.
 STR_ID sid = 0;	// 02/15/07 AM.
 STR_ID c_sid = 0;	// 02/15/07 AM.
-while (name = (_TCHAR *) ALIST::list_pop(&args))
+while (name = ALIST::list_pop_buf(&args,buf))
    {
    sid = cg->qkbm_->sym_get(name, /*UP*/dirty);	// 02/27/07 AM.
    child_id = con->dn;
@@ -648,7 +651,7 @@ while (name)
    newcon = cg->qkbm_->Con(cid);
    cg->kbfree(con);	// 02/15/07 AM.
    con = newcon;		// 02/15/07 AM.
-   name = (_TCHAR *) ALIST::list_pop(&args);
+   name = ALIST::list_pop_buf(&args,buf);
    }
 
 cg->kbfree(con);	// Could return this ...	// 02/15/07 AM.
@@ -815,6 +818,7 @@ cmd_add_word(
 	)
 {
 _TCHAR *name;
+_TCHAR *buf = cg->alist_->List_buffer;
 //SYM *sym;
 //XCON_S *con;
 
@@ -825,7 +829,7 @@ if (!args)
    return(false);
    }
 
-name = (_TCHAR *) ALIST::list_pop(&args);
+name = ALIST::list_pop_buf(&args,buf);
 
 if (args)
    {
@@ -879,6 +883,7 @@ cmd_bind(
 	)
 {
 _TCHAR *str;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -886,7 +891,7 @@ if (!args)
    return(false);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 if (!_tcscmp(str, _T("app")))				/* Bind application concepts.	*/
    return(cmd_bind_app(args, out,cg));
@@ -993,6 +998,7 @@ cmd_con(
 #ifdef OLD_070215_
 _TCHAR *str;
 long id;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -1000,7 +1006,7 @@ if (!args)
    return(true);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 if (!_tcscmp(str, _T("pp")))
    {
@@ -1041,6 +1047,7 @@ cmd_gen(
 	)
 {
 _TCHAR *str;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {\
@@ -1048,7 +1055,7 @@ if (!args)
    return(false);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 *cgerr << _T("[cmd gen: Command not updated. 07/01/00 AM.]") << endl;
 return false;
@@ -1168,7 +1175,7 @@ cmd_ind(
 	)
 {
 _TCHAR *str;
-ALIST *alist = cg->alist_;	// List manager.							// 08/14/02 AM.
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -1176,7 +1183,7 @@ if (!args)
    return(false);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 //if (!strcmp(str, "action"))
 //   return(ind_action(args, in, out, i_flag, silent,cg));
@@ -1229,6 +1236,7 @@ long id;
 long ord;
 XCON_S *con, *phr, *prox;
 CON_ID phr_nid;	// 03/05/07 AM.
+_TCHAR *buf = cg->alist_->List_buffer;
 
 usage = _T("Usage: proxy ID NTH");
 
@@ -1238,7 +1246,7 @@ if (!args)
    return(false);
    }
 
-s_id = (_TCHAR *) ALIST::list_pop(&args);
+s_id = ALIST::list_pop_buf(&args,buf);
 
 if (!args)
    {
@@ -1246,7 +1254,7 @@ if (!args)
    return(false);
    }
 
-s_ord = (_TCHAR *) ALIST::list_pop(&args);
+s_ord = ALIST::list_pop_buf(&args,buf);
 
 if (!s_to_l(s_id, /*UP*/ &id) || !s_to_l(s_ord, /*UP*/ &ord))
    {
@@ -1289,14 +1297,14 @@ cmd_show(
 	)
 {
 _TCHAR *str;
-ALIST *alist = cg->alist_;	// List manager.							// 08/14/02 AM.
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
    return(false);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 if (!_tcscmp(str, _T("name")))				/* Show instances of name in kb.*/
    return(cmd_show_name(args, out,cg));
@@ -1331,13 +1339,14 @@ _TCHAR *str;
 LIST *list=0, *end=0, *elt;
 XCON_S *con;
 ALIST *alist = cg->alist_;	// List manager.							// 08/14/02 AM.
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
    *out << _T("Usage: show name NAME") << endl;
    return(false);
    }
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 if (args)
    {
    *out << _T("Too many args in \"show name\" command.") << endl;
@@ -1393,13 +1402,14 @@ cmd_st(
 {
 /*
 _TCHAR *str;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
    cg->ast_->st_pp(out);
    return(true);
    }
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 if (!_tcscmp(str, _T("add")))				// Add string to string table.
    return(cmd_st_add(args, out,cg));
@@ -1436,13 +1446,14 @@ cmd_st_add(
 /*
 _TCHAR *str;
 _TCHAR *ptr;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
    *out << _T("Usage: st add \"STRING\"") << endl;
    return(false);
    }
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 if (args)
    {
    *out << _T("Too many args in \"st add\" command.") << endl;
@@ -1519,6 +1530,7 @@ cmd_sym(
 return false;	// 02/15/07 AM.
 /*
 _TCHAR *str;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
@@ -1526,7 +1538,7 @@ if (!args)
    return(true);
    }
 
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 
 if (!_tcscmp(str, _T("add")))				// Add string to sym table.
    return(cmd_sym_add(args, out,cg));
@@ -1570,13 +1582,14 @@ cmd_sym_add(
 return false;	// 02/15/07 AM.
 /*
 _TCHAR *str;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 if (!args)
    {
    *out << _T("Usage: sym add \"STRING\"") << endl;
    return(false);
    }
-str = (_TCHAR *) ALIST::list_pop(&args);
+str = ALIST::list_pop_buf(&args,buf);
 if (args)
    {
    *out << _T("Too many args in \"sym add\" command.") << endl;
@@ -1675,7 +1688,7 @@ cmd_take(
 _TCHAR *fil;
 //ifstream *fin;						// 03/08/00 AM.
 bool ok;
-ALIST *alist = cg->alist_;	// List Manager.							// 08/14/02 AM.
+_TCHAR *buf = cg->alist_->List_buffer;
 
 #ifdef OLD_030701_
 _TCHAR *dir;
@@ -1685,7 +1698,7 @@ if (!args)
    return(false);
    }
 
-dir = (_TCHAR *) ALIST::list_pop(&args);
+dir = ALIST::list_pop_buf(&args,buf);
 #endif
 
 if (!args)
@@ -1694,7 +1707,7 @@ if (!args)
    return(false);
    }
 
-fil = (_TCHAR *) ALIST::list_pop(&args);
+fil = ALIST::list_pop_buf(&args,buf);
 
 if (args)
    {

--- a/cs/libqconsh/cmd.h
+++ b/cs/libqconsh/cmd.h
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									CMD.H
 *
-* FILE:	conch.¹/cmd.h
+* FILE:	conch.ï¿½/cmd.h
 * SUBJ:	Declarations for the command-line interface.
 * CR:	8/20/95 AM.
 *
@@ -109,7 +109,8 @@ cmd_gen_all(
 extern LIBQCONSH_API bool
 cmd_help(
 	LIST *args,
-	_t_ostream *out
+	_t_ostream *out,
+	_TCHAR *buf
 	);
 extern LIBQCONSH_API bool
 cmd_ind(

--- a/cs/libqconsh/ind.cpp
+++ b/cs/libqconsh/ind.cpp
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									IND.C
 *
-* FILE:	consh.¹/ind.c
+* FILE:	consh.ï¿½/ind.c
 * SUBJ:	Higher-level knowledge addition commands.
 * CR:		10/15/95 AM.
 * NOTE:	Support multi-line addition commands, with some abstraction from kb.
@@ -761,13 +761,13 @@ if (!ok)
    return(false);
    }
 
-if (!ends || _tcscmp(_T("end"), (_TCHAR *) ends->val))
+if (!ends || _tcscmp(_T("end"), ALIST::list_str(&ends,buf)))
    *out << _T("ind childs: Missing 'end ind'.") << endl;
 alist->list_free(ends, LNULL);
 
 /* ADD CHILDREN TO HIERARCHY */
 save = names;
-while (str = (_TCHAR *) ALIST::list_pop(&names))
+while (str = ALIST::list_pop(&names,nbuf))
    cg->cgcon_->con_add_basic(str, con);
 
 alist->list_free(save, LNULL);

--- a/cs/libqconsh/ui.cpp
+++ b/cs/libqconsh/ui.cpp
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									UI.C
 *
-* FILE:	consh.¹/ui.c
+* FILE:	consh.ï¿½/ui.c
 * SUBJ:	UI primitives for Consh.
 * CR:	10/15/95 AM.
 *
@@ -97,11 +97,12 @@ path_to_con(
 _TCHAR *name;
 XCON_S *con, *sub, *child, *tmp;
 CON_ID cid, sid;
+_TCHAR *buf = cg->alist_->List_buffer;
 
 *upcon = 0;
 
 /* Set up root of hierarchy. */
-name = (_TCHAR *) ALIST::list_pop(&args);
+name = ALIST::list_pop_buf(&args,buf);
 if (!name || !*name)	// 10/31/06 AM.
    {
    _t_cerr << _T("[path_to_con: Empty args.]") << endl;	// 10/31/06 AM.
@@ -132,7 +133,7 @@ cid = sid = (CON_ID) 1;	// Root concept id.
 
 /* Find first path component not yet built. */
 _TCHAR *nm;
-while (name = (_TCHAR *) ALIST::list_pop(&args))
+while (name = ALIST::list_pop_buf(&args,buf))
    {
    sid = con->dn;
    child = cg->qkbm_->Con(sid);
@@ -211,11 +212,12 @@ path_to_con(
 
 _TCHAR *name;
 XCON_S *con, *sub, *child, *tmp;
+_TCHAR *buf = cg->alist_->List_buffer;
 //CON_ID cid, sid;
 
 
 /* Set up root of hierarchy. */
-name = (_TCHAR *) ALIST::list_pop(&args);
+name = ALIST::list_pop_buf(&args,buf);
 if (!name || !*name)	// 10/31/06 AM.
    {
    _t_cerr << _T("[path_to_con: Empty args.]") << endl;	// 10/31/06 AM.
@@ -260,7 +262,7 @@ else	// Get root concept from tracking.
 
 /* Find first path component not yet built. */
 _TCHAR *nm;
-while (name = (_TCHAR *) ALIST::list_pop(&args))
+while (name = ALIST::list_pop_buf(&args,buf))
    {
 //   sid = con->dn;
    ++depth;

--- a/include/Api/prim/list.h
+++ b/include/Api/prim/list.h
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -106,6 +106,10 @@ public:
 		LIST **list
 		);
 	static _TCHAR* list_pop_buf(
+		LIST** list,
+		_TCHAR* buf
+	);
+	static _TCHAR* list_str(
 		LIST** list,
 		_TCHAR* buf
 	);


### PR DESCRIPTION
This is being done because "long" in windows is only 4 bytes. Signed-off-by: David de Hilster <david.dehilster@lexisnexisrisk.com>