### PR TITLE
NLP-ENGINE-495 generate kb_setup wrapper for compiled-KB load (fixes pass 16 crash in v3.1.23)

### DIFF
--- a/cs/libconsh/cc_gen.cpp
+++ b/cs/libconsh/cc_gen.cpp
@@ -105,3 +105,56 @@ gen_file_head(fp);
 //   return;
 delete fp;
 }
+
+
+/**************************************************
+*						CC_GEN_KB_SETUP
+* FUN:	cc_gen_kb_setup
+* SUBJ:	Generate kb_setup.cpp + kb_setup.h in the analyzer's kb/ folder.
+* NOTE:	NLP-ENGINE-495. The engine's call_kb_setup (cs/libconsh/dyn.cpp)
+*			resolves "kb_setup" via GetProcAddress / dlsym from the compiled
+*			KB library. Without this generated wrapper the symbol isn't
+*			present and patExecute<n> for the `kb` pass crashes in compiled
+*			runs because the compiled KB data structures never get
+*			initialized. Wrap in extern "C" + __declspec(dllexport) on
+*			Windows so the symbol is exported from the cmake-built DLL.
+**************************************************/
+
+void cc_gen_kb_setup(
+	_TCHAR *dir,		/* Output directory for gend code.		*/
+	_TCHAR *tail		/* Tail for naming generated files.		*/
+	)
+{
+std::_t_ofstream *fp;
+_TCHAR s_nam[PATH];
+
+// kb_setup.h
+_stprintf(s_nam, _T("%s%skb_setup.h%s"), dir, DIR_SEP, tail);
+fp = new std::_t_ofstream(TCHAR2A(s_nam));
+gen_file_head(fp);
+*fp << _T("extern \"C\" bool kb_setup(void*);") << std::endl;
+delete fp;
+
+// kb_setup.cpp
+_stprintf(s_nam, _T("%s%skb_setup.cpp%s"), dir, DIR_SEP, tail);
+fp = new std::_t_ofstream(TCHAR2A(s_nam));
+gen_file_head(fp);
+#ifdef LINUX
+*fp << _T("#include \"stdafx.h\"") << std::endl;
+#else
+*fp << _T("#include \"StdAfx.h\"") << std::endl;
+#endif
+*fp << _T("#include \"Cc_code.h\"") << std::endl;
+*fp << _T("#include \"kb_setup.h\"") << std::endl;
+*fp << _T("#ifdef _WIN32") << std::endl;
+*fp << _T("#define NLP_KB_EXPORT __declspec(dllexport)") << std::endl;
+*fp << _T("#else") << std::endl;
+*fp << _T("#define NLP_KB_EXPORT") << std::endl;
+*fp << _T("#endif") << std::endl;
+*fp << _T("extern \"C\" NLP_KB_EXPORT bool kb_setup(void *cg)") << std::endl;
+*fp << _T("{") << std::endl;
+*fp << _T("if (!cc_ini(cg)) return false;") << std::endl;
+*fp << _T("return true;") << std::endl;
+*fp << _T("}") << std::endl;
+delete fp;
+}

--- a/cs/libconsh/cc_gen.h
+++ b/cs/libconsh/cc_gen.h
@@ -1,5 +1,5 @@
 /****************************************
-Copyright © 1995 by Conceptual Systems.
+Copyright ï¿½ 1995 by Conceptual Systems.
 Copyright (c) 1995 by Conceptual Systems.
 All rights reserved.
 *****************************************/ 
@@ -7,7 +7,7 @@ All rights reserved.
 *
 *									CC_GEN.H
 *
-* FILE:	consh.¹/cc_gen.h
+* FILE:	consh.ï¿½/cc_gen.h
 * SUBJ:	Declarations for overall code generation.
 * CR:	10/1/95 AM.
 *
@@ -20,6 +20,10 @@ extern void cc_gen_hdr(
    _TCHAR *tail		/* Tail for naming generated files.		*/
    );
 extern void cc_gen_ini(
+	_TCHAR *dir,		/* Output directory for gend code.		*/
+	_TCHAR *tail		/* Tail for naming generated files.		*/
+	);
+extern void cc_gen_kb_setup(
 	_TCHAR *dir,		/* Output directory for gend code.		*/
 	_TCHAR *tail		/* Tail for naming generated files.		*/
 	);

--- a/cs/libconsh/cmd.cpp
+++ b/cs/libconsh/cmd.cpp
@@ -1036,6 +1036,7 @@ tail = _T("");			/* 10/1/95 AM */
 std::_t_cerr << _T("Generating overall code.") << std::endl;
 cc_gen_hdr(dir, tail);
 cc_gen_ini(dir, tail);
+cc_gen_kb_setup(dir, tail);					// NLP-ENGINE-495 AM.
 
 /* Generate analyzer code first, because it modifies the kb.
    Creates trigger attributes, for example. */

--- a/cs/libqconsh/cmd.cpp
+++ b/cs/libqconsh/cmd.cpp
@@ -1111,6 +1111,7 @@ tail = _T("");			/* 10/1/95 AM */
 _t_cerr << _T("Generating overall code.") << endl;
 cc_gen_hdr(dir, tail);
 cc_gen_ini(dir, tail);
+cc_gen_kb_setup(dir, tail);					// NLP-ENGINE-495 AM.
 
 /* Generate analyzer code first, because it modifies the kb.
    Creates trigger attributes, for example. */

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.23"
+#define NLP_ENGINE_VERSION "3.1.24"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Follow-up to NLP-ENGINE-493/494 (`run_analyzer` dllexport). v3.1.23 got
the compiled `run.dll` loading and executing passes 1–15 cleanly, but
pass 16 (the `kb` pass) was still crashing.

Root cause: the engine's `call_kb_setup` (`cs/libconsh/dyn.cpp:41`)
resolves a `"kb_setup"` symbol from kb.dll via `GetProcAddress`. The
symbol isn't generated by `nlp.exe -COMPILE` — only the `cc_ini`
helper in `Cc_code.cpp` is. With `kb_setup` load failing, the engine
falls back to interpreted KB load, and the compiled pass-16 code in
run.dll then runs against KB data structures that were never
initialized via `cc_ini` → crash.

## Change

- `cs/libconsh/cc_gen.cpp`: new `cc_gen_kb_setup()` writes
  `kb_setup.cpp` + `kb_setup.h` into the analyzer's `kb/` folder during
  the existing "Generating overall code" step. The generated function:

  ```cpp
  extern "C" NLP_KB_EXPORT bool kb_setup(void *cg) {
      if (!cc_ini(cg)) return false;
      return true;
  }
