### PR TITLE
NLP-ENGINE-484 bump NLP_ENGINE_VERSION to 3.1.16

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.14"
+#define NLP_ENGINE_VERSION "3.1.16"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The version constant printed by `nlp.exe --version` had been one release behind the actual tag for several cycles (v3.1.14 shipped reporting "3.1.13", v3.1.15 shipped reporting "3.1.14"). This caused vscode-nlp to perpetually re-download the engine because its version check never matched the tag it had just installed.

Bump to "3.1.16" so v3.1.16 will be the first release where the binary's self-reported version matches the release tag.