### PR TITLE
NLP-ENGINE-489 add RFASem overloads for attrtype/pnremoveval/pnvartype

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -842,6 +842,7 @@ public:
 
 	static _TCHAR *attrname(Nlppp*,RFASem*);
 	static int attrtype(Nlppp*,RFASem*,_TCHAR*);
+	static int attrtype(Nlppp*,RFASem*,RFASem*);
 	static RFASem *attrvals(Nlppp*,RFASem*);
 
 	static RFASem *findvals(Nlppp*,RFASem*,_TCHAR*);
@@ -1286,6 +1287,7 @@ public:
 	static RFASem *pnprev(Nlppp*,RFASem*);								// 04/29/01 AM.
 
 	static bool pnremoveval(Nlppp*,NODE*,_TCHAR*);
+	static bool pnremoveval(Nlppp*,NODE*,RFASem*);
 	static _TCHAR *pnrename(Nlppp*,NODE*,_TCHAR*);						// 01/08/01 AM.
 	static _TCHAR *pnrename(Nlppp*,RFASem*,_TCHAR*);						// 04/28/01 AM.
 	static _TCHAR *pnrename(Nlppp*,NODE*,RFASem*);						// 04/28/01 AM.
@@ -1552,6 +1554,7 @@ public:
 	static RFASem *pnvarnames(Nlppp*,NODE*);							// 05/13/02 AM.
 	static RFASem *pnvarnames(Nlppp*,RFASem*);						// 05/13/02 AM.
 	static RFASem *pnvartype(Nlppp*,NODE*,_TCHAR*);
+	static RFASem *pnvartype(Nlppp*,NODE*,RFASem*);
 
 	static bool pnsetfired(Nlppp*,NODE*,bool);
 

--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -503,6 +503,26 @@ delete sem;
 return type;
 }
 
+// NLP++ source may pass the attribute-name arg as a local variable (e.g.
+// `L("name")`), in which case codegen emits Arun::l(...) returning RFASem*
+// where this fn's _TCHAR* third arg is expected. Extract the string at
+// call time and delegate to the existing impl. Mirrors the existing
+// pnrename(Nlppp*,NODE*,RFASem*) / pnrename(Nlppp*,RFASem*,_TCHAR*) etc.
+// overload pattern in this file.
+int Arun::attrtype(
+	Nlppp *nlppp,
+	RFASem *sem,
+	RFASem *name_sem
+	)
+{
+if (!name_sem)
+	return attrtype(nlppp, sem, (_TCHAR*)0);
+_TCHAR *name = name_sem->sem_to_str();
+int result = attrtype(nlppp, sem, name);
+delete name_sem;
+return result;
+}
+
 
 
 /********************************************
@@ -8595,6 +8615,21 @@ Ivar::nodeRemoveval(pn,name2);
 return true;
 }
 
+// RFASem overload — see attrtype overload near line 506 for rationale.
+bool Arun::pnremoveval(
+	Nlppp *nlppp,
+	NODE *nd,
+	RFASem *name_sem
+	)
+{
+if (!name_sem)
+	return false;
+_TCHAR *name = name_sem->sem_to_str();
+bool result = pnremoveval(nlppp, nd, name);
+delete name_sem;
+return result;
+}
+
 
 /********************************************
 * FN:		PNRENAME
@@ -13409,6 +13444,21 @@ case IAFLOAT:
 
 sem = new RFASem(typNum);
 return sem;
+}
+
+// RFASem overload — see attrtype overload near line 506 for rationale.
+RFASem *Arun::pnvartype(
+	Nlppp *nlppp,
+	NODE *pnode,
+	RFASem *name_sem
+	)
+{
+if (!name_sem)
+	return 0;
+_TCHAR *name = name_sem->sem_to_str();
+RFASem *result = pnvartype(nlppp, pnode, name);
+delete name_sem;
+return result;
 }
 
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.18"
+#define NLP_ENGINE_VERSION "3.1.19"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Three Arun functions take a _TCHAR* at the third arg position (attribute / variable name strings). When NLP++ source passes that arg as a local variable (e.g. `L("name")`), codegen wraps it in Arun::l(...) returning RFASem*, producing calls of the form

    attrtype(nlppp, sem, Arun::l(_T("name"),-1,false,nlppp))

…which don't match the only existing _TCHAR* overload — every cmake build of an analyzer using these fns fails with C2664:

    cannot convert argument 3 from 'RFASem *' to '_TCHAR *'

Add RFASem-third-arg overloads that extract the string via sem_to_str() and delegate to the existing impl, then clean up the sem. Follows the same overload pattern already established for pnrename (Arun.h:1290-1292) and others.

Scope: only the three fns surfaced by the date-time analyzer's compile. Other Arun fns with _TCHAR* args at non-first positions likely need the same treatment when hit by other analyzers — the pattern is the same one-page change per function.

Also bumps NLP_ENGINE_VERSION to 3.1.19.