### PR TITLE
NLP-ENGINE-498 fix sem_to_str crash on non-zero RSLONG and RSFLOAT (fixes pass 16 SIGSEGV)

### DIFF
--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -13375,6 +13375,13 @@ _TCHAR *Arun::sem_to_str(
 if (!sem)																		// 03/13/02 AM.
 	return 0;																	// 03/13/02 AM.
 
+// NLP-ENGINE-498: RSLONG with non-zero value and RSFLOAT used to fall
+// through to the "Bad sem type in sem_to_str" error path and return NULL.
+// Callers in user-function codegen (Arun::numval, Arun::addnumval, etc.)
+// then either propagated the NULL or dereferenced it, causing SIGSEGVs
+// inside the kb-update pass of compiled analyzers. Convert numeric sems
+// to their string representation using a thread-local buffer.
+static thread_local _TCHAR num_buf_[64];
 switch (sem->getType())														// 08/08/02 AM.
 	{
 	case RSSTR:																	// 08/08/02 AM.
@@ -13385,7 +13392,11 @@ switch (sem->getType())														// 08/08/02 AM.
 		// Zero is acceptable as "empty string".
 		if (sem->getLong() == 0)											// 08/08/02 AM.
 			return 0;															// 08/08/02 AM.
-		break;
+		_stprintf(num_buf_, _T("%lld"), sem->getLong());
+		return num_buf_;
+	case RSFLOAT:
+		_stprintf(num_buf_, _T("%g"), sem->getFloat());
+		return num_buf_;
 	case RSARGS:																// 08/08/02 AM.
 		{
 		std::_t_strstream gerrStr;

--- a/lite/rfasem.cpp
+++ b/lite/rfasem.cpp
@@ -923,7 +923,14 @@ return 0;
 
 _TCHAR *RFASem::sem_to_str()
 {
-_TCHAR *st = 0;
+// NLP-ENGINE-498: RSLONG with non-zero value and RSFLOAT used to fall
+// through to the "Bad sem type in sem_to_str" error path and return NULL.
+// Callers in user-function codegen (Arun::numval, Arun::addnumval, etc.)
+// then either propagated the NULL or dereferenced it, causing SIGSEGVs
+// inside the kb-update pass of compiled analyzers. Convert numeric sems
+// to their string representation using a thread-local buffer so the
+// caller gets a usable string instead of a NULL.
+static thread_local _TCHAR num_buf_[64];
 switch (type_)
 	{
 	case RSSTR:
@@ -933,7 +940,11 @@ switch (type_)
 	case RSLONG:																// 08/08/02 AM.
 		if (val_.long_ == 0)													// 08/08/02 AM.
 			return 0;															// 08/08/02 AM.
-		break;
+		_stprintf(num_buf_, _T("%lld"), val_.long_);
+		return num_buf_;
+	case RSFLOAT:
+		_stprintf(num_buf_, _T("%g"), val_.float_);
+		return num_buf_;
 	case RSARGS:																// 08/08/02 AM.
 		{
 		std::_t_strstream gerrStr;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.26"
+#define NLP_ENGINE_VERSION "3.1.27"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Sixth fix in the compiled-cloud-build chain. After 493/494/495/496/497
got the .dll loading and the compiled KB initializing cleanly,
compiled analyzers still SIGSEGV'd inside pass 16 (the `kb` pass) for
any analyzer that called user functions like `AddDate` / `AddTime`
that manipulate KB attributes. Binary-searching with the date-time
analyzer's text input showed:

| Input | Result |
|---|---|
| empty | ✅ ana017 produced, final.tree clean |
| non-matching | ✅ ana017 produced, final.tree clean |
| single date | ❌ "[Error: Bad sem type in sem_to_str]" ×2, then SIGSEGV |
| single time | ❌ "[Error: Bad sem type in sem_to_str]" ×1, then SIGSEGV |

That error pointed straight at this bug.

## Root cause

`RFASem::sem_to_str()` (rfasem.cpp) and `Arun::sem_to_str(RFASem*)`
(Arun.cpp) handled `RSSTR` / `RSNAME` / `RSNUM` by returning the
stored name, and `RSLONG` with value 0 by returning NULL (an "empty
string" convention), but had a `break;` for `RSLONG` with non-zero
value that fell through to the error path:

```cpp
case RSLONG:
    if (val_.long_ == 0) return 0;
    break;                           // ← falls through to error!
case RSARGS: ...
default: break;
// → "[Error: Bad sem type in sem_to_str]", return NULL
