### PR TITLE
NLP-ENGINE-486 fix segfault in nlp-source-file emission

### DIFF
--- a/lite/ifile.cpp
+++ b/lite/ifile.cpp
@@ -463,7 +463,16 @@ _TCHAR *algo = parse->getAlgo();											// 05/31/00 AM.
 *fcode << _T("// Automatically generated: ") << today() << std::endl;	// 04/03/09 AM.
 // File-level provenance anchor consumed by the compile-service error parser.
 // Per-construct `// nlp-source: <line>` comments downstream inherit this file.
-*fcode << _T("// nlp-source-file: ") << sfile << std::endl;
+// sfile (from parse->getInput()) may be NULL/empty/"NIL" — same null-check
+// pattern used at the existing fdata emission below (around line 678). Without
+// this, streaming a NULL _TCHAR* into ostream is undefined behavior and
+// segfaults on MSVC's runtime, crashing -COMPILE before producing any pass file.
+{
+    _TCHAR *src = sfile;
+    if (!src || !*src || !strcmp_i(src, _T("NIL")))
+        src = _T("0");
+    *fcode << _T("// nlp-source-file: ") << src << std::endl;
+}
 
 *fcode << _T("#include \"analyzer.h\"") << std::endl;			// 04/03/09 AM.
 *fcode << _T("#include \"ehead.h\"") << std::endl;				// 04/03/09 AM.


### PR DESCRIPTION
NLP-ENGINE-481 added `*fcode << _T("// nlp-source-file: ") << sfile` at the top of every generated pass{N}.cpp, but `sfile` (from `parse->getInput()`) can be NULL/empty/"NIL". The existing code at line ~678 already guards against this for the fdata emission:

    if (!sfile || !*sfile || !strcmp_i(sfile, _T("NIL")))
        sfile = _T("0");

…but 481's new emission runs ~200 lines earlier, before that guard. Streaming a NULL `_TCHAR*` into an `ostream` is undefined behavior; on MSVC's runtime it segfaults inside `nlpEngine->init()`, killing `-COMPILE` before any pass file is written.

Reproduced with v3.1.15 and v3.1.16 release binaries on Windows (both crash with exit 139 immediately after printing "[Compiling analyzer and KB: ...]"). v3.1.14 release binary (predates 481) runs cleanly.

Fix: apply the same null/"NIL" guard to a local copy of sfile inside a block scope, so the existing code path further down is unaffected.