### PR TITLE
NLP-ENGINE-499 flush Arun::out writes immediately for diagnostic visibility

### DIFF
--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -8426,8 +8426,18 @@ if (!Var::filevar(fname,nlppp->getParse(),
 	delete sem;												// MEM LEAK.	// 06/12/00 AM.
 	return 0;
 	}
+// NLP-ENGINE-499: flush after each write so user-facing diagnostic output
+// (e.g. `"dbg.txt" << "marker N";` from NLP++ source) is visible in the
+// file as it's produced, not only at clean shutdown. Without flushing,
+// buffered writes are lost if the process crashes mid-pass, making it
+// impossible to bisect a SIGSEGV by sprinkling print statements in the
+// .nlp source. Performance impact is negligible for typical diagnostic
+// volumes; the streams aren't being hammered.
 if (ostr)																		// 08/04/02 AM.
+	{
 	sem->out(ostr);
+	ostr->flush();
+	}
 delete sem;				// No one using sem past this point.		// 05/27/00 AM.
 return ostr;
 }
@@ -8448,7 +8458,10 @@ if (!Var::filevar(fname,nlppp->getParse(),
 	}
 if (str && *str																// 04/30/01 AM.
 	&& ostr)																		// 08/04/02 AM.
+	{
 	*ostr << str;
+	ostr->flush();					// NLP-ENGINE-499
+	}
 return ostr;
 }
 
@@ -8466,7 +8479,11 @@ if (!Var::filevar(fname,nlppp->getParse(),
 	nlppp->parse_->errOut(&gerrStr,false);
 	return 0;
 	}
-*ostr << num;
+if (ostr)								// NLP-ENGINE-499
+	{
+	*ostr << num;
+	ostr->flush();
+	}
 return ostr;
 }
 
@@ -8485,7 +8502,11 @@ if (!Var::filevar(fname,nlppp->getParse(),
 	nlppp->parse_->errOut(&gerrStr,false);
 	return 0;
 	}
-*ostr << (flag ? 1 : 0);
+if (ostr)								// NLP-ENGINE-499
+	{
+	*ostr << (flag ? 1 : 0);
+	ostr->flush();
+	}
 return ostr;
 }
 
@@ -8506,7 +8527,10 @@ if (!Var::filevar(fname,nlppp->getParse(),
 	return 0;
 	}
 if (ostr)																		// 08/04/02 AM.
+	{
 	*ostr << num;
+	ostr->flush();					// NLP-ENGINE-499
+	}
 return ostr;
 }
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.27"
+#define NLP_ENGINE_VERSION "3.1.28"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
NLP++ user code that does `"dbg.txt" << "marker"` went through
`Arun::out` but never flushed the C++ stream. Buffered writes were
lost if the process SIGSEGV'd mid-pass — diagnostic file showed up
empty even though the markers had run. This blocked the most natural
diagnostic for crashes in compiled mode (sprinkle prints, bisect).

Fix: call `ostr->flush()` after each successful write in the five
fname-based `Arun::out` overloads (`sem`, `_TCHAR*`, `long long`,
`bool`, `float`). Engine's own `dbg.log` / `err.log` already flush
eagerly via a different path — this brings user-facing `Arun::out`
to the same behavior.

Bumps `NLP_ENGINE_VERSION` to `3.1.28`.

## Test plan
- [ ] CI builds pass
- [ ] Cut `v3.1.28`
- [ ] Re-run instrumented date-time analyzer; verify `dbg.txt` now
      contains all markers up to the crash point
