### PR TITLE
NLP-ENGINE-493 export run_analyzer from compiled run.dll on Windows

### DIFF
--- a/lite/seqn.cpp
+++ b/lite/seqn.cpp
@@ -567,11 +567,24 @@ Arun::set_specialarr_len();												// 06/09/00 AM.
 
 
 // Output prototype.
-*fhead << _T("extern \"C\" bool run_analyzer(Parse *);");
+// __declspec(dllexport) on Windows so GetProcAddress("run_analyzer") can
+// find it inside the compiled run.dll. Without it MSVC builds a DLL with
+// zero exported symbols and the engine's call_runAnalyzer fails silently.
+*fhead << _T("#ifdef _WIN32");
+Gen::nl(fhead);
+*fhead << _T("#define NLP_RUN_EXPORT __declspec(dllexport)");
+Gen::nl(fhead);
+*fhead << _T("#else");
+Gen::nl(fhead);
+*fhead << _T("#define NLP_RUN_EXPORT");
+Gen::nl(fhead);
+*fhead << _T("#endif");
+Gen::nl(fhead);
+*fhead << _T("extern \"C\" NLP_RUN_EXPORT bool run_analyzer(Parse *);");
 Gen::nl(fhead);																// 04/04/03 AM.
 
 // Output function head.
-*fcode << _T("bool run_analyzer(Parse *parse)");
+*fcode << _T("extern \"C\" NLP_RUN_EXPORT bool run_analyzer(Parse *parse)");
 Gen::nl(fcode);																// 04/04/03 AM.
 *fcode << _T("{");
 Gen::nl(fcode);																// 04/04/03 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.21"
+#define NLP_ENGINE_VERSION "3.1.22"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

The cloud-compile pipeline produced loadable but functionally-empty
`run.dll` files on Windows because `run_analyzer` was never exported.
Codegen in `lite/seqn.cpp` emitted it as `extern "C" bool run_analyzer(Parse *)`
with no `__declspec(dllexport)`, so MSVC built a DLL with zero exported
symbols. The engine's `call_runAnalyzer` (lite/dyn.cpp:111) hit
`GetProcAddress(hLibrary, "run_analyzer") == NULL`, logged
`Error in call_runAnalyzer` to `<input>_log/err.log`, and skipped all
passes — `final.tree` came out as just the `FINAL OUTPUT TREE:` header.

Linux/macOS default symbol visibility is "default" so this bug was
silent on those platforms — only Windows was affected.

## Change

- `lite/seqn.cpp`: wrap the emitted `run_analyzer` prototype + definition
  with an `NLP_RUN_EXPORT` macro that expands to `__declspec(dllexport)`
  on `_WIN32` and to nothing elsewhere.
- `nlp/main.cpp`: bump `NLP_ENGINE_VERSION` to `3.1.22`.

## Test plan

- [ ] CI builds pass on Windows / Linux / macOS
- [ ] After merge: cut `v3.1.22` release
- [ ] Update bundled `nlp.exe` in vscode-nlp; re-run Compile Analyzer
      on date-time; verify `final.tree` matches interp (425 lines)