### PR TITLE
NLP-ENGINE-494 emit real newlines for run_analyzer dllexport block

### DIFF
--- a/lite/seqn.cpp
+++ b/lite/seqn.cpp
@@ -570,16 +570,13 @@ Arun::set_specialarr_len();												// 06/09/00 AM.
 // __declspec(dllexport) on Windows so GetProcAddress("run_analyzer") can
 // find it inside the compiled run.dll. Without it MSVC builds a DLL with
 // zero exported symbols and the engine's call_runAnalyzer fails silently.
-*fhead << _T("#ifdef _WIN32");
-Gen::nl(fhead);
-*fhead << _T("#define NLP_RUN_EXPORT __declspec(dllexport)");
-Gen::nl(fhead);
-*fhead << _T("#else");
-Gen::nl(fhead);
-*fhead << _T("#define NLP_RUN_EXPORT");
-Gen::nl(fhead);
-*fhead << _T("#endif");
-Gen::nl(fhead);
+// Preprocessor directives must each be on their own line; Gen::nl is a
+// no-op for fhead in this codepath, so emit real newlines via std::endl.
+*fhead << _T("#ifdef _WIN32") << std::endl;
+*fhead << _T("#define NLP_RUN_EXPORT __declspec(dllexport)") << std::endl;
+*fhead << _T("#else") << std::endl;
+*fhead << _T("#define NLP_RUN_EXPORT") << std::endl;
+*fhead << _T("#endif") << std::endl;
 *fhead << _T("extern \"C\" NLP_RUN_EXPORT bool run_analyzer(Parse *);");
 Gen::nl(fhead);																// 04/04/03 AM.
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.22"
+#define NLP_ENGINE_VERSION "3.1.23"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Follow-up fix to NLP-ENGINE-493 (v3.1.22). The dllexport codegen block
landed correctly *as a string* but with bad newline handling — `Gen::nl(fhead)`
is a no-op for `fhead`, so the preprocessor directives got concatenated
into a single line in the generated `run/analyzer.h`:

#ifdef _WIN32#define NLP_RUN_EXPORT __declspec(dllexport)#else#define NLP_RUN_EXPORT#endifextern "C" NLP_RUN_EXPORT bool run_analyzer(Parse *);



MSVC rejects this with a preprocessor error and the cloud-compile build
fails with "Expected date-time.dll not produced." (The original
`extern "C" bool run_analyzer(...)` that 493 replaced was a single string,
so 493's diff never exercised the missing-newline behavior — only the
new multi-line preprocessor block did.)

## Change

- `lite/seqn.cpp`: replace `Gen::nl(fhead)` between preprocessor directives
  with explicit `<< std::endl`, matching the pattern used in
  `lite/gen.cpp` for the surrounding `#include` block emission.
- `nlp/main.cpp`: bump `NLP_ENGINE_VERSION` to `3.1.23`.

## Note on v3.1.22

The v3.1.22 release on VisualText/nlp-engine should be treated as
known-broken for Windows cloud-compile (codegen does not produce
buildable C++). v3.1.23 is the recommended replacement.

## Test plan

- [ ] CI builds pass on Windows / Linux / macOS
- [ ] After merge: cut `v3.1.23` release
- [ ] In EDH, re-run Compile Analyzer on date-time; verify cloud build
      succeeds and `final.tree` matches interp (425 lines)