### PR TITLE
NLP-ENGINE-503 add Arun::vargt/varlt for compiled mode + resync func tables

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -475,12 +475,18 @@ public:
 	static bool varz(Nlppp*,_TCHAR*);                           // 10/01/05 AM.
 	static bool vareq(Nlppp*,_TCHAR*,_TCHAR*);                  // 10/01/05 AM.
 	static bool vareq(Nlppp*,_TCHAR*,long long);                     // 10/01/05 AM.
+	static bool vargt(Nlppp*,_TCHAR*,_TCHAR*);
+	static bool vargt(Nlppp*,_TCHAR*,long long);
+	static bool varlt(Nlppp*,_TCHAR*,_TCHAR*);
+	static bool varlt(Nlppp*,_TCHAR*,long long);
 	static bool varne(Nlppp*,_TCHAR*,_TCHAR*);                  // 10/01/05 AM.
 	static bool varne(Nlppp*,_TCHAR*,long long);                     // 10/01/05 AM.
 
 	static bool var(Nlppp*,RFASem*);                            // 10/04/05 AM.
 	static bool varz(Nlppp*,RFASem*);                           // 10/04/05 AM.
 	static bool vareq(Nlppp*,RFASem*,RFASem*);                  // 10/04/05 AM.
+	static bool vargt(Nlppp*,RFASem*,RFASem*);
+	static bool varlt(Nlppp*,RFASem*,RFASem*);
 	static bool varne(Nlppp*,RFASem*,RFASem*);                  // 10/04/05 AM.
 
 	static bool regexp(Nlppp*,RFASem*);                         // 03/23/09 AM.
@@ -1884,6 +1890,8 @@ public:
 	static bool setunsealed(Nlppp *, long long, RFASem *);
 	static bool sortvals(Nlppp *, RFASem *);
 	static bool vareq(Nlppp*, RFASem *, long long);
+	static bool vargt(Nlppp*, RFASem *, long long);
+	static bool varlt(Nlppp*, RFASem *, long long);
 	static bool varne(Nlppp*, RFASem *, long long);
 	static bool xdump(Nlppp*, RFASem *, long long);
 

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -4577,6 +4577,52 @@ bool Arun::varne(
 {
  return !Ivar::nodeVarEQ(nlppp->node_->getData(),str,nval);
 }
+/********************************************
+* FN:		VARGT
+* SUBJ:	Runtime variant of pre action.  Var greater than a number.
+* NOTE:	gt/lt are only defined numerically; a string value never matches.
+********************************************/
+
+bool Arun::vargt(
+	Nlppp *nlppp,
+	_TCHAR *str,
+	_TCHAR *sval
+	)
+{
+ return false;
+}
+
+bool Arun::vargt(
+	Nlppp *nlppp,
+	_TCHAR *str,
+	long long nval
+	)
+{
+ return Ivar::nodeVarGTLT(nlppp->node_->getData(),str,nval,false);
+}
+/********************************************
+* FN:		VARLT
+* SUBJ:	Runtime variant of pre action.  Var less than a number.
+* NOTE:	gt/lt are only defined numerically; a string value never matches.
+********************************************/
+
+bool Arun::varlt(
+	Nlppp *nlppp,
+	_TCHAR *str,
+	_TCHAR *sval
+	)
+{
+ return false;
+}
+
+bool Arun::varlt(
+	Nlppp *nlppp,
+	_TCHAR *str,
+	long long nval
+	)
+{
+ return Ivar::nodeVarGTLT(nlppp->node_->getData(),str,nval,true);
+}
 
 
 
@@ -4713,6 +4759,90 @@ switch (val_sem->getType())
 		return !Ivar::nodeVarEQ(nlppp->node_->getData(),str,nval);
 		break;
 	default:
+		delete val_sem;
+		return false;
+	}
+return false;
+}
+
+/********************************************
+* FN:		VARGT
+* SUBJ:	Runtime variant of pre action.  Var greater than a number.
+* NOTE:	gt/lt are only defined numerically; a string value never matches.
+********************************************/
+
+bool Arun::vargt(
+	Nlppp *nlppp,
+	RFASem *str_sem,
+	RFASem *val_sem
+	)
+{
+if (!str_sem)
+	{
+	if (val_sem) delete val_sem;
+	return false;
+	}
+_TCHAR *str = sem_to_str(str_sem);
+delete str_sem;
+
+if (!val_sem)
+	return false;
+
+bool ok = true;
+long long nval = 0;
+switch (val_sem->getType())
+	{
+	case RSLONG:
+		nval = val_sem->sem_to_long(ok);
+		delete val_sem;
+		if (!ok)
+			return false;
+		return Ivar::nodeVarGTLT(nlppp->node_->getData(),str,nval,false);
+		break;
+	default:
+		// gt/lt undefined for non-numeric values.
+		delete val_sem;
+		return false;
+	}
+return false;
+}
+
+/********************************************
+* FN:		VARLT
+* SUBJ:	Runtime variant of pre action.  Var less than a number.
+* NOTE:	gt/lt are only defined numerically; a string value never matches.
+********************************************/
+
+bool Arun::varlt(
+	Nlppp *nlppp,
+	RFASem *str_sem,
+	RFASem *val_sem
+	)
+{
+if (!str_sem)
+	{
+	if (val_sem) delete val_sem;
+	return false;
+	}
+_TCHAR *str = sem_to_str(str_sem);
+delete str_sem;
+
+if (!val_sem)
+	return false;
+
+bool ok = true;
+long long nval = 0;
+switch (val_sem->getType())
+	{
+	case RSLONG:
+		nval = val_sem->sem_to_long(ok);
+		delete val_sem;
+		if (!ok)
+			return false;
+		return Ivar::nodeVarGTLT(nlppp->node_->getData(),str,nval,true);
+		break;
+	default:
+		// gt/lt undefined for non-numeric values.
 		delete val_sem;
 		return false;
 	}

--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -757,11 +757,15 @@ switch (fnid)																	// 12/21/01 AM.
 		break;
 	case FNvareq:																// 07/25/06 AM.
 		break;
+	case FNvargt:
+		break;
 	case FNvarfn:
 	case FNvarfnarray:
 		break;
 	case FNvarinlist:
 		return fnVarinlist(args,nlppp,/*UP*/sem);						// 11/21/00 AM.
+	case FNvarlt:
+		break;
 	case FNvarne:																// 07/25/06 AM.
 		break;
 	case FNvarstrs:

--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -19286,6 +19286,22 @@ if (s1_sem) delete s1_sem;
 return _r;
 }
 
+bool Arun::vargt(Nlppp* a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = vargt(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
+bool Arun::varlt(Nlppp* a0, RFASem * s1_sem, long long a2)
+{
+_TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;
+bool _r = varlt(a0, str1, a2);
+if (s1_sem) delete s1_sem;
+return _r;
+}
+
 bool Arun::xdump(Nlppp* a0, RFASem * s1_sem, long long a2)
 {
 _TCHAR *str1 = s1_sem ? s1_sem->sem_to_str() : 0;

--- a/lite/func_defs.h
+++ b/lite/func_defs.h
@@ -328,9 +328,11 @@ enum funcDef
 	FNurltofile,	// 02/11/03 AM.
 	FNvar,			// 06/14/05 AM.
 	FNvareq,			// 07/25/06 AM.
+	FNvargt,			// MUST stay aligned with funcs.h (vargt).
 	FNvarfn,
 	FNvarfnarray,
 	FNvarinlist,
+	FNvarlt,			// MUST stay aligned with funcs.h (varlt).
 	FNvarne,			// 07/25/06 AM.
 	FNvarstrs,
 	FNvarz,			// 07/25/06 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.32"
+#define NLP_ENGINE_VERSION "3.1.33"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Compiled analyzers using vargt() failed to build:

  error C2039: 'vargt' is not a member of 'Arun'
  error C2668: ambiguous call to overloaded function 'Arun::stmt'

Codegen emits Arun::stmt(Arun::vargt(nlppp, ...)), but vargt/varlt were never implemented as Arun methods (only vareq/varne were). The stmt ambiguity was a cascade from vargt resolving to <error type>.

Also, funcs.h (nlpFuncs[] name array, hashed to dispatch indices) listed vargt and varlt while func_defs.h (the funcDef enum, which must stay index-aligned) did not, desyncing the name->enum mapping for ~20 trailing functions. The interpreter was unaffected (var comparisons resolve by strcmp in Pre::preVargt), but compiled mode is not.

- func_defs.h: add FNvargt, FNvarlt (tables now both 325 entries, aligned)
- Arun.h: declare vargt/varlt overloads mirroring vareq/varne
- Arun.cpp + fnrun.cpp: implement them; numeric values route to the existing Ivar::nodeVarGTLT(...,false/true), non-numeric returns false (matching Pre::preVargt/preVarlt)
- fn.cpp: runtime dispatch cases
- bump NLP_ENGINE_VERSION to 3.1.33