### PR TITLE
NLP-ENGINE-492 add int-rhs overloads for Arun::assign / Arun::iassign

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -513,6 +513,11 @@ public:
 	static _TCHAR   *assign(int,_TCHAR*,int,long long,Nlppp*,_TCHAR*);
 	static std::_t_ostream *assign(int,_TCHAR*,int,long long,Nlppp*,std::_t_ostream*);	// 11/20/02 AM.
 	static bool		assign(int,_TCHAR*,int,long long,Nlppp*,bool);		// 12/10/02 AM.
+	// `int` rhs disambiguator (NLP-ENGINE-492): codegen emits Arun::attrtype(...)
+	// (returns int) as the rhs of an assign; `int` implicitly converts to bool /
+	// long long / float so the call is ambiguous. This exact-match overload
+	// routes through the long long form.
+	static long long    assign(int,_TCHAR*,int,long long,Nlppp*,int);
 
 	// VARIANTS.
 	static RFASem  *assign(int,_TCHAR*,int,RFASem*,Nlppp*,RFASem*);
@@ -521,6 +526,7 @@ public:
 	static _TCHAR    *assign(int,_TCHAR*,int,RFASem*,Nlppp*,_TCHAR*);
 	static std::_t_ostream *assign(int,_TCHAR*,int,RFASem*,Nlppp*,std::_t_ostream*);//11/20/02 AM.
 	static bool     assign(int,_TCHAR*,int,RFASem*,Nlppp*,bool);	// 12/10/02 AM.
+	static long long     assign(int,_TCHAR*,int,RFASem*,Nlppp*,int);
 
 	// INDEXED ASSIGNMENT.
 	static RFASem *iassign(int,_TCHAR*,int,long long,Nlppp*,RFASem*);
@@ -529,6 +535,7 @@ public:
 	static _TCHAR   *iassign(int,_TCHAR*,int,long long,Nlppp*,_TCHAR*);
 	static std::_t_ostream *iassign(int,_TCHAR*,int,long long,Nlppp*,std::_t_ostream*); // 11/20/02 AM.
 	static bool    iassign(int,_TCHAR*,int,long long,Nlppp*,bool);		// 12/10/02 AM.
+	static long long    iassign(int,_TCHAR*,int,long long,Nlppp*,int);
 
 	static bool truth(long long);
 	static bool truth(float);

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -7487,6 +7487,13 @@ Var::setVal(pair, (val ? 1LL : 0LL));	// No boolean vars yet.
 return val;
 }
 
+// `int` rhs disambiguator (NLP-ENGINE-492). See Arun.h header block.
+long long Arun::assign(
+	int typ, _TCHAR *varname, int nelt, long long index, Nlppp *nlppp, int val)
+{
+return assign(typ, varname, nelt, index, nlppp, (long long)val);
+}
+
 // VARIANTS OF ASSIGN.
 
 RFASem *Arun::assign(														// 05/04/01 AM.
@@ -7605,11 +7612,18 @@ if (!flag)
 return assign(typ,varname,nelt,index,nlppp,val);
 }
 
+// `int` rhs disambiguator (NLP-ENGINE-492). See Arun.h header block.
+long long Arun::assign(
+	int typ, _TCHAR *varname, int nelt, RFASem *index_sem, Nlppp *nlppp, int val)
+{
+return assign(typ, varname, nelt, index_sem, nlppp, (long long)val);
+}
+
 /********************************************
 * FN:		IASSIGN
 * CR:		03/11/02 AM.
 * SUBJ:	INDEXED NLP++ assignment statement, compiled runtime.
-* NOTE:	
+* NOTE:
 ********************************************/
 
 RFASem *Arun::iassign(
@@ -7879,6 +7893,13 @@ arg->setType(IANUM);
 arg->setNum((val ? 1 : 0));
 
 return val;
+}
+
+// `int` rhs disambiguator (NLP-ENGINE-492). See Arun.h header block.
+long long Arun::iassign(
+	int typ, _TCHAR *varname, int nelt, long long index, Nlppp *nlppp, int val)
+{
+return iassign(typ, varname, nelt, index, nlppp, (long long)val);
 }
 
 


### PR DESCRIPTION
The -COMPILE codegen at iexpr.cpp:3674 emits an Arun::assign call with the rhs expression inline. When the rhs is a builtin returning int (most commonly `Arun::attrtype(...)`), the call becomes ambiguous because int implicitly converts to bool, long long, AND float — all three matching existing assign overloads:

    pass3.cpp(16): error C2668: 'Arun::assign': ambiguous call
      could be 'bool   assign(...,bool)'
      or       'float  assign(...,float)'
      or       '__int64 assign(...,__int64)'

Adds three exact-match int-rhs overloads (one per overload group: long-long-index assign, RFASem-index assign, long-long-index iassign) that delegate to the long-long form with an explicit (long long) cast.

Cheaper and safer than a codegen change to wrap nested int returns in `(long long)`, which would require expression-type analysis in iexpr.cpp.

Intended to land alongside NLP-ENGINE-491 for the same v3.1.21 release; version bump deferred to 491 to avoid a main.cpp merge conflict between the two PRs.