### PR TITLE
NLP-ENGINE-490 add 24 more RFASem overloads for NLP++ builtins

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -1832,6 +1832,48 @@ public:
 		);
 
 
+	// =====================================================================
+	// RFASem-substitution overloads for NLP++ builtins with _TCHAR* args.
+	//
+	// NLP++ source can pass any string arg as a local variable (e.g.
+	// `L("name")`), in which case -COMPILE codegen at iaction.cpp:942
+	// emits `Arun::l(...)` returning RFASem*. When the receiving function
+	// expects _TCHAR* at that position, the generated C++ doesn't compile.
+	//
+	// Each overload below takes RFASem* at every position where the
+	// original took _TCHAR* (positions > 0), extracts the string via
+	// sem_to_str(), delegates to the existing impl, then deletes the sem.
+	// Same pattern as the attrtype/pnremoveval/pnvartype overloads added
+	// in NLP-ENGINE-489; this PR fans out to the remaining 24 builtins
+	// found by walking funcs.h × Arun.h.
+	//
+	// Matching impls live at the bottom of lite/fnrun.cpp.
+	static bool addattr(Nlppp*, RFASem *, RFASem *, RFASem *);
+	static bool addstrs(Nlppp *, RFASem *, long long);
+	static bool fileout(Nlppp *, RFASem *);
+	static bool fprintvar(Nlppp*, RFASem *, RFASem *, RFASem *);
+	static bool gdump(Nlppp*, RFASem *);
+	static bool gtolower(Nlppp *, RFASem *);
+	static bool guniq(Nlppp *, RFASem *);
+	static long long inc(int, RFASem *, int, long long, Nlppp *);
+	static long long inc(int, RFASem *, int, RFASem*, Nlppp*);
+	static bool lookup(Nlppp *, RFASem *, RFASem *, RFASem *);
+	static bool ndump(Nlppp*, RFASem *, long long);
+	static bool prchild(Nlppp *, RFASem *, long long, RFASem *);
+	static bool print(Nlppp *, RFASem *);
+	static bool prlit(Nlppp *, RFASem *, RFASem *);
+	static bool prrange(Nlppp *, RFASem *, long long, long long);
+	static bool prtree(Nlppp *, RFASem *, long long, RFASem *);
+	static bool prxtree(Nlppp*, RFASem *, RFASem *, long long, RFASem *, RFASem *);
+	static bool sdump(Nlppp*, RFASem *);
+	static bool setbase(Nlppp *, long long, RFASem *);
+	static bool setunsealed(Nlppp *, long long, RFASem *);
+	static bool sortvals(Nlppp *, RFASem *);
+	static bool vareq(Nlppp*, RFASem *, long long);
+	static bool varne(Nlppp*, RFASem *, long long);
+	static bool xdump(Nlppp*, RFASem *, long long);
+
+
 };		// End of Arun class.
 
 

--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -19026,3 +19026,230 @@ return DICTphraselookup(nlppp,n,k,m,a,p);
 }
 
 //////////////////////////
+
+
+// =========================================================================
+// RFASem-substitution overloads (NLP-ENGINE-490). See block at end of
+// include/Api/lite/Arun.h for rationale. Each takes RFASem* where the
+// original takes _TCHAR* at positions > 0, extracts the string via
+// sem_to_str(), delegates to the existing impl, and deletes the sem.
+// =========================================================================
+
+// 24 RFASem-substitution overloads (NLP-ENGINE-490)
+
+bool Arun::addattr(Nlppp* a0, RFASem * s1_sem, RFASem * s2_sem, RFASem * s3_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+_TCHAR *str3 = s3_sem ? s3_sem->sem_to_str() : 0;
+bool _r = addattr(a0, str1, str2, str3);
+if (s1_sem) delete s1_sem;
+if (s2_sem) delete s2_sem;
+if (s3_sem) delete s3_sem;
+return _r;
+}
+
+bool Arun::addstrs(Nlppp * a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = addstrs(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::fileout(Nlppp * a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = fileout(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::fprintvar(Nlppp* a0, RFASem * s1_sem, RFASem * s2_sem, RFASem * s3_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+_TCHAR *str3 = s3_sem ? s3_sem->sem_to_str() : 0;
+bool _r = fprintvar(a0, str1, str2, str3);
+if (s1_sem) delete s1_sem;
+if (s2_sem) delete s2_sem;
+if (s3_sem) delete s3_sem;
+return _r;
+}
+
+bool Arun::gdump(Nlppp* a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = gdump(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::gtolower(Nlppp * a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = gtolower(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::guniq(Nlppp * a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = guniq(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+long long Arun::inc(int a0, RFASem * s1_sem, int a2, long long a3, Nlppp * a4)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+long long _r = inc(a0, str1, a2, a3, a4);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+long long Arun::inc(int a0, RFASem * s1_sem, int a2, RFASem* a3, Nlppp* a4)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+long long _r = inc(a0, str1, a2, a3, a4);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::lookup(Nlppp * a0, RFASem * s1_sem, RFASem * s2_sem, RFASem * s3_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+_TCHAR *str3 = s3_sem ? s3_sem->sem_to_str() : 0;
+bool _r = lookup(a0, str1, str2, str3);
+if (s1_sem) delete s1_sem;
+if (s2_sem) delete s2_sem;
+if (s3_sem) delete s3_sem;
+return _r;
+}
+
+bool Arun::ndump(Nlppp* a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = ndump(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::prchild(Nlppp * a0, RFASem * s1_sem, long long a2, RFASem * s3_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str3 = s3_sem ? s3_sem->sem_to_str() : 0;
+bool _r = prchild(a0, str1, a2, str3);
+if (s1_sem) delete s1_sem;
+if (s3_sem) delete s3_sem;
+return _r;
+}
+
+bool Arun::print(Nlppp * a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = print(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::prlit(Nlppp * a0, RFASem * s1_sem, RFASem * s2_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+bool _r = prlit(a0, str1, str2);
+if (s1_sem) delete s1_sem;
+if (s2_sem) delete s2_sem;
+return _r;
+}
+
+bool Arun::prrange(Nlppp * a0, RFASem * s1_sem, long long a2, long long a3)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = prrange(a0, str1, a2, a3);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::prtree(Nlppp * a0, RFASem * s1_sem, long long a2, RFASem * s3_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str3 = s3_sem ? s3_sem->sem_to_str() : 0;
+bool _r = prtree(a0, str1, a2, str3);
+if (s1_sem) delete s1_sem;
+if (s3_sem) delete s3_sem;
+return _r;
+}
+
+bool Arun::prxtree(Nlppp* a0, RFASem * s1_sem, RFASem * s2_sem, long long a3, RFASem * s4_sem, RFASem * s5_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+_TCHAR *str4 = s4_sem ? s4_sem->sem_to_str() : 0;
+_TCHAR *str5 = s5_sem ? s5_sem->sem_to_str() : 0;
+bool _r = prxtree(a0, str1, str2, a3, str4, str5);
+if (s1_sem) delete s1_sem;
+if (s2_sem) delete s2_sem;
+if (s4_sem) delete s4_sem;
+if (s5_sem) delete s5_sem;
+return _r;
+}
+
+bool Arun::sdump(Nlppp* a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = sdump(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::setbase(Nlppp * a0, long long a1, RFASem * s2_sem)
+{
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+bool _r = setbase(a0, a1, str2);
+if (s2_sem) delete s2_sem;
+return _r;
+}
+
+bool Arun::setunsealed(Nlppp * a0, long long a1, RFASem * s2_sem)
+{
+_TCHAR *str2 = s2_sem ? s2_sem->sem_to_str() : 0;
+bool _r = setunsealed(a0, a1, str2);
+if (s2_sem) delete s2_sem;
+return _r;
+}
+
+bool Arun::sortvals(Nlppp * a0, RFASem * s1_sem)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = sortvals(a0, str1);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::vareq(Nlppp* a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = vareq(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::varne(Nlppp* a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = varne(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::xdump(Nlppp* a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = xdump(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.19"
+#define NLP_ENGINE_VERSION "3.1.20"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
NLP-ENGINE-489 added RFASem-third-arg overloads for the three functions surfaced by the date-time analyzer's cmake build (attrtype, pnremoveval, pnvartype). This PR fans out to the remaining builtins that have _TCHAR* at positions > 0.

For every NLP++ builtin in funcs.h whose Arun declaration has _TCHAR* at a non-first arg position, this PR adds an overload that takes RFASem* at every such position. The overload extracts each string via sem_to_str(), delegates to the existing impl, then deletes the sem objects.

This eliminates the per-function whack-a-mole pattern where each new analyzer using a different builtin reveals one more missing overload. With this PR plus 489, any NLP++ source that uses a local variable for any string arg of any builtin will generate code that links.

Scope: this adds the all-RFASem* overload per function — i.e., all string args via locals. Mixed cases (some literal, some local) for functions with multiple string args fall through to the original _TCHAR* overload when all args are literals; for truly mixed args, additional overloads would be needed but are deferred (combinatorial: a 4-string-arg function has 2^4 = 16 possible literal/local combinations).

Functions added (24): addattr, addstrs, fileout, fprintvar, gdump, gtolower, guniq, inc (×2 — the long long and the RFASem* index forms), lookup, ndump, prchild, print, prlit, prrange, prtree, prxtree, sdump, setbase, setunsealed, sortvals, vareq, varne, xdump.

Declarations grouped at end of Arun class; impls grouped at end of fnrun.cpp with a clear section header. Generated via walking funcs.h × Arun.h; pattern-identical to 489's three.

Also bumps NLP_ENGINE_VERSION to 3.1.20.