### PR TITLE
NLP-ENGINE-249 Remove "using namespace std" from headers

### DIFF
--- a/cs/include/consh/arg.h
+++ b/cs/include/consh/arg.h
@@ -16,7 +16,7 @@ All rights reserved.
 
 extern LIBCONSH_API bool
 arg_get(
-	_t_istream *fp,			/* Stream to read from.				*/
+	std::_t_istream *fp,			/* Stream to read from.				*/
 	ALIST *alist,		// List manager.									// 08/14/02 AM.
 	/*DU*/
 	_TCHAR *cup,			/* Lookahead char.					*/
@@ -27,15 +27,15 @@ arg_get(
 	);
 extern LIBCONSH_API bool
 arg_get_comment(
-	_t_istream *fp,			/* Stream to read from.				*/
+	std::_t_istream *fp,			/* Stream to read from.				*/
 	/*DU*/
 	_TCHAR *cup			/* Lookahead char.					*/
 	);
 extern LIBCONSH_API bool
 arg_get_str(
-	_t_istream *fp,			/* Stream to read from.			*/
+	std::_t_istream *fp,			/* Stream to read from.			*/
 	ALIST *alist,		// List manager.									// 08/14/02 AM.
-	_t_ostream *out,																// 06/21/03 AM.
+	std::_t_ostream *out,																// 06/21/03 AM.
 	/*DU*/
 	int ci,
 	_TCHAR *cup,			/* Lookahead char.				*/
@@ -47,13 +47,13 @@ arg_get_str(
 extern LIBCONSH_API void
 args_pp(
 	LIST *args,
-	_t_ostream *out,
+	std::_t_ostream *out,
 	_TCHAR *buf
 	);
 extern LIBCONSH_API bool
 args_read(
-	_t_istream *fp,						/* Stream to read.			*/
-	_t_ostream *out,						/* Stream to echo to.		*/
+	std::_t_istream *fp,						/* Stream to read.			*/
+	std::_t_ostream *out,						/* Stream to echo to.		*/
 	bool silent_f,					/* True if not echoing.		*/
 	ALIST *alist,		// List manager.									// 08/14/02 AM.
 	_TCHAR *buf,						/* Buffer for args.			*/

--- a/cs/include/prim/io.h
+++ b/cs/include/prim/io.h
@@ -14,10 +14,10 @@ All rights reserved.
 *******************************************************************************/
 
 extern LIBPRIM_API void
-indent(int num, _t_ostream *out);
+indent(int num, std::_t_ostream *out);
 
 extern LIBPRIM_API _TCHAR
-skip_blanks(_TCHAR cc, _t_istream *fp);
+skip_blanks(_TCHAR cc, std::_t_istream *fp);
 
 
 //extern LIBPRIM_API void

--- a/cs/libconsh/Aconsh.cpp
+++ b/cs/libconsh/Aconsh.cpp
@@ -13,7 +13,6 @@ All rights reserved.
 #include "StdAfx.h"
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "consh/libconsh.h"
 
 #include "prim/libprim.h"

--- a/cs/libconsh/arg.cpp
+++ b/cs/libconsh/arg.cpp
@@ -25,7 +25,6 @@ All rights reserved.
 #include <ctype.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "u_out.h"					// 01/13/06 AM.
 #include "prim/libprim.h"

--- a/cs/libconsh/bind.cpp
+++ b/cs/libconsh/bind.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -21,7 +21,6 @@ All rights reserved.
 #include "StdAfx.h"			// 04/26/99 AM.
 #include <stdio.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "prim/prim.h"
 #include "prim/list_s.h"

--- a/cs/libconsh/cc_code.cpp
+++ b/cs/libconsh/cc_code.cpp
@@ -11,7 +11,6 @@ All rights reserved.
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 //#include "prim/mach.h"
 #include "prim/prim.h"

--- a/cs/libconsh/cc_gen.cpp
+++ b/cs/libconsh/cc_gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -21,7 +21,6 @@ All rights reserved.
 #include <stdio.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "prim/prim.h"
 #include "gen.h"
@@ -42,16 +41,16 @@ void cc_gen_hdr(
    _TCHAR *tail		/* Tail for naming generated files.		*/
    )
 {
-_t_ofstream *fp;
+std::_t_ofstream *fp;
 _TCHAR s_nam[PATH];	/* Name of file.		*/
 
 _stprintf(s_nam, _T("%s%s%s_code.h%s"), dir, DIR_SEP, consh_CC_BASE, tail);
 //if (!file_open(s_nam, "w", &fp))
 //   return;
-fp = new _t_ofstream(TCHAR2A(s_nam));		// 04/20/99 AM.
+fp = new std::_t_ofstream(TCHAR2A(s_nam));		// 04/20/99 AM.
 
 gen_file_head(fp);
-*fp << _T("extern bool cc_ini(void*);") << endl;							// 08/16/02 AM.
+*fp << _T("extern bool cc_ini(void*);") << std::endl;							// 08/16/02 AM.
 
 //if (!file_close(s_nam, fp))
 //   return;
@@ -72,35 +71,35 @@ void cc_gen_ini(
 	_TCHAR *tail		/* Tail for naming generated files.		*/
 	)
 {
-_t_ofstream *fp;
+std::_t_ofstream *fp;
 _TCHAR s_nam[PATH];	/* Name of file.		*/
 
 _stprintf(s_nam, _T("%s%s%s_code.cpp%s"), dir, DIR_SEP, consh_CC_BASE, tail);
 //if (!file_open(s_nam, "w", &fp))
 //   return;
-fp = new _t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
+fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
 gen_file_head(fp);
 #ifdef LINUX
-*fp << _T("#include \"stdafx.h\"") << endl;								// 05/05/01 AM.
+*fp << _T("#include \"stdafx.h\"") << std::endl;								// 05/05/01 AM.
 #else
-*fp << _T("#include \"StdAfx.h\"") << endl;								// 05/05/01 AM.
+*fp << _T("#include \"StdAfx.h\"") << std::endl;								// 05/05/01 AM.
 #endif
-*fp << _T("extern bool cc_st_ini(void*);") << endl;						// 08/15/02 AM.
-*fp << _T("extern bool cc_sym_ini(void*);") << endl;					// 08/15/02 AM.
-*fp << _T("extern bool cc_con_ini(void*);") << endl;					// 08/15/02 AM.
-*fp << _T("extern bool cc_ptr_ini(void*);") << endl;					// 08/15/02 AM.
+*fp << _T("extern bool cc_st_ini(void*);") << std::endl;						// 08/15/02 AM.
+*fp << _T("extern bool cc_sym_ini(void*);") << std::endl;					// 08/15/02 AM.
+*fp << _T("extern bool cc_con_ini(void*);") << std::endl;					// 08/15/02 AM.
+*fp << _T("extern bool cc_ptr_ini(void*);") << std::endl;					// 08/15/02 AM.
 
-*fp << _T("bool") << endl;														// 05/05/01 AM.
-*fp << _T("cc_ini(void *cg)") << endl;										// 08/16/02 AM.
-*fp << _T("{") << endl;
-*fp << _T("if (!cc_st_ini(cg))  return false;") << endl;				// 08/15/02 AM.
-*fp << _T("if (!cc_sym_ini(cg)) return false;") << endl;				// 08/15/02 AM.
+*fp << _T("bool") << std::endl;														// 05/05/01 AM.
+*fp << _T("cc_ini(void *cg)") << std::endl;										// 08/16/02 AM.
+*fp << _T("{") << std::endl;
+*fp << _T("if (!cc_st_ini(cg))  return false;") << std::endl;				// 08/15/02 AM.
+*fp << _T("if (!cc_sym_ini(cg)) return false;") << std::endl;				// 08/15/02 AM.
 // cg->asym_->sym_reset();	// Probably not for compiled.			// 08/15/02 AM.
-*fp << _T("if (!cc_con_ini(cg)) return false;") << endl;				// 08/15/02 AM.
-*fp << _T("if (!cc_ptr_ini(cg)) return false;") << endl;				// 08/15/02 AM.
-*fp << _T("return true;") << endl;											// 05/05/01 AM.
-*fp << _T("}") << endl;
+*fp << _T("if (!cc_con_ini(cg)) return false;") << std::endl;				// 08/15/02 AM.
+*fp << _T("if (!cc_ptr_ini(cg)) return false;") << std::endl;				// 08/15/02 AM.
+*fp << _T("return true;") << std::endl;											// 05/05/01 AM.
+*fp << _T("}") << std::endl;
 
 //if (!file_close(s_nam, fp))
 //   return;

--- a/cs/libconsh/cg_global.cpp
+++ b/cs/libconsh/cg_global.cpp
@@ -19,7 +19,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 #include <string.h>
 
@@ -32,12 +31,12 @@ const _TCHAR *strNULL = _T("");
 
 // A global output stream.
 // This way, output will be dynamically controlled.
-_t_ostream *cgout = &_t_cout;			// Default is standard output.
+std::_t_ostream *cgout = &std::_t_cout;			// Default is standard output.
 
 // Global error stream.
 // This way, error output will be dynamically controlled.
 //ostream *cgerr = &cerr;			// Default is standard error.
-_t_ofstream *cgerr = 0;	// 07/18/03 AM.
+std::_t_ofstream *cgerr = 0;	// 07/18/03 AM.
 
 /********************************************
 * FN:		CGFILEOUT
@@ -45,9 +44,9 @@ _t_ofstream *cgerr = 0;	// 07/18/03 AM.
 * SUBJ:	Set global output to a file.
 ********************************************/
 
-void cgfileOut(_TCHAR *fname, /*DU*/ _t_ofstream* &fout, _t_ostream* &sout)
+void cgfileOut(_TCHAR *fname, /*DU*/ std::_t_ofstream* &fout, std::_t_ostream* &sout)
 {
-fout = new _t_ofstream(TCHAR2A(fname), ios::out);
+fout = new std::_t_ofstream(TCHAR2A(fname), std::ios::out);
 sout = cgout;				// Save current output stream.
 cgout = fout;				// Bind output to file.
 }
@@ -59,7 +58,7 @@ cgout = fout;				// Bind output to file.
 * SUBJ:	Reset global output.
 ********************************************/
 
-void cgresetOut(/*DU*/ _t_ofstream* &fout, _t_ostream* &sout)
+void cgresetOut(/*DU*/ std::_t_ofstream* &fout, std::_t_ostream* &sout)
 {
 cgout = sout;				// Restore current output stream.
 delete fout;				// Done with file output stream.
@@ -77,10 +76,10 @@ sout = 0;
 //void cgfileErr(char *fname, /*DU*/ ofstream* &fout, ostream* &sout)
 void cgfileErr(_TCHAR *fname)	// 07/18/03 AM.
 {
-//fout = new ofstream(fname, ios::out);
+//fout = new ofstream(fname, std::ios::out);
 //sout = cgerr;				// Save current output stream.
 //cgerr = fout;				// Bind output to file.
-cgerr = new _t_ofstream(TCHAR2A(fname), ios::out);	// 07/18/03 AM.
+cgerr = new std::_t_ofstream(TCHAR2A(fname), std::ios::out);	// 07/18/03 AM.
 }
 
 

--- a/cs/libconsh/cg_global.h
+++ b/cs/libconsh/cg_global.h
@@ -23,14 +23,14 @@ All rights reserved.
 // Changed from SNULL to avoid conflict with libkbm.			// 02/15/01 AM.
 extern const _TCHAR *strNULL;
 
-extern _t_ostream *cgout;
-void cgfileOut(_TCHAR *fname, /*DU*/ _t_ofstream* &fout, _t_ostream* &sout);
-void cgresetOut(/*DU*/ _t_ofstream* &fout, _t_ostream* &sout);
+extern std::_t_ostream *cgout;
+void cgfileOut(_TCHAR *fname, /*DU*/ std::_t_ofstream* &fout, std::_t_ostream* &sout);
+void cgresetOut(/*DU*/ std::_t_ofstream* &fout, std::_t_ostream* &sout);
 
 //extern ostream *cgerr;
 //void cgfileErr(char *fname, /*DU*/ ofstream* &fout, ostream* &sout);
 //void cgresetErr(/*DU*/ ofstream* &fout, ostream* &sout);
-extern _t_ofstream *cgerr;	// 07/18/03 AM.
+extern std::_t_ofstream *cgerr;	// 07/18/03 AM.
 void cgfileErr(_TCHAR *fname);	// 07/18/03 AM.
 void cgresetErr();	// 07/18/03 AM.
 

--- a/cs/libconsh/cmd.cpp
+++ b/cs/libconsh/cmd.cpp
@@ -28,7 +28,6 @@ All rights reserved.
 #include <ctype.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <string.h>
 
 

--- a/cs/libconsh/con_gen.cpp
+++ b/cs/libconsh/con_gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									CON_GEN.C
 *
-* FILE:	consh.¹/con_gen.c
+* FILE:	consh.ï¿½/con_gen.c
 * SUBJ:	Generate concept table code files, from Consh.
 * CR:	10/6/95 AM.
 *
@@ -23,7 +23,6 @@ All rights reserved.
 #include <string.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 //#include "prim/mach.h"
@@ -72,7 +71,7 @@ void con_gen(
 	CG *cg
 	)
 {
-_t_ofstream *fp;
+std::_t_ofstream *fp;
 int ii;
 int segs_tot, seg_curr;
 long seg_size;
@@ -100,7 +99,7 @@ for (ii = 0; ii <= seg_curr; ii++)
    _stprintf(s_nam, _T("%s%s%s.cpp"), dir, DIR_SEP, s_tab);
 //   if (!file_open(s_nam, "w", &fp))
 //      return;
-fp = new _t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
+fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
    gen_file_head(fp);
    consh_gen_includes(fp);
@@ -147,7 +146,7 @@ for (ii = seg_curr + 1; ii < segs_tot; ii++)
    _stprintf(s_nam, _T("%s%s%s.cpp"), dir, DIR_SEP, s_tab);
 //   if (!file_open(s_nam, "w", &fp))
 //      return;
-fp = new _t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
+fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
    gen_file_head(fp);
    consh_gen_includes(fp);
@@ -173,7 +172,7 @@ void con_gen_hdr(
 	CG *cg
 	)
 {
-_t_ofstream *fp;
+std::_t_ofstream *fp;
 int ii;
 _TCHAR s_nam[PATH],	/* Name of con table hdr file.		*/
      s_tab[16];		/* Name of con table array.			*/
@@ -183,7 +182,7 @@ segs_tot = cg->acon_->con_segs_tot();
 _stprintf(s_nam, _T("%s%s%s_ini.h%s"), dir, DIR_SEP, consh_CON_BASE, tail);
 //if (!file_open(s_nam, "w", &fp))
 //   return;
-fp = new _t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
+fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
 gen_file_head(fp);
 
@@ -215,7 +214,7 @@ void con_gen_ini(
 	CG *cg
 	)
 {
-_t_ofstream *fp;
+std::_t_ofstream *fp;
 int ii;
 _TCHAR s_nam[PATH];	/* Name of con table hdr file.		*/
 //char s_tab[16];		/* Name of con table array.			*/
@@ -233,7 +232,7 @@ tcount		= cg->acon_->con_count();
 _stprintf(s_nam, _T("%s%s%s_ini.cpp%s"), dir, DIR_SEP, tbase, tail);
 //if (!file_open(s_nam, "w", &fp))
 //   return;
-fp = new _t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
+fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
 gen_file_head(fp);
 
@@ -283,7 +282,7 @@ delete fp;
 void
 con_gen_struct(
 	CON *pseg,
-	_t_ofstream *fp,
+	std::_t_ofstream *fp,
 	CG *cg
 	)
 {

--- a/cs/libconsh/con_ini.cpp
+++ b/cs/libconsh/con_ini.cpp
@@ -9,7 +9,6 @@ All rights reserved.
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 //#include "prim/mach.h"
 #include "prim/prim.h"

--- a/cs/libconsh/consh_gen.cpp
+++ b/cs/libconsh/consh_gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									CONSH_GEN.C
 *
-* FILE:	conan.¹/consh_gen.c
+* FILE:	conan.ï¿½/consh_gen.c
 * SUBJ:	Module for generating code specifically for Consh.
 * CR:	10/7/95 AM.
 *
@@ -22,7 +22,6 @@ All rights reserved.
 #include <string.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"
@@ -62,7 +61,7 @@ using namespace std;											// Upgrade	// 01/24/01 AM.
 
 void
 consh_gen_includes(
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	)
 {
 #ifdef LINUX
@@ -72,7 +71,6 @@ consh_gen_includes(
 //*fp << "#include <fstream.h>" << endl;								// 04/23/99 AM.
 *fp << _T("#include <iostream>") << endl;					// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include <fstream>") << endl;					// Upgrade. // 01/24/01 AM.
-*fp << _T("using namespace std;") << endl;					// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include \"prim\\libprim.h\"") << endl;
 //*fp << "#include \"prim\\mach.h\"" << endl;	// 04/23/99 AM.
 *fp << _T("#include \"prim\\prim.h\"") << endl;
@@ -101,7 +99,6 @@ consh_gen_includes(
 //*fp << "#include <fstream.h>" << endl;								// 04/23/99 AM.
 *fp << _T("#include <iostream>") << endl;					// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include <fstream>") << endl;					// Upgrade. // 01/24/01 AM.
-*fp << _T("using namespace std;") << endl;					// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include \"prim/libprim.h\"") << endl;
 //*fp << "#include \"prim/mach.h\"" << endl;	// 04/23/99 AM.
 *fp << _T("#include \"prim/prim.h\"") << endl;

--- a/cs/libconsh/consh_kb.cpp
+++ b/cs/libconsh/consh_kb.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									CONSH_KB.C
 *
-* FILE:	consh.¹/consh_kb.c
+* FILE:	consh.ï¿½/consh_kb.c
 * SUBJ:	Consh-specific knowledge base handlers.
 * CR:	11/28/95 AM.
 *
@@ -22,7 +22,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <string.h>			// 03/07/00 AM.
 #include <iostream>											// Upgrade.	// 01/30/01 AM.
-using namespace std;											// Upgrade.	// 01/30/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libconsh/dyn.cpp
+++ b/cs/libconsh/dyn.cpp
@@ -17,7 +17,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 #include <string.h>
 
@@ -45,16 +44,16 @@ if (Func4 != NULL)
 if (kb_setup(cg))
 //if (kb_static_setup(cg))	// SETUP COMPILED KB IN LINUX. // 02/19/19 AM.
   {
-	_t_cerr << _T("[call_kb_setup: Kb setup complete.]") << endl;	// 05/07/01 AM.
-	*cgerr << _T("call_kb_setup: Kb setup completed.") << endl;
+	std::_t_cerr << _T("[call_kb_setup: Kb setup complete.]") << std::endl;	// 05/07/01 AM.
+	*cgerr << _T("call_kb_setup: Kb setup completed.") << std::endl;
 	return true;	// 02/20/19 AM.
   
   }
 #endif
 else
 	{
-	_t_cerr << _T("[call_kb_setup: Error. No entry point.]") << endl;	// 05/07/01 AM.
-	*cgerr << _T("Error in call_kb_setup") << endl;
+	std::_t_cerr << _T("[call_kb_setup: Error. No entry point.]") << std::endl;	// 05/07/01 AM.
+	*cgerr << _T("Error in call_kb_setup") << std::endl;
 	}
 return false;
 }

--- a/cs/libconsh/gen.cpp
+++ b/cs/libconsh/gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									GEN.C
 *
-* FILE:	conan.¹/gen.c
+* FILE:	conan.ï¿½/gen.c
 * SUBJ:	Module for generating code.
 * NOTE:	Should separate primitives from consh_gen facilities.
 *		Some old stuff still infests these files.
@@ -24,7 +24,6 @@ All rights reserved.
 #include <string.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"
@@ -62,7 +61,7 @@ int count,				/* Number of string table files.			*/
 //long ii;
 long off,				/* Offset in total string table.			*/
      max;				/* Size of string table segment.			*/
-_t_ofstream *s_fp;				/* File ptr for string table file.		*/
+std::_t_ofstream *s_fp;				/* File ptr for string table file.		*/
 _t_ifstream *w_fp;				/* Words file ptr.							*/
 
 max = SEG_SIZE;
@@ -78,7 +77,7 @@ _stprintf(s_nam, _T("%s.%s"), s_tab, tail);
 
 //if (!file_open(s_nam, "w", &s_fp))
 //   return;
-s_fp = new _t_ofstream(s_nam);			// 04/20/99 AM.
+s_fp = new std::_t_ofstream(s_nam);			// 04/20/99 AM.
 
 gen_array_hd(_T("char"), s_tab, _T(""), s_fp);			/* Start array.				*/
 *s_fp << _T("\"");							/* Start quote for string.	*/
@@ -95,12 +94,12 @@ while ((*w_fp >> buf) != _TEOF)
    _t_cout << _T("off=") << off
 		  << _T(", len=") << len
 		  << _T(", max=") << max
-		  << endl;
+		  << std::endl;
    _t_cout << _T("seg1=")
 		  << (off + (long)len)/max
 		  << _T(" seg2=")
 		  << off/max
-		  << endl;
+		  << std::endl;
    if ((((off + (long)len) / max) > (off / max))  || !(off % max))
       {
       
@@ -119,7 +118,7 @@ while ((*w_fp >> buf) != _TEOF)
 
       //if (!file_open(s_nam, "w", &s_fp))
       //   return;
-		s_fp = new _t_ofstream(s_nam);			// 04/20/99 AM.
+		s_fp = new std::_t_ofstream(s_nam);			// 04/20/99 AM.
 
       gen_array_hd(_T("char"), s_tab, _T(""), s_fp);		/* Start array.				*/
       *s_fp << _T("\"");							/* Start quote for string.	*/
@@ -167,12 +166,12 @@ gen_st_empty(
 	)
 {
 long ii;
-_t_ofstream *s_fp;			/* File ptr for string table file.		*/
+std::_t_ofstream *s_fp;			/* File ptr for string table file.		*/
 //int count;			/* Number of string table files.		*/
 
 //if (!file_open(s_nam, "w", &s_fp))
 //   return;
-s_fp = new _t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
+s_fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
 gen_array_hd(_T("char"), s_tab, _T(""), s_fp);			/* Start array.				*/
 *s_fp << _T("\"");							/* Start quote for string.	*/
@@ -206,37 +205,37 @@ delete s_fp;
 void gen_array_decl(
 	_TCHAR *typ,
 	_TCHAR *nam,
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	)
 {
-*fp << typ << _T(" ") << nam << _T("[];") << endl;
+*fp << typ << _T(" ") << nam << _T("[];") << std::endl;
 }
 
 void gen_array_def(
 	_TCHAR *typ,
 	_TCHAR *nam,
 	_TCHAR *siz,
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	)
 {
-*fp << typ << _T(" ") << nam << _T("[") << siz << _T("];") << endl;
+*fp << typ << _T(" ") << nam << _T("[") << siz << _T("];") << std::endl;
 }
 
 void gen_array_hd(
 	_TCHAR *typ,
 	_TCHAR *nam,
 	_TCHAR *siz,
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	)
 {
-*fp << typ << _T(" ") << nam << _T("[") << siz << _T("]=\n   {") << endl;
+*fp << typ << _T(" ") << nam << _T("[") << siz << _T("]=\n   {") << std::endl;
 }
 
 void gen_array_tl(
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	)
 {
-*fp << _T("\n   };") << endl;
+*fp << _T("\n   };") << std::endl;
 }
 
 
@@ -249,7 +248,7 @@ void gen_array_tl(
 **************************************************/
 
 void gen_file_head(
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	)
 {
 _TCHAR str[80];
@@ -259,6 +258,6 @@ _stprintf(str, _T("%s"), _T("DUMMYDATE"));
 *fp << _T("/*** ")
 	 << str
 	 << _T(" AUTOMATICALLY GENERATED! EDITS WILL BE LOST. ***/")
-	 << endl;
+	 << std::endl;
 }
 

--- a/cs/libconsh/gen.h
+++ b/cs/libconsh/gen.h
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									GEN.H
 *
-* FILE:	conan.¹/gen.h
+* FILE:	conan.ï¿½/gen.h
 * SUBJ:	Declarations for code generation.
 * NOTE:	
 * CR:	5/06/95 AM.
@@ -17,25 +17,25 @@ All rights reserved.
 extern void gen_array_decl(
 	_TCHAR *typ,
 	_TCHAR *nam,
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	);
 extern void gen_array_def(
 	_TCHAR *typ,
 	_TCHAR *nam,
 	_TCHAR *siz,
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	);
 extern void gen_array_hd(
 	_TCHAR *typ,
 	_TCHAR *nam,
 	_TCHAR *siz,
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	);
 extern void gen_array_tl(
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	);
 extern void gen_file_head(
-	_t_ofstream *fp
+	std::_t_ofstream *fp
 	);
 extern void
 gen_st_empty(

--- a/cs/libconsh/help.cpp
+++ b/cs/libconsh/help.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									HELP.C
 *
-* FILE:	consh.¹/help.c
+* FILE:	consh.ï¿½/help.c
 * SUBJ:	Help commands.
 * CR:	11/11/95 AM.
 *
@@ -23,7 +23,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libconsh/ind.cpp
+++ b/cs/libconsh/ind.cpp
@@ -25,7 +25,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 
 #include "prim/libprim.h"
@@ -94,8 +93,8 @@ using namespace std;											// Upgrade	// 01/24/01 AM.
 #ifdef OLD_020815_
 bool ind_action(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -192,8 +191,8 @@ return(ra_add(con, typ, ds, slot, val, from, to));
 
 bool ind_attr(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -315,8 +314,8 @@ return(added);
 
 bool ind_nattr(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -450,8 +449,8 @@ return(added);
 
 bool ind_wattr(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -560,8 +559,8 @@ return(added);
 
 bool ind_childs(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -630,8 +629,8 @@ return(true);
 
 bool ind_named_phrase(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -734,8 +733,8 @@ return(true);
 
 bool ind_phrase(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg
@@ -857,8 +856,8 @@ return(true);
 
 bool ind_proxy(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent
 	)
@@ -961,8 +960,8 @@ return(added);
 #ifdef OLD_020815_
 bool ind_rest(
 	LIST *args,
-	_t_istream *in,
-	_t_ostream *out,
+	std::_t_istream *in,
+	std::_t_ostream *out,
 	bool i_flag,
 	bool silent,
 	CG *cg

--- a/cs/libconsh/io.cpp
+++ b/cs/libconsh/io.cpp
@@ -13,7 +13,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 //#include "prim/mach.h"

--- a/cs/libconsh/ptr_gen.cpp
+++ b/cs/libconsh/ptr_gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									PTR_GEN.C
 *
-* FILE:	consh.¹/ptr_gen.c
+* FILE:	consh.ï¿½/ptr_gen.c
 * SUBJ:	Generate ptr table code files, from Consh.
 * CR:	10/8/95 AM.
 *
@@ -23,7 +23,6 @@ All rights reserved.
 #include <string.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 //#include "prim/mach.h"

--- a/cs/libconsh/ptr_ini.cpp
+++ b/cs/libconsh/ptr_ini.cpp
@@ -7,7 +7,6 @@ All rights reserved.
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libconsh/st_gen.cpp
+++ b/cs/libconsh/st_gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									ST_GEN.C
 *
-* FILE:	consh.¹/st_gen.c
+* FILE:	consh.ï¿½/st_gen.c
 * SUBJ:	Generate string table code for Consh.
 * CR:	5/07/95 AM.
 * NOTE:	9/25/95 AM. Moved from st.c .
@@ -22,7 +22,6 @@ All rights reserved.
 #include <stdio.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 //#include "prim/mach.h"
@@ -278,7 +277,6 @@ gen_file_head(fp);
 //*fp << "#include <fstream.h>" << endl;			// 04/23/99 AM.
 *fp << _T("#include <iostream>") << endl;	// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include <fstream>") << endl;	// Upgrade.	// 01/24/01 AM.
-*fp << _T("using namespace std;") << endl;	// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include \"prim\\libprim.h\"") << endl;
 *fp << _T("#include \"prim\\prim.h\"") << endl;
 //*fp << "#include \"prim\\mach.h\"" << endl;			// 04/23/99 AM.
@@ -293,7 +291,6 @@ gen_file_head(fp);
 //*fp << "#include <fstream.h>" << endl;			// 04/23/99 AM.
 *fp << _T("#include <iostream>") << endl;	// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include <fstream>") << endl;	// Upgrade.	// 01/24/01 AM.
-*fp << _T("using namespace std;") << endl;	// Upgrade.	// 01/24/01 AM.
 *fp << _T("#include \"prim/libprim.h\"") << endl;
 *fp << _T("#include \"prim/prim.h\"") << endl;
 //*fp << "#include \"prim/mach.h\"" << endl;			// 04/23/99 AM.

--- a/cs/libconsh/st_ini.cpp
+++ b/cs/libconsh/st_ini.cpp
@@ -9,7 +9,6 @@ All rights reserved.
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libconsh/sym_gen.cpp
+++ b/cs/libconsh/sym_gen.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									SYM_GEN.C
 *
-* FILE:	consh.¹/sym_gen.c
+* FILE:	consh.ï¿½/sym_gen.c
 * SUBJ:	Generate symbol and conflict table code files, from Consh.
 * CR:	10/1/95 AM.
 *
@@ -21,7 +21,6 @@ All rights reserved.
 #include <stdio.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 //#include "prim/mach.h"

--- a/cs/libconsh/sym_ini.cpp
+++ b/cs/libconsh/sym_ini.cpp
@@ -16,7 +16,6 @@ time Consh is invoked. */
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"			// 04/21/99 AM.

--- a/cs/libconsh/ui.cpp
+++ b/cs/libconsh/ui.cpp
@@ -24,7 +24,6 @@ All rights reserved.
 //#include <fstream.h>			// 04/20/99 AM.
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 
 #include "prim/libprim.h"

--- a/cs/libkbm/Akbm.cpp
+++ b/cs/libkbm/Akbm.cpp
@@ -15,7 +15,6 @@ modified without written permission from Text Analysis International, Inc.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 #include <time.h>
 #include "machine-min.h"
 

--- a/cs/libkbm/attr.cpp
+++ b/cs/libkbm/attr.cpp
@@ -30,7 +30,6 @@ All rights reserved.
 #ifdef LINUX
 #include <sstream>
 #endif
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 
@@ -1004,7 +1003,7 @@ return(attr_as_add_end(con, slot_con));
 void AKBM::attrs_pret(
 	PTR *attrs,
 	//FILE *out,		// 04/20/99 AM.
-	_t_ostream *out,		// 04/20/99 AM.
+	std::_t_ostream *out,		// 04/20/99 AM.
 	_TCHAR *indent		/* String for indenting. */
 	)
 {
@@ -1021,7 +1020,7 @@ while (attrs)
    s_slot = ACON::con_str(slot);
    //fprintf(out, "%s%s ", indent, s_slot);			// 04/20/99 AM.
    //fflush(out);												// 04/20/99 AM.
-	*out << indent << s_slot << flush;					// 04/20/99 AM.
+	*out << indent << s_slot << std::flush;					// 04/20/99 AM.
    while (vals)
       {
       switch (vals->kind)
@@ -1036,7 +1035,7 @@ while (attrs)
          default:
 			// 04/20/99 AM.
         //fprintf(stderr, "[attrs_pret: Bad value kind=%d]\n", vals->kind);
-		  _t_cerr << _T("[attrs_pret: Bad value kind=") << vals->kind << endl;
+		  std::_t_cerr << _T("[attrs_pret: Bad value kind=") << vals->kind << std::endl;
             exit(1);
          }
       //fprintf(out, "%s ", str);	// 04/20/99 AM.
@@ -1044,7 +1043,7 @@ while (attrs)
       vals = vals->next;
       }
    //fprintf(out, "\n");		// 04/20/99 AM.
-	*out << endl;					// 04/20/99 AM.
+	*out << std::endl;					// 04/20/99 AM.
    attrs = attrs->next;
    }
 }

--- a/cs/libkbm/con_.cpp
+++ b/cs/libkbm/con_.cpp
@@ -25,7 +25,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 
@@ -265,7 +264,7 @@ bool ACON::con_hard_ini(
 {
 if (seg_size <= 0)															// 05/05/01 AM.
 	{
-	_t_cerr << _T("[con_hard_ini: Error. Zero seg size.]") << endl;		// 05/07/01 AM.
+	std::_t_cerr << _T("[con_hard_ini: Error. Zero seg size.]") << std::endl;		// 05/07/01 AM.
 	return false;																// 05/05/01 AM.
 	}
 
@@ -426,7 +425,7 @@ return(Con_segs);
 
 void ACON::con_tab_pretty(
 	//FILE *out			// 04/20/99 AM.
-	_t_ostream *out		// 04/20/99 AM.
+	std::_t_ostream *out		// 04/20/99 AM.
 	)
 {
 int ii;
@@ -434,12 +433,12 @@ long jj, tot;
 CON *con;
 
 if (!out)	// 02/20/19 AM.
-  out = &_t_cout;	// 02/20/19 AM.
+  out = &std::_t_cout;	// 02/20/19 AM.
 
 //fprintf(out, "Concept Table\n");	// 04/20/99 AM.
 //fprintf(out, "-------------\n");	// 04/20/99 AM.
-*out << _T("Concept Table") << endl;		// 04/20/99 AM.
-*out << _T("-------------") << endl;		// 04/20/99 AM.
+*out << _T("Concept Table") << std::endl;		// 04/20/99 AM.
+*out << _T("-------------") << std::endl;		// 04/20/99 AM.
 tot = 0;
 for (ii = 0; ii <= Con_seg_curr; ii++)	/* For every segment. */
    {
@@ -454,7 +453,7 @@ for (ii = 0; ii <= Con_seg_curr; ii++)	/* For every segment. */
 			  << _T(": (")
 		     << con_kind_str(con)
 			  << _T(") ")
-			  << con_str(con) << endl;			// 04/20/99 AM.
+			  << con_str(con) << std::endl;			// 04/20/99 AM.
       ++tot;
       ++con;
       }
@@ -1031,7 +1030,7 @@ if (!_tcscmp(compo, _T("concept")))
 	return c_cg_CONCEPT;			// Return root of hierarchy.
 
 // We can be lenient and allow it to be a direct child of "concept", ie, root of hierarchy.
-_t_cerr << _T("[Path should start with \"concept\"]") << endl;
+std::_t_cerr << _T("[Path should start with \"concept\"]") << std::endl;
 return con_get_child(c_cg_CONCEPT, compo);
 }
 
@@ -1055,7 +1054,7 @@ CON *ACON::path_to_con(
 {
 if (!path || !*path)
 	{
-	_t_cerr << _T("[path_to_con: Warn: Given null path.]") << endl;
+	std::_t_cerr << _T("[path_to_con: Warn: Given null path.]") << std::endl;
 	return 0;
 	}
 
@@ -1079,7 +1078,7 @@ for (;;)
 			*bptr = '\0';
 			con = get_component(con, buf);	// Get final component of path, if any.
 			if (!con)
-				_t_cerr << _T("[path_to_con: Warn: Couldn't find con for path=") << path << _T("]") << endl;
+				std::_t_cerr << _T("[path_to_con: Warn: Couldn't find con for path=") << path << _T("]") << std::endl;
 			return con;			// Chars exhausted, return concept found.
 		case ' ':
 		case '\t':
@@ -1469,7 +1468,7 @@ _TCHAR *ACON::con_to_path(		// 04/29/99 AM.
 *buf = '\0';
 if (!con)
 	{
-	_t_cerr << _T("[con_to_path: Given null concept.]") << endl;
+	std::_t_cerr << _T("[con_to_path: Given null concept.]") << std::endl;
 	return (_TCHAR *) NULL;
 	}
 

--- a/cs/libkbm/dict.cpp
+++ b/cs/libkbm/dict.cpp
@@ -21,7 +21,6 @@ All rights reserved.
 #include "StdAfx.h"
 #include <ctype.h>		// 03/07/00 AM.
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 
@@ -221,7 +220,7 @@ else if (unicu::isDigit(ch))									// 05/13/99 AM.
 	}
 else	// Catchall																// 06/19/03 AM.
 	{
-   _t_cerr << _T("[dict_add_word: Unhandled word=") << name << _T("]") << endl;
+   std::_t_cerr << _T("[dict_add_word: Unhandled word=") << name << _T("]") << std::endl;
 	hier = acon_->c_dict_ALPHA;											// 06/19/03 AM.
 	}
 
@@ -229,7 +228,7 @@ else	// Catchall																// 06/19/03 AM.
 index = dict_find_index(hier, name);
 if (!index)
    {
-   _t_cerr << _T("[dict_add_word: Failed on name=") << name << _T("]") << endl;
+   std::_t_cerr << _T("[dict_add_word: Failed on name=") << name << _T("]") << std::endl;
    return(CNULL);
    }
 
@@ -300,9 +299,9 @@ if (!subs || subs->kind == cWORD)
 result = _tcscmp(name, ACON::con_str(subs));
 if (result < 0)
    {
-   _t_cerr << _T("[dict_find_index: name=")
+   std::_t_cerr << _T("[dict_find_index: name=")
 		  << name << _T(" precedes first index=")
-		  << ACON::con_str(subs) << _T("]") << endl;
+		  << ACON::con_str(subs) << _T("]") << std::endl;
    return(CNULL);
    }
 else if (result == 0)

--- a/cs/libkbm/find.cpp
+++ b/cs/libkbm/find.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									FIND.C
 *
-* FILE:	consh.¹/find.c
+* FILE:	consh.ï¿½/find.c
 * SUBJ:	Find stuff in the knowledge base.
 * CR:	12/10/95 AM.
 *
@@ -19,7 +19,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 

--- a/cs/libkbm/kbm.cpp
+++ b/cs/libkbm/kbm.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									KBM.C
 *
-* FILE:	ext.¹/kbm.c
+* FILE:	ext.ï¿½/kbm.c
 * SUBJ:	Knowledge base management.
 * CR:	9/26/95 AM.
 *
@@ -19,7 +19,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 

--- a/cs/libkbm/kbm_kb.cpp
+++ b/cs/libkbm/kbm_kb.cpp
@@ -5,7 +5,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 

--- a/cs/libkbm/pret.cpp
+++ b/cs/libkbm/pret.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									PRET.C
 *
-* FILE:	consh.¹/pret.c
+* FILE:	consh.ï¿½/pret.c
 * SUBJ:	Pretty printers that mix modules.
 * CR:	3/30/96 AM.
 *
@@ -19,7 +19,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cs/libkbm/ptr.cpp
+++ b/cs/libkbm/ptr.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									PTR.C
 *
-* FILE:	consh.¹/ptr.c
+* FILE:	consh.ï¿½/ptr.c
 * SUBJ:	Ptr table manager for Consh.
 * NOTE:	Analogous to concept table.
 *		'ptr' may be a bad choice of words.  In text, 'ptr' will mean a regular
@@ -22,7 +22,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 

--- a/cs/libkbm/st.cpp
+++ b/cs/libkbm/st.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									ST.C
 *
-* FILE:	conan.¹/st.c
+* FILE:	conan.ï¿½/st.c
 * SUBJ:	String table manager for Conch.
 * CR:	5/07/95 AM.
 * NOTE:	String table split into segments (Macintosh).
@@ -37,7 +37,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 
@@ -430,7 +429,7 @@ if (str)
 bool
 AST::st_pp(
 	//FILE *fp			// 04/20/99 AM.
-	_t_ostream *fp			// 04/20/99 AM.
+	std::_t_ostream *fp			// 04/20/99 AM.
 	)
 {
 int ii;
@@ -439,7 +438,7 @@ _TCHAR *ptr;
 int flag;
 
 //fprintf(fp, "String Table:\n-------------\n");
-*fp << _T("String Table:\n-------------") << endl;
+*fp << _T("String Table:\n-------------") << std::endl;
 for (ii = 0; ii < St_segs_tot; ii++)
    {
    ptr = St_segs[ii];
@@ -449,11 +448,11 @@ for (ii = 0; ii < St_segs_tot; ii++)
       {
       if (!(count % STD_LINE))
          //fprintf(fp, "\n");
-			*fp << endl;
+			*fp << std::endl;
       if (ptr == St_seg_p + 1)	/* End of filled table. */
          {
          //fprintf(fp, "\n");
-			*fp << endl;
+			*fp << std::endl;
          return true;
          }
       if (*ptr)
@@ -489,7 +488,7 @@ return true;
 
 void AST::st_pp_all(
 	//FILE *fp			// 04/20/99 AM.
-	_t_ostream *fp			// 04/20/99 AM.
+	std::_t_ostream *fp			// 04/20/99 AM.
 	)
 {
 int ii;
@@ -506,11 +505,11 @@ for (ii = 0; ii < St_segs_tot; ii++)
       {
       if (!(count % STD_LINE))
          //fprintf(fp, "\n");
-			*fp << endl;
+			*fp << std::endl;
       if (!(count % 1000))
          {
          //printf("%ld\n", count);
-			*fp << count << endl;
+			*fp << count << std::endl;
          }
       if (*ptr)
          {

--- a/cs/libkbm/sym.cpp
+++ b/cs/libkbm/sym.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									SYM.C
 *
-* FILE:	consh.¹/sym.c
+* FILE:	consh.ï¿½/sym.c
 * SUBJ:	Symbol table manager for Conan.
 * NOTE:	For the compiled analyzer (i.e., Conan), implementing highly optimized
 *		(hopefully) (for Macintosh) primitive table managers from scratch.
@@ -39,7 +39,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "kbm/libkbm.h"
 
@@ -594,7 +593,7 @@ if (sym)
 void
 ASYM::sym_pp(
 	//FILE *out		// 04/20/99 AM.
-	_t_ostream *out	// 04/20/99 AM.
+	std::_t_ostream *out	// 04/20/99 AM.
 	)
 {
 int ii;
@@ -604,8 +603,8 @@ SYM *sym, *ptr;
 
 //fprintf(out, "Symbol Table\n");
 //fprintf(out, "------------\n");
-*out << _T("Symbol Table") << endl;
-*out << _T("------------") << endl;
+*out << _T("Symbol Table") << std::endl;
+*out << _T("------------") << std::endl;
 
 /* Traverse the symbol hash table, looking for nonempty locs. */
 count = 0;
@@ -626,7 +625,7 @@ for (ii = 0; ii < SYM_HASH_TOT; ii++)
             //fprintf(out, " %s", ptr->str);
 				*out << _T(" ") << ptr->str;
          //fprintf(out, "\n");
-			*out << endl;
+			*out << std::endl;
          }
       ++sym;
       if (count++ >= SYM_HASH_SIZE - 1)
@@ -730,7 +729,7 @@ return(Sym_segs);
 void
 ASYM::sym_stat(
 	//FILE *out		// 04/20/99 AM.
-	_t_ostream *out	// 04/20/99 AM.
+	std::_t_ostream *out	// 04/20/99 AM.
 	)
 {
 #ifdef _OBSOLETE_
@@ -752,22 +751,22 @@ _ftprintf(out, _T("Total filled size   = %ld\n"),
 	(long) (Conf_seg_p - Sym_segs[Conf_seg_curr] + (long) 1) );
 #endif
 
-*out << _T("Sym structure size  = ") << (int) sizeof(SYM) << endl;
-*out << _T("Sym segment size    = ") << SYM_SEG_SIZE << endl;
-*out << _T("Hash table size     = ") << SYM_HASH_SIZE << endl;
-*out << _T("# of hard hash segs = ") << SYM_HASH_TOT << endl;
-*out << _T("# of hard sym segs  = ") << SYM_SEGS_TOT << endl;
-*out << _T("# hard filled segs  = ") << CONF_SEG_CURR+1 << endl;
+*out << _T("Sym structure size  = ") << (int) sizeof(SYM) << std::endl;
+*out << _T("Sym segment size    = ") << SYM_SEG_SIZE << std::endl;
+*out << _T("Hash table size     = ") << SYM_HASH_SIZE << std::endl;
+*out << _T("# of hard hash segs = ") << SYM_HASH_TOT << std::endl;
+*out << _T("# of hard sym segs  = ") << SYM_SEGS_TOT << std::endl;
+*out << _T("# hard filled segs  = ") << CONF_SEG_CURR+1 << std::endl;
 *out << _T("Hard filled size    = ") <<
 	((long)CONF_SEG_CURR * SYM_SEG_SIZE) +
-	(long) (CONF_SEG_P - Sym_segs[CONF_SEG_CURR] + (long) 1) << endl;
-*out << _T("Number of segments  = ") << Sym_segs_tot << endl;
-*out << _T("Current conf seg    = ") << Conf_seg_curr << endl;
+	(long) (CONF_SEG_P - Sym_segs[CONF_SEG_CURR] + (long) 1) << std::endl;
+*out << _T("Number of segments  = ") << Sym_segs_tot << std::endl;
+*out << _T("Current conf seg    = ") << Conf_seg_curr << std::endl;
 *out << _T("Conflict offset     = ") <<
-               (long) (Conf_seg_p - Sym_segs[Conf_seg_curr]) << endl;
+               (long) (Conf_seg_p - Sym_segs[Conf_seg_curr]) << std::endl;
 *out << _T("Total filled size   = ") <<
 	(((long)Conf_seg_curr * SYM_SEG_SIZE) +
-	(long) (Conf_seg_p - Sym_segs[Conf_seg_curr] + (long) 1) ) << endl;
+	(long) (Conf_seg_p - Sym_segs[Conf_seg_curr] + (long) 1) ) << std::endl;
 
 }
 

--- a/cs/libprim/dyn.cpp
+++ b/cs/libprim/dyn.cpp
@@ -13,7 +13,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "prim/dyn.h"
 typedef int ( * lpFunc1)();
@@ -31,10 +30,10 @@ LIBPRIM_API HINSTANCE load_dll(_TCHAR *path)
     if (hLibrary != NULL)
     {
     }
-//    else cerr << "Error in Load Library" << endl;				// 08/20/00 AM.
+//    else cerr << "Error in Load Library" << std::endl;				// 08/20/00 AM.
 	else
-		_t_cerr << _T("[Couldn't load library: ") << path					// 08/20/00 AM.
-			  << endl;
+		std::_t_cerr << _T("[Couldn't load library: ") << path					// 08/20/00 AM.
+			  << std::endl;
 return hLibrary;
 }
 

--- a/cs/libprim/hold/x.cpp
+++ b/cs/libprim/hold/x.cpp
@@ -1,7 +1,6 @@
 #include "StdAfx.h"
 #include <iostream>
 #include <sstream>
-using namespace std;
 #include "prim/libprim.h"
 
 int xxx()

--- a/cs/libprim/io.cpp
+++ b/cs/libprim/io.cpp
@@ -19,7 +19,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,12 +43,12 @@ bool resolve_file_unix(_TCHAR*,_TCHAR*,_TCHAR*);	// 07/01/03 AM.
 
 LIBPRIM_API void
 //indent(int num, FILE *out)		// 04/20/99 AM.
-indent(int num, _t_ostream *out)		// 04/20/99 AM.
+indent(int num, std::_t_ostream *out)		// 04/20/99 AM.
 {
 while (num-- > 0)
    //fprintf(out, " ");				// 04/20/99 AM.
 	*out << _T(" ");						// 04/20/99 AM.
-*out << flush;							// 04/20/99 AM.
+*out << std::flush;							// 04/20/99 AM.
 }
 
 
@@ -65,7 +64,7 @@ while (num-- > 0)
 
 LIBPRIM_API _TCHAR
 //skip_blanks(char cc, FILE *fp)			// 04/20/99 AM.
-skip_blanks(_TCHAR cc, _t_istream *fp)		// 04/20/99 AM.
+skip_blanks(_TCHAR cc, std::_t_istream *fp)		// 04/20/99 AM.
 {
 for (;;)
    {
@@ -97,11 +96,11 @@ for (;;)
 LIBPRIM_API void
 //tab(int num, FILE *out)			// 04/20/99 AM.
 // Name conflicts with Gnu	// 10/27/06 AM.
-vttab(int num, _t_ostream *out)		// 04/20/99 AM.
+vttab(int num, std::_t_ostream *out)		// 04/20/99 AM.
 {
 while (num-- > 0)
    //fprintf(out, "\t");		// 04/20/99 AM.
-	*out << _T("\t") << flush;		// 04/20/99 AM.
+	*out << _T("\t") << std::flush;		// 04/20/99 AM.
 }
 
 /********************************************

--- a/cs/libprim/list.cpp
+++ b/cs/libprim/list.cpp
@@ -23,7 +23,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 
 #include <stdio.h>
@@ -507,23 +506,23 @@ return(tmp);
 * SUBJ:	Pretty-print a list of strings.
 * CR:	8/27/95 AM.
 *
-**************************************************/
+***************************************flush_t_***********/
 
 void ALIST::list_pp_strs(
 	LIST *args,
 //	FILE *out			// 04/20/99 AM.
-	_t_ostream *out,	// 04/20/99 AM.
+	std::_t_ostream *out,	// 04/20/99 AM.
 	_TCHAR *buf
 	)
 {
 while (args)
    {
    //fprintf(out, "\"%s\" ", (char *) args->val);				// 04/20/99 AM.
-	*out << _T("\"") << (ALIST::list_str(&args,buf)) << _T("\" ") << flush;	// 04/20/99 AM.
+	*out << _T("\"") << (ALIST::list_str(&args,buf)) << _T("\" ") << std::flush;	// 04/20/99 AM.
    args = args->next;
    }
 //fprintf(out, "\n");		// 04/20/99 AM.
-*out << endl;					// 04/20/99 AM.
+*out << std::endl;					// 04/20/99 AM.
 }
 
 

--- a/cs/libprim/prim.cpp
+++ b/cs/libprim/prim.cpp
@@ -3,7 +3,7 @@ Copyright (c) 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -11,7 +11,7 @@ All rights reserved.
 *
 *									PRIM.C
 *
-* FILE:	conan.¹/prim.c
+* FILE:	conan.ï¿½/prim.c
 * SUBJ:	Primitive utilities.
 * NOTE:	Machine dependencies should be localized in a file called mach.c,
 *		to the extent possible.  ifdefs should enable each machine and
@@ -24,7 +24,6 @@ All rights reserved.
 
 #include "StdAfx.h"
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 
 #include <stdio.h>
@@ -53,8 +52,8 @@ for (;;)
    //fflush(stdout);
    //fflush(stdin);
    //scanf("%s", line);
-	_t_cout << _T("Proceed? (y or n) ") << flush;			// 04/20/99 AM.
-	_t_cin >> line;
+	std::_t_cout << _T("Proceed? (y or n) ") << std::flush;			// 04/20/99 AM.
+	std::_t_cin >> line;
    if (*line == 'y')
       return;
    exit(0);

--- a/cs/libqconsh/Aconsh.cpp
+++ b/cs/libqconsh/Aconsh.cpp
@@ -14,8 +14,7 @@ modified without written permission from Text Analysis International, Inc.
 #include "StdAfx.h"
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
-#include "consh/libconsh.h"
+u#include "consh/libconsh.h"
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libqconsh/Aqconsh.cpp
+++ b/cs/libqconsh/Aqconsh.cpp
@@ -15,7 +15,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 #include <time.h>
 #include "machine-min.h"
 

--- a/cs/libqconsh/arg.cpp
+++ b/cs/libqconsh/arg.cpp
@@ -20,7 +20,6 @@ All rights reserved.
 #include <ctype.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "u_out.h"					// 01/13/06 AM.
 #include "prim/libprim.h"

--- a/cs/libqconsh/bind.cpp
+++ b/cs/libqconsh/bind.cpp
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									BIND.C
 *
-* FILE:	consh.¹/bind.c
+* FILE:	consh.ï¿½/bind.c
 * SUBJ:	Bindings of C variables to knowledge base concepts.
 * NOTE:	
 * CR:	9/18/95 AM.
@@ -17,7 +17,6 @@ All rights reserved.
 #include "StdAfx.h"			// 04/26/99 AM.
 #include <stdio.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include "prim/libprim.h"
 #include "prim/prim.h"
 #include "prim/list_s.h"

--- a/cs/libqconsh/cg_global.cpp
+++ b/cs/libqconsh/cg_global.cpp
@@ -20,7 +20,6 @@ modified without written permission from Text Analysis International, Inc.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 #include <string.h>
 

--- a/cs/libqconsh/cmd.cpp
+++ b/cs/libqconsh/cmd.cpp
@@ -23,7 +23,6 @@ All rights reserved.
 #include <ctype.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <string.h>
 
 

--- a/cs/libqconsh/consh_kb.cpp
+++ b/cs/libqconsh/consh_kb.cpp
@@ -1,6 +1,6 @@
 
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -8,7 +8,7 @@ All rights reserved.
 *
 *									CONSH_KB.C
 *
-* FILE:	consh.¹/consh_kb.c
+* FILE:	consh.ï¿½/consh_kb.c
 * SUBJ:	Consh-specific knowledge base handlers.
 * CR:	11/28/95 AM.
 *
@@ -19,7 +19,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <string.h>			// 03/07/00 AM.
 #include <iostream>											// Upgrade.	// 01/30/01 AM.
-using namespace std;											// Upgrade.	// 01/30/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libqconsh/help.cpp
+++ b/cs/libqconsh/help.cpp
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									HELP.C
 *
-* FILE:	consh.¹/help.c
+* FILE:	consh.ï¿½/help.c
 * SUBJ:	Help commands.
 * CR:	11/11/95 AM.
 *
@@ -19,7 +19,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 #include "prim/prim.h"

--- a/cs/libqconsh/ind.cpp
+++ b/cs/libqconsh/ind.cpp
@@ -21,7 +21,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 
 #include "prim/libprim.h"

--- a/cs/libqconsh/io.cpp
+++ b/cs/libqconsh/io.cpp
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 
 #include "prim/libprim.h"
 //#include "prim/mach.h"

--- a/cs/libqconsh/ui.cpp
+++ b/cs/libqconsh/ui.cpp
@@ -20,7 +20,6 @@ All rights reserved.
 //#include <fstream.h>			// 04/20/99 AM.
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <ctype.h>
 
 #include "prim/libprim.h"

--- a/cs/libqkbm/Aqkbm.cpp
+++ b/cs/libqkbm/Aqkbm.cpp
@@ -21,7 +21,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 #include <time.h>
 #include "machine-min.h"
 

--- a/cs/libqkbm/mgr.cpp
+++ b/cs/libqkbm/mgr.cpp
@@ -16,7 +16,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/cs/libqkbm/strx.cpp
+++ b/cs/libqkbm/strx.cpp
@@ -20,7 +20,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/cs/libqkbm/util.cpp
+++ b/cs/libqkbm/util.cpp
@@ -16,7 +16,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "qkbm/libqkbm.h"
 #include "depot.h"

--- a/cs/libqkbm/xcon.cpp
+++ b/cs/libqkbm/xcon.cpp
@@ -16,7 +16,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "depot.h"
 #include "curia.h"

--- a/cs/libqkbm/xptr.cpp
+++ b/cs/libqkbm/xptr.cpp
@@ -19,7 +19,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/cs/libqkbm/xstr.cpp
+++ b/cs/libqkbm/xstr.cpp
@@ -19,7 +19,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/cs/libqkbm/xsym.cpp
+++ b/cs/libqkbm/xsym.cpp
@@ -16,7 +16,6 @@ All rights reserved.
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
-using namespace std;
 
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/include/Api/kbm/Akbm.h
+++ b/include/Api/kbm/Akbm.h
@@ -170,7 +170,7 @@ public:
 	attrs_pret(
 		PTR *attrs,
 		//FILE *out,		// 04/20/99 AM.
-		_t_ostream *out,		// 04/20/99 AM.
+		std::_t_ostream *out,		// 04/20/99 AM.
 		_TCHAR *indent		/* String for indenting. */
 		);
 	CON *attr_get_c();

--- a/include/Api/kbm/con_.h
+++ b/include/Api/kbm/con_.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-Copyright © 1998-2009 by Text Analysis International, Inc.
+Copyright ï¿½ 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 ********************************************************************************
 *
@@ -93,7 +93,7 @@ public:
 	CON **con_seg_table();
 	void con_tab_pretty(
 		//FILE *out			// 04/20/99 AM.
-		_t_ostream *out		// 04/20/99 AM.
+		std::_t_ostream *out		// 04/20/99 AM.
 		);
 	ID con_count();
 	long con_curr_off();

--- a/include/Api/kbm/st.h
+++ b/include/Api/kbm/st.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-Copyright © 1998-2009 by Text Analysis International, Inc.
+Copyright ï¿½ 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 ********************************************************************************
 *
@@ -71,11 +71,11 @@ public:
 		);
 	bool		 st_pp(
 		//FILE *fp			// 04/20/99 AM.
-		_t_ostream *fp			// 04/20/99 AM.
+		std::_t_ostream *fp			// 04/20/99 AM.
 		);
 	void		 st_pp_all(
 		//FILE *fp			// 04/20/99 AM.
-		_t_ostream *fp			// 04/20/99 AM.
+		std::_t_ostream *fp			// 04/20/99 AM.
 		);
 	int		 st_seg_curr();
 	_TCHAR		*st_seg_p();

--- a/include/Api/kbm/sym.h
+++ b/include/Api/kbm/sym.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-Copyright © 1998-2009 by Text Analysis International, Inc.
+Copyright ï¿½ 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
 ********************************************************************************
 *
@@ -100,12 +100,12 @@ public:
 		);
 	void	 sym_pp(
 		// FILE *out
-		_t_ostream *out				// 04/20/99 AM.
+		std::_t_ostream *out				// 04/20/99 AM.
 		);
 	SYM		**sym_seg_table();
 	void	 sym_stat(
 		//FILE *out
-		_t_ostream *out				// 04/20/99 AM.
+		std::_t_ostream *out				// 04/20/99 AM.
 		);
 
 

--- a/include/Api/prim/list.h
+++ b/include/Api/prim/list.h
@@ -119,7 +119,7 @@ public:
 	static void list_pp_strs(
 		LIST *args,
 		//FILE *out				// 04/20/99 AM.
-		_t_ostream *out,		// 04/20/99 AM.
+		std::_t_ostream *out,		// 04/20/99 AM.
 		_TCHAR *buf
 		);
 	static LIST *list_push_elt(

--- a/lite/Auser.cpp
+++ b/lite/Auser.cpp
@@ -11,7 +11,6 @@ All rights reserved.
 *******************************************************************************/
 
 #ifdef LINUX
-using namespace std;
 #endif
 #include "StdAfx.h"
 #include "machine.h"	// 10/25/06 AM.

--- a/lite/global.cpp
+++ b/lite/global.cpp
@@ -13,7 +13,6 @@ All rights reserved.
 #include "StdAfx.h"
 #include "machine.h"								// 02/21/02 AM.
 //#include <iostream> // 07/18/03 AM.
-//using namespace std;	// 07/18/03 AM.
 #include <math.h>									// 10/08/00 AM.
 #include <float.h>								// 12/17/99 AM.
 #include "u_out.h"		// 01/19/06 AM.

--- a/lite/hold/dirfile.cpp
+++ b/lite/hold/dirfile.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-Copyright © 2007-2010 by Text Analysis International, Inc.
+Copyright ï¿½ 2007-2010 by Text Analysis International, Inc.
 All rights reserved.
 ********************************************************************************
 *
@@ -45,7 +45,6 @@ All rights reserved.
 #include <ctype.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <string.h>
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/lite/hold/web.cpp
+++ b/lite/hold/web.cpp
@@ -8,7 +8,6 @@
 
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <windows.h>
 #include <wininet.h>

--- a/lite/u_ofstream.cpp
+++ b/lite/u_ofstream.cpp
@@ -3,7 +3,6 @@ Copyright (c) 1998-2010 by Text Analysis International, Inc.
 All rights reserved.
 *******************************************************************************/
 #include "StdAfx.h"
-//using namespace std;
 
 
 #include "machine.h"	// 10/25/06 AM.

--- a/lite/vtrun.cpp
+++ b/lite/vtrun.cpp
@@ -53,7 +53,6 @@ All rights reserved.
 #include <ctype.h>
 #include <iostream>											// Upgrade	// 01/24/01 AM.
 #include <fstream>											// Upgrade	// 01/24/01 AM.
-using namespace std;											// Upgrade	// 01/24/01 AM.
 #include <string.h>
 #include "qkbm/libqkbm.h"
 #include "qkbm/defs.h"

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "1.19.1"
+#define NLP_ENGINE_VERSION "1.20.0"
 
 bool cmdReadArgs(int,_TCHAR*argv[],_TCHAR*&,_TCHAR*&,_TCHAR*&,_TCHAR*&,bool&,bool&,bool&);
 void cmdHelpargs(_TCHAR*);

--- a/src/web/tear.cpp
+++ b/src/web/tear.cpp
@@ -22,7 +22,6 @@
 
 #include <iostream>											// Upgrade.	// 01/24/01 AM.
 #include <fstream>											// Upgrade.	// 01/24/01 AM.
-using namespace std;											// Upgrade.	// 01/24/01 AM.
 #include <stdlib.h>
 
 #include "url.h"			// 02/11/99 AM.

--- a/src/web/url.cpp
+++ b/src/web/url.cpp
@@ -18,7 +18,6 @@ All rights reserved.
 */
 
 #include <iostream>											// Upgrade.	// 01/24/01 AM.
-using namespace std;											// Upgrade.	// 01/24/01 AM.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/web/urls.cpp
+++ b/src/web/urls.cpp
@@ -21,7 +21,6 @@ All rights reserved.
 
 #include <iostream>											// Upgrade.	// 01/24/01 AM.
 #include <fstream>											// Upgrade.	// 01/24/01 AM.
-using namespace std;											// Upgrade.	// 01/24/01 AM.
 #include <stdlib.h>
 
 #include "util.h"

--- a/src/web/util.cpp
+++ b/src/web/util.cpp
@@ -17,7 +17,6 @@ All rights reserved.
 
 #include <iostream>											// Upgrade.	// 01/24/01 AM.
 #include <fstream>											// Upgrade.	// 01/24/01 AM.
-using namespace std;											// Upgrade.	// 01/24/01 AM.
 #include <stdlib.h>
 
 #include "util.h"


### PR DESCRIPTION
Signed-off-by: David de Hilster <david.dehilster@lexisnexisrisk.com>