### PR TITLE
NLP-ENGINE-497 stop double-loading KB when compiled KB is present (fixes pass 16 crash)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -578,16 +578,22 @@ if (!kbm_ || !ast_ || !aptr_ || !asym_ || !acon_)	// 07/29/03 AM.
 	return false;
 	}
 
-// ASSUME COMPILED KB.	// 02/19/19 AM.
-// #ifndef LINUX
-hkbdll_ = 0;
+// If a compiled KB library was loaded by the CG constructor (kb.dll
+// resolved + kb_setup ran + bind_all succeeded), the KB tables are
+// already populated. Reading the interpreted .kb files on top would
+// re-add every concept, hierarchy, etc. and produce a flood of
+// "[Hierarchy already exists.]" messages — and worse, leave the KB
+// in a state that crashes the compiled `kb` pass at run time.
+//
+// NLP-ENGINE-497: removed a 2019 `hkbdll_ = 0;` debug hack from above
+// this check that made the guard always-false. The hack was latent
+// for years because nothing ever produced a working compiled KB
+// until NLP-ENGINE-495/496 generated kb_setup with proper dllexport.
 if (hkbdll_)
 	{
 	*cgerr << _T("[Using compiled kb. readKB ignored.]") << std::endl;	// 06/29/00 AM.
 	return true;		// This is just info, ok.						// 06/29/00 AM.
 	}
-// ASSUME COMPILED KB.	// 02/19/19 AM.
-//#endif
 
 // For example, path= C:\apps\Resume\kb\user.
 _TCHAR *kbdir = _T("kb");

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.25"
+#define NLP_ENGINE_VERSION "3.1.26"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Third (and hopefully final) fix in the kb_setup chain. With v3.1.25
(NLP-ENGINE-495 + 496) the compiled KB finally loads, `kb_setup` runs,
and `bind_all` succeeds. But the cloud-compiled `date-time` analyzer
still crashes at pass 16 producing no `final.tree`.

Root cause: `cs/libconsh/cg.cpp:583` has a `hkbdll_ = 0;` line under a
2019-vintage `// ASSUME COMPILED KB.` comment that unconditionally
zeroes the compiled-KB handle right before the guard that's supposed
to skip the interpreted KB load when a compiled KB is loaded:

```cpp
hkbdll_ = 0;          // ← always-zero
if (hkbdll_)          // ← always-false
    { return true; }  // ← skip path is dead code
