### PR TITLE
NLP-ENGINE-482 include ICU import libs in Windows compile-libs zip

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -112,6 +112,19 @@ jobs:
             Copy-Item -Force $lib.FullName (Join-Path $libRoot "$name.lib")
           }
 
+          # ICU import libs from vcpkg. lite.lib's find_str_nocase references
+          # icuin78 (Collator), and prim.lib pulls in icuuc78/icudt78.
+          # Downstream analyzer/KB compilation linking against the engine
+          # static libs above will fail with LNK2019 without these.
+          $icuLibDir = Join-Path $env:GITHUB_WORKSPACE 'vcpkg/packages/icu_x64-windows/lib'
+          $icuLibs = Get-ChildItem -Path $icuLibDir -File -Filter "icu*.lib" -ErrorAction Stop
+          if ($icuLibs.Count -lt 3) {
+            throw "Expected at least 3 ICU import libs in $icuLibDir, found $($icuLibs.Count)"
+          }
+          foreach ($icu in $icuLibs) {
+            Copy-Item -Force $icu.FullName (Join-Path $libRoot $icu.Name)
+          }
+
           Compress-Archive -Path (Join-Path $outRoot '*') -DestinationPath (Join-Path $env:GITHUB_WORKSPACE 'nlpengine-compile-libs.zip') -Force
 
       - name: Upload nlpengine-compile-libs.zip


### PR DESCRIPTION
The Windows nlpengine-compile-libs.zip ships prim/kbm/consh/words/lite as .lib static libraries, but those reference ICU symbols (lite.lib's find_str_nocase uses the Collator from icuin78; prim.lib pulls in icuuc78/icudt78). Without matching ICU import libraries in the zip, any downstream analyzer/KB build that links against the engine libs fails with LNK2019.

vcpkg already builds the ICU import libs as part of the engine build — they live at vcpkg/packages/icu_x64-windows/lib/. This change copies them into the compile-libs/lib directory alongside the engine .lib files so the zip is self-sufficient for downstream linking.

This mirrors the Linux/macOS compile-libs zips, which already include static ICU libs from their respective vcpkg installs.