### PR TITLE
NLP-ENGINE-481 emit nlp-source provenance comments during -COMPILE

### DIFF
--- a/lite/ifile.cpp
+++ b/lite/ifile.cpp
@@ -461,6 +461,9 @@ _TCHAR *algo = parse->getAlgo();											// 05/31/00 AM.
 
 
 *fcode << _T("// Automatically generated: ") << today() << std::endl;	// 04/03/09 AM.
+// File-level provenance anchor consumed by the compile-service error parser.
+// Per-construct `// nlp-source: <line>` comments downstream inherit this file.
+*fcode << _T("// nlp-source-file: ") << sfile << std::endl;
 
 *fcode << _T("#include \"analyzer.h\"") << std::endl;			// 04/03/09 AM.
 *fcode << _T("#include \"ehead.h\"") << std::endl;				// 04/03/09 AM.

--- a/lite/irule.cpp
+++ b/lite/irule.cpp
@@ -1696,6 +1696,11 @@ _stprintf(eltarr, _T("elts%d_%d_%d"),											// 05/30/00 AM.
 				gen->id_,gen->recid_,gen->ruleid_);						// 05/30/00 AM.
 Ielt::genElts(phrase_,eltarr,gen);	// Array for rule elts.		// 05/17/00 AM.
 
+// Per-rule provenance anchor for the compile-service error parser.
+// File context inherits from the `// nlp-source-file:` line emitted at top of pass.
+*fcode << indent << _T("// nlp-source: ") << line_;
+Gen::nl(fcode);
+
 // Initialize rule data.
 *fcode << indent
 		 << _T("Arun::init_rule(")


### PR DESCRIPTION
Adds two short anchors in the generated C++ that let the compile-service error parser map C++ build errors back to NLP++ source locations:

- lite/ifile.cpp: once per pass, after the "Automatically generated"
  header: // nlp-source-file: <pass-file-path>
- lite/irule.cpp: once per rule, just before Arun::init_rule(...):
  // nlp-source: <rule-line>

A downstream parser walks backward from each compiler error: the first per-rule comment supplies the line, the file anchor supplies the path.