### PR TITLE
NLP-ENGINE-488 fix per-rule provenance comment swallowing switch clos…

### DIFF
--- a/lite/irule.cpp
+++ b/lite/irule.cpp
@@ -1697,8 +1697,12 @@ _stprintf(eltarr, _T("elts%d_%d_%d"),											// 05/30/00 AM.
 Ielt::genElts(phrase_,eltarr,gen);	// Array for rule elts.		// 05/17/00 AM.
 
 // Per-rule provenance anchor for the compile-service error parser.
-// File context inherits from the `// nlp-source-file:` line emitted at top of pass.
-*fcode << indent << _T("// nlp-source: ") << line_;
+// File context inherits from the `// nlp-source-file:` line emitted at top
+// of pass. Must use C-style `/* ... */` (not `//`) because Gen::nl is a no-op
+// without GENPRETTY_ defined in release builds, so the surrounding code is
+// emitted on a single line and a `//` comment would swallow the rest of the
+// case body (including the switch's closing brace).
+*fcode << indent << _T("/* nlp-source: ") << line_ << _T(" */");
 Gen::nl(fcode);
 
 // Initialize rule data.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.17"
+#define NLP_ENGINE_VERSION "3.1.18"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
…ing brace

NLP-ENGINE-481 emitted `// nlp-source: <line>` before each rule's init_rule call in lite/irule.cpp, expecting Gen::nl to insert a newline after it. But Gen::nl is a no-op unless GENPRETTY_ is defined, which it isn't in release builds — so the entire pass function body ends up on one physical line. The `//` line comment then swallows the rest of the line, including the case body and the switch's closing brace, leading to:

    pass5.cpp(16): fatal error C1075: '{': no matching token found

…during downstream cmake build of the generated C++. The compile- service workflow's `parse-errors.py` consumer regex also needs to be updated to match the new comment shape.

Fix: emit the provenance anchor as a C-style block comment (`/* nlp-source: 14 */`) which terminates at `*/` and doesn't depend on a newline. Behavior is identical to the intended design; just a single-vs-block comment style change.

Also bumps NLP_ENGINE_VERSION to 3.1.18.