### PR TITLE
NLP-ENGINE-501 fix Arun::attrtype always returning 0 (unblocks pass 17)

### DIFF
--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -476,7 +476,7 @@ if (!sem || !name || !*name || !nlppp)
 if (sem->getType() != RS_KBCONCEPT)
 	{
 	std::_t_strstream gerrStr;
-	gerrStr << _T("[fltval: Bad semantic arg.]") << std::ends;
+	gerrStr << _T("[attrtype: Bad semantic arg.]") << std::ends;
 	errOut(&gerrStr,false);
 	delete sem;
 	return 0;
@@ -486,16 +486,14 @@ CONCEPT *conc1 = sem->getKBconcept();
 // Need to get the current KB.
 CG *cg = nlppp->getParse()->getAna()->getCG();
 
-// Get concept from sem.
-if (sem->getType() != RS_KBATTR)
-	{
-	std::_t_strstream gerrStr;
-	gerrStr << _T("[attrname: Bad semantic arg.]") << std::ends;
-	errOut(&gerrStr,false);
-	delete sem;												// MEM LEAK.	// 06/27/00 AM.
-	return 0;
-	}
-ATTR *attr = sem->getKBattr();
+// NLP-ENGINE-501: removed a copy-paste-bug check that required
+// `sem->getType() != RS_KBATTR` and unconditionally returned 0 with
+// an "[attrname: Bad semantic arg.]" error, because `sem` had just
+// been verified to be RS_KBCONCEPT (mutually exclusive with
+// RS_KBATTR). The function therefore always returned 0 regardless
+// of the actual attribute type, which routed DisplayAttributes
+// (KBFuncs.nlp) into the string-val branch for every attribute and
+// crashed when getstrval() was called on a numeric value.
 
 int type = cg->attrValType(conc1,name);
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.29"
+#define NLP_ENGINE_VERSION "3.1.30"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

After NLP-ENGINE-500 unblocked pass 16, pass 17 (`output`) crashed
inside SaveKB → DisplayKBRecurse → DisplayAttributes. Instrumentation
pinpointed `attrtype(L("con"), L("name"))` returning **0 (string)**
for the `date_count` attribute that had been set via
`addnumval(con, "date_count", 1)` — should have returned 1 (int).
DisplayAttributes then routed into the string-val branch and crashed
when `getstrval()` was called on a numeric value.

## Root cause

`Arun::attrtype(Nlppp*, RFASem*, _TCHAR*)` had a copy-paste bug. After
correctly checking `sem->getType() != RS_KBCONCEPT` and returning,
it then re-checked the same `sem` against `RS_KBATTR` (mutually
exclusive with `RS_KBCONCEPT`) and returned 0 again with an
`[attrname: Bad semantic arg.]` error. The function therefore
ALWAYS returned 0, never reaching the real
`cg->attrValType(conc1, name)` lookup.

## Change

Remove the dead RS_KBATTR check + the unused `ATTR *attr =
sem->getKBattr();` that followed it. Now `attrtype` returns the
actual type.

Bumps `NLP_ENGINE_VERSION` to `3.1.30`.

## Test plan

- [ ] CI green (parse-en-us baseline should be unaffected — interp
      apparently bypassed the dead code via a different path; only
      compiled mode was exercising it)
- [ ] Cut v3.1.30 after merge
- [ ] Re-run instrumented date-time in compiled mode; DA.8 should
      now show `type=1` for `date_count`, DA.10a/b fire, pass 17
      completes, `datetimes.kbb` has content, `final.tree` produced
