### PR TITLE
Fixing an issue that prevented using the VCPkg ICU library linking 

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -33,7 +33,7 @@ jobs:
         run: mkdir build
 
       - name: Generate Solution Windows
-        run: cmake -B build -A Win32 -DCMAKE_TOOLCHAIN_FILE='${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake'
+        run: cmake -B build -A x64 -DCMAKE_TOOLCHAIN_FILE='${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake'
 
       - name: Cmake Build all targets Windows
         run: cmake --build build --config Release --target nlp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 include(CTest)
 enable_testing()
 
-find_package(ICU REQUIRED COMPONENTS uc i18n io)
+find_package(ICU REQUIRED COMPONENTS i18n uc data io)
 set(CMAKE_GENERATOR_PLATFORM Win32 HINT)
 
 if(MSVC)


### PR DESCRIPTION
The order in which icu components are linked is important. Fix it so that static linking works across platforms.