### PR TITLE
NLP-ENGINE-487 bump NLP_ENGINE_VERSION to 3.1.17

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.16"
+#define NLP_ENGINE_VERSION "3.1.17"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Follow-up to NLP-ENGINE-486 (segfault fix in nlp-source-file emission). The bump should have been included in 486 itself, but that PR was merged before the bump commit was added — this PR carries the bump forward so the next release tag reports the right version.