### PR TITLE
NLP-ENGINE-500 add RFASem-first overloads for pnvartype (fixes pass 16 crash)

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -1562,6 +1562,13 @@ public:
 	static RFASem *pnvarnames(Nlppp*,RFASem*);						// 05/13/02 AM.
 	static RFASem *pnvartype(Nlppp*,NODE*,_TCHAR*);
 	static RFASem *pnvartype(Nlppp*,NODE*,RFASem*);
+	// NLP-ENGINE-500: RFASem-first-arg overloads. Compiled user code
+	// passes `Arun::l("node")` (RFASem*) as the second arg; without
+	// these overloads C++ silently picks one of the NODE*-second
+	// versions and treats the RFASem* memory as a NODE*, crashing
+	// inside `node->getData()` when the impl tries to dereference.
+	static RFASem *pnvartype(Nlppp*,RFASem*,_TCHAR*);
+	static RFASem *pnvartype(Nlppp*,RFASem*,RFASem*);
 
 	static bool pnsetfired(Nlppp*,NODE*,bool);
 

--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -13461,6 +13461,49 @@ delete name_sem;
 return result;
 }
 
+// NLP-ENGINE-500: RFASem-first-arg overloads. Compiled user code passes
+// `Arun::l("node")` (which returns RFASem*) as the node arg. Without
+// these overloads the compiler unsafely matched a NODE*-first version,
+// reinterpreting the RFASem* memory as a Node<Pn>*, which crashed
+// inside `node->getData()` in pass-16-like KB-mutating user code.
+// Pattern mirrors the Arun::pnvar(RFASem*, ...) overloads.
+RFASem *Arun::pnvartype(
+	Nlppp *nlppp,
+	RFASem *node_sem,
+	_TCHAR *name
+	)
+{
+if (!node_sem)
+	return 0;
+NODE *pnode = node_sem->sem_to_node();
+delete node_sem;
+return pnvartype(nlppp, pnode, name);
+}
+
+RFASem *Arun::pnvartype(
+	Nlppp *nlppp,
+	RFASem *node_sem,
+	RFASem *name_sem
+	)
+{
+if (!node_sem)
+	{
+	if (name_sem)
+		delete name_sem;
+	return 0;
+	}
+if (!name_sem)
+	{
+	delete node_sem;
+	return 0;
+	}
+NODE *pnode = node_sem->sem_to_node();
+delete node_sem;
+_TCHAR *name = name_sem->sem_to_str();
+delete name_sem;
+return pnvartype(nlppp, pnode, name);
+}
+
 
 bool Arun::pnsetfired(
 	Nlppp *nlppp,

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.28"
+#define NLP_ENGINE_VERSION "3.1.29"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

After NLP-ENGINE-499 made user-facing file output flush eagerly,
diagnostic prints sprinkled in date-time's `funcs.nlp` pinpointed the
compiled-mode SIGSEGV to:

  L("type") = pnvartype(L("node"), L("attr"));

That compiles to `Arun::pnvartype(nlppp, RFASem*, RFASem*)`, but only
two overloads existed — both taking `NODE*` as the second arg. C++
silently matched one of them and reinterpreted the `RFASem*` memory
as a `Node<Pn>*`. The impl then crashed inside `node->getData()`.

Same bug pattern as PRs 489, 490, 492 — just one more missing
overload pair.

## Changes

- Add `pnvartype(Nlppp*, RFASem*, _TCHAR*)` and
  `pnvartype(Nlppp*, RFASem*, RFASem*)` overloads (mirror the three
  existing `pnvar` overloads — call `sem_to_node` / `sem_to_str` then
  dispatch to the existing NODE*-first version).

- Fix an adjacent latent bug in the existing
  `pnvartype(Nlppp*, NODE*, _TCHAR*)` impl: `case IASEM:` was missing
  a `break;`, so for `IASEM/RS_KBCONCEPT` (a concept-valued attr) the
  outer switch fell through into `case IAFLOAT:` and overwrote
  `typNum = 2` with `typNum = 3`. Cosmetic for date-time (which sees
  IANUM attrs from pass 16's path), but a real bug for analyzers
  with concept-valued node attrs.

- Bump `NLP_ENGINE_VERSION` to `3.1.29`.

## Test plan

- [ ] CI builds pass on Windows / Linux / macOS
- [ ] After merge: cut `v3.1.29` release
- [ ] Re-run instrumented date-time; expect to see CPATC.5 / CPATC.6X
      markers in `dbg.txt` instead of crash after `CPATC.4b`
- [ ] If pass 16 fully completes, remove the diagnostic instrumentation
      from `funcs.nlp` / `KBFuncs.nlp` / `init.nlp` and verify
      `final.tree` matches the interpreted 425-line output
