### PR TITLE
NLP-ENGINE-491 cast FULLARRAY to long long in generated Arun::assign …

### DIFF
--- a/lite/iexpr.cpp
+++ b/lite/iexpr.cpp
@@ -3678,7 +3678,7 @@ switch (type_)		// Type of expression.
 		if (index)													// FIX.	// 05/04/01 AM.
 			index->genEval(gen);									// FIX.	// 05/04/01 AM.
 		else															// FIX.	// 05/04/01 AM.
-			*fcode << FULLARRAY;									// FIX.	// 05/04/01 AM.
+			*fcode << _T("(long long)") << FULLARRAY;									// FIX.	// 05/04/01 AM.
 		*fcode														// FIX.	// 05/04/01 AM.
 				 << _T(", nlppp, ")
 				 << _T("(");
@@ -3709,7 +3709,7 @@ switch (type_)		// Type of expression.
 				if (index)											// FIX.	// 05/04/01 AM.
 					index->genEval(gen);							// FIX.	// 05/04/01 AM.
 				else													// FIX.	// 05/04/01 AM.
-					*fcode << FULLARRAY;							// FIX.	// 05/04/01 AM.
+					*fcode << _T("(long long)") << FULLARRAY;							// FIX.	// 05/04/01 AM.
 				*fcode												// FIX.	// 05/04/01 AM.
 				 << _T(", ")															// 01/09/01 AM.
 						 << _T("nlppp")
@@ -3733,7 +3733,7 @@ switch (type_)		// Type of expression.
 				if (index)											// FIX.	// 05/04/01 AM.
 					index->genEval(gen);							// FIX.	// 05/04/01 AM.
 				else													// FIX.	// 05/04/01 AM.
-					*fcode << FULLARRAY;							// FIX.	// 05/04/01 AM.
+					*fcode << _T("(long long)") << FULLARRAY;							// FIX.	// 05/04/01 AM.
 				*fcode												// FIX.	// 05/04/01 AM.
 				 << _T(", ")															// 01/09/01 AM.
 						 << _T("nlppp")
@@ -3788,7 +3788,7 @@ switch (type_)		// Type of expression.
 				if (index)											// FIX.	// 05/04/01 AM.
 					index->genEval(gen);							// FIX.	// 05/04/01 AM.
 				else													// FIX.	// 05/04/01 AM.
-					*fcode << FULLARRAY;							// FIX.	// 05/04/01 AM.
+					*fcode << _T("(long long)") << FULLARRAY;							// FIX.	// 05/04/01 AM.
 				*fcode												// FIX.	// 05/04/01 AM.
 				 << _T(", ")															// 01/09/01 AM.
 						 << _T("nlppp")
@@ -3812,7 +3812,7 @@ switch (type_)		// Type of expression.
 				if (index)											// FIX.	// 05/04/01 AM.
 					index->genEval(gen);							// FIX.	// 05/04/01 AM.
 				else													// FIX.	// 05/04/01 AM.
-					*fcode << FULLARRAY;							// FIX.	// 05/04/01 AM.
+					*fcode << _T("(long long)") << FULLARRAY;							// FIX.	// 05/04/01 AM.
 				*fcode												// FIX.	// 05/04/01 AM.
 				 << _T(", ")															// 01/09/01 AM.
 						 << _T("nlppp")

--- a/lite/ifunc.cpp
+++ b/lite/ifunc.cpp
@@ -773,7 +773,7 @@ for (; darg; darg = darg->Right())
 		*fcode << _T("Arun::stmt(Arun::assign(")							// 03/11/02 AM.
 				 << LOCALVAR << _T(", ")											// 03/11/02 AM.
 				 << _T("_T(\"") << varg->getStr() << _T("\"), 0,")					// 03/11/02 AM.
-				 << FULLARRAY													// 03/11/02 AM.
+				 << _T("(long long)") << FULLARRAY													// 03/11/02 AM.
 				 << _T(", nlppp, ")												// 03/11/02 AM.
 				 << _T("L") << ii << _T("));");										// 03/11/02 AM.
 		Gen::nl(fcode);														// 04/04/03 AM.

--- a/lite/ivar.cpp
+++ b/lite/ivar.cpp
@@ -1959,7 +1959,7 @@ switch (getType())
 if (index_)															// FIX.	// 05/04/01 AM.
 	index_->genEval(gen);											// FIX.	// 05/04/01 AM.
 else																	// FIX.	// 05/04/01 AM.
-	*fcode << FULLARRAY;											// FIX.	// 05/04/01 AM.
+	*fcode << _T("(long long)") << FULLARRAY;											// FIX.	// 05/04/01 AM.
 
 // CALL-BY-REFERENCE.														// 06/16/02 AM.
 if (ref)																			// 06/16/02 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.20"
+#define NLP_ENGINE_VERSION "3.1.21"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
…calls

The -COMPILE codegen emits `FULLARRAY` (= -1 from lite/ivar.h) as the index arg of Arun::assign / Arun::inc / Arun::dec calls when the variable has no explicit array index. The receiving signatures want `long long` at that position, but FULLARRAY is bare `int`. With the RFASem* overloads from NLP-ENGINE-489/490 fixing the string-arg ambiguities, the next blocker in cmake-building date-time was:

    pass3.cpp(16): error C2664: 'Arun::assign(...,long long,...)'
    cannot convert argument 4 from 'int' to 'long long'

Wraps each `<< FULLARRAY` emission with `<< _T("(long long)")` so the generated code casts the literal explicitly. Same fix mechanically across 7 sites (5 in iexpr.cpp, 1 each in ivar.cpp + ifunc.cpp):

- iexpr.cpp:3681  Arun::assign(...) index
- iexpr.cpp:3712  Arun::inc(...) index
- iexpr.cpp:3736  Arun::dec(...) index
- iexpr.cpp:3791  similar unary op codegen
- iexpr.cpp:3815  similar unary op codegen
- ivar.cpp:1962   Arun::g/x/s/l/n(...) variable read index
- ifunc.cpp:776   inline Arun::assign(...) emission for function params

Also bumps NLP_ENGINE_VERSION to 3.1.21.