### PR TITLE
NLP-ENGINE-496 fix kb_setup.h/cpp linkage mismatch (fixes v3.1.24 cloud build)

### DIFF
--- a/cs/libconsh/cc_gen.cpp
+++ b/cs/libconsh/cc_gen.cpp
@@ -129,13 +129,25 @@ std::_t_ofstream *fp;
 _TCHAR s_nam[PATH];
 
 // kb_setup.h
+// Define the NLP_KB_EXPORT macro here so the declaration and the
+// definition in kb_setup.cpp agree on linkage. MSVC errors out with
+// "redefinition; different linkage" (C2375) if the header declares
+// kb_setup without __declspec(dllexport) and the .cpp defines it with
+// dllexport.
 _stprintf(s_nam, _T("%s%skb_setup.h%s"), dir, DIR_SEP, tail);
 fp = new std::_t_ofstream(TCHAR2A(s_nam));
 gen_file_head(fp);
-*fp << _T("extern \"C\" bool kb_setup(void*);") << std::endl;
+*fp << _T("#ifdef _WIN32") << std::endl;
+*fp << _T("#define NLP_KB_EXPORT __declspec(dllexport)") << std::endl;
+*fp << _T("#else") << std::endl;
+*fp << _T("#define NLP_KB_EXPORT") << std::endl;
+*fp << _T("#endif") << std::endl;
+*fp << _T("extern \"C\" NLP_KB_EXPORT bool kb_setup(void*);") << std::endl;
 delete fp;
 
-// kb_setup.cpp
+// kb_setup.cpp — definition uses the same NLP_KB_EXPORT macro from the
+// header so MSVC sees identical linkage between declaration and
+// definition.
 _stprintf(s_nam, _T("%s%skb_setup.cpp%s"), dir, DIR_SEP, tail);
 fp = new std::_t_ofstream(TCHAR2A(s_nam));
 gen_file_head(fp);
@@ -146,11 +158,6 @@ gen_file_head(fp);
 #endif
 *fp << _T("#include \"Cc_code.h\"") << std::endl;
 *fp << _T("#include \"kb_setup.h\"") << std::endl;
-*fp << _T("#ifdef _WIN32") << std::endl;
-*fp << _T("#define NLP_KB_EXPORT __declspec(dllexport)") << std::endl;
-*fp << _T("#else") << std::endl;
-*fp << _T("#define NLP_KB_EXPORT") << std::endl;
-*fp << _T("#endif") << std::endl;
 *fp << _T("extern \"C\" NLP_KB_EXPORT bool kb_setup(void *cg)") << std::endl;
 *fp << _T("{") << std::endl;
 *fp << _T("if (!cc_ini(cg)) return false;") << std::endl;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.24"
+#define NLP_ENGINE_VERSION "3.1.25"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Follow-up to NLP-ENGINE-495. The generated `kb_setup` wrapper got the
codegen logic right but the `.h` declared `kb_setup` without
`__declspec(dllexport)` while the `.cpp` defined it with dllexport.
MSVC errored out:

error kb\kb_setup.cpp:10:31: 'kb_setup': redefinition; different linkage


The cloud-compile build then produced no `.dll`.

## Change

- `cs/libconsh/cc_gen.cpp`: emit `NLP_KB_EXPORT` macro definition into
  `kb_setup.h`, so the declaration in the header carries the same
  `__declspec(dllexport)` attribute as the definition in the .cpp. MSVC
  now sees identical linkage between declaration and definition.

This matches the pattern that NLP-ENGINE-494 settled on for
`run_analyzer` (analyzer.h defines `NLP_RUN_EXPORT`, analyzer.cpp's
definition uses the same macro).

## Note on v3.1.24

The v3.1.24 release on VisualText/nlp-engine should be treated as
known-broken for Windows cloud-compile (kb_setup codegen produces an
invalid C++ file). v3.1.25 is the recommended replacement.

## Test plan

- [ ] CI builds pass on Windows / Linux / macOS
- [ ] After merge: cut `v3.1.25` release
- [ ] In EDH, re-run Compile Analyzer on date-time; verify cloud build
      succeeds and `final.tree` matches interp (425 lines)
