### PR TITLE
NLP-ENGINE-502 bump NLP_ENGINE_VERSION to 3.1.32

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.30"
+#define NLP_ENGINE_VERSION "3.1.32"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The attrtype fix from NLP-ENGINE-501 (PR #613) is on master, but the
`v3.1.30` and `v3.1.31` release tags both point to commits cut BEFORE
that merge and therefore don't contain the fix. `main.cpp` is still
at `3.1.30` on master too — my amended bump to `3.1.31` in PR #613
was superseded at merge time.

Bump to `3.1.32` so we can cut a clean release that actually contains
the attrtype fix and matches what `nlp.exe --version` reports.

After merge, cut `v3.1.32`. `nlp.exe --version` will report `3.1.32`
and the attrtype fix will be in.
