### PR TITLE
NLP-ENGINE-505 flush var-LHS << writes (SaveKB-produced files empty in compiled mode)

### DIFF
--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -8750,7 +8750,10 @@ if (!sem)																		// 08/19/01 AM.
 	}
 
 if (ostr)																		// 08/04/02 AM.
-	sem->out(ostr);	// PRINT IT.										// 08/19/01 AM. 
+	{
+	sem->out(ostr);	// PRINT IT.										// 08/19/01 AM.
+	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	}
 
 delete ostrsem;																// 08/19/01 AM.
 delete sem;				// No one using sem past this point.		// 05/27/00 AM.
@@ -8831,7 +8834,10 @@ if (!str || !*str)															// 08/19/01 AM.
 	}
 
 if (ostr)																		// 08/04/02 AM.
-	*ostr << str;	// PRINT IT.											// 08/19/01 AM. 
+	{
+	*ostr << str;	// PRINT IT.											// 08/19/01 AM.
+	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	}
 
 delete ostrsem;																// 08/19/01 AM.
 return ostr;																	// 08/19/01 AM.
@@ -8905,7 +8911,10 @@ switch(ostrsem->getType())													// 08/07/02 AM.
 	}
 
 if (ostr)																		// 08/04/02 AM.
-	*ostr << num;	// PRINT IT.											// 08/19/01 AM. 
+	{
+	*ostr << num;	// PRINT IT.											// 08/19/01 AM.
+	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	}
 
 delete ostrsem;																// 08/19/01 AM.
 return ostr;																	// 08/19/01 AM.
@@ -8981,7 +8990,10 @@ switch(ostrsem->getType())
 	}
 
 if (ostr)
+	{
 	*ostr << (flag ? 1 : 0);	// PRINT IT.
+	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	}
 
 delete ostrsem;
 return ostr;
@@ -9056,7 +9068,10 @@ switch(ostrsem->getType())													// 08/07/02 AM.
 	}
 
 if (ostr)																		// 08/04/02 AM.
-	*ostr << num;	// PRINT IT.											// 08/19/01 AM. 
+	{
+	*ostr << num;	// PRINT IT.											// 08/19/01 AM.
+	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	}
 
 delete ostrsem;																// 08/19/01 AM.
 return ostr;																	// 08/19/01 AM.
@@ -9069,7 +9084,10 @@ if (!sem)
 	return ostr;
 
 if (ostr)																		// 08/04/02 AM.
+	{
 	sem->out(ostr);	// PRINT IT.
+	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	}
 delete sem;
 return ostr;
 }
@@ -9078,28 +9096,40 @@ std::_t_ostream *Arun::out(std::_t_ostream *ostr, _TCHAR *str, Nlppp *nlppp)
 {
 if (str && *str																// 04/30/01 AM.
 		  && ostr)																// 08/04/02 AM.
+	{
 	*ostr << str;
+	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	}
 return ostr;
 }
 
 std::_t_ostream *Arun::out(std::_t_ostream *ostr, long long num, Nlppp *nlppp)
 {
 if (ostr)																		// 08/04/02 AM.
+	{
 	*ostr << num;
+	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	}
 return ostr;
 }
 
 std::_t_ostream *Arun::out(std::_t_ostream *ostr, bool flag, Nlppp *nlppp)		// 07/11/03 AM.
 {
 if (ostr)
+	{
 	*ostr << (flag ? 1 : 0);
+	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	}
 return ostr;
 }
 
 std::_t_ostream *Arun::out(std::_t_ostream *ostr, float num, Nlppp *nlppp)		// 08/19/01 AM.
 {
 if (ostr)																		// 08/04/02 AM.
+	{
 	*ostr << num;
+	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	}
 return ostr;
 }
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.34"
+#define NLP_ENGINE_VERSION "3.1.35"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);

--- a/scripts/compile-analyzer.ps1
+++ b/scripts/compile-analyzer.ps1
@@ -84,9 +84,12 @@ if (-not (Test-Path -LiteralPath $VcpkgToolchain)) {
     Fail "Vcpkg toolchain not found at $VcpkgToolchain. Run: vcpkg\bootstrap-vcpkg.bat then vcpkg\vcpkg.exe install --triplet x64-windows"
 }
 
-# Output DLL name the engine LoadLibrarys (cs/libconsh/cg.cpp line ~157+).
-# We're not using UNICODE in the engine build, so kbd.dll / kb.dll.
-$DllBase = if ($Config -eq 'Debug') { 'kbd' } else { 'kb' }
+# Output DLL names the engine LoadLibrarys.
+#   Compiled KB:  cs/libconsh/cg.cpp ~ line 157 — kbd.dll / kb.dll (Debug / Release).
+#   Compiled rules: lite/nlp.cpp ~ line 1232 — rund.dll / run.dll.
+# We're not using UNICODE in the engine build.
+$KbDllBase  = if ($Config -eq 'Debug') { 'kbd' }  else { 'kb' }
+$RunDllBase = if ($Config -eq 'Debug') { 'rund' } else { 'run' }
 
 Write-Host ""
 Write-Host "==> [1/3] nlp.exe -COMPILE  ($AnalyzerDir)"
@@ -162,7 +165,7 @@ endif()
 
 add_library(nlp_kb SHARED `${GENERATED_CPP})
 set_target_properties(nlp_kb PROPERTIES
-    OUTPUT_NAME "$DllBase"
+    OUTPUT_NAME "$KbDllBase"
     PREFIX ""
 )
 
@@ -201,6 +204,44 @@ target_link_libraries(nlp_kb PRIVATE
     prim kbm consh words lite
     ICU::i18n ICU::uc ICU::data ICU::io
 )
+
+# --- Compiled analyzer (run.dll / rund.dll) -----------------------------
+# Engine looks for <appdir>/bin/rund.dll (Debug) or run.dll (Release) at
+# load_compiled time (lite/nlp.cpp ~ line 1232). Empty run/ -> skipped.
+file(GLOB RUN_CPP "$AnaCmake/run/*.cpp")
+if(RUN_CPP)
+    add_library(nlp_run SHARED `${RUN_CPP})
+    set_target_properties(nlp_run PROPERTIES
+        OUTPUT_NAME "$RunDllBase"
+        PREFIX ""
+    )
+    target_include_directories(nlp_run PRIVATE
+        "$SrcDirCmake"
+        "$AnaCmake"
+        "$AnaCmake/run"
+        "$AnaCmake/kb"
+        "$EngineRootCmake/include"
+        "$EngineRootCmake/include/Api"
+        "$EngineRootCmake/include/Api/lite"
+        "$EngineRootCmake/cs/include"
+    )
+    target_compile_definitions(nlp_run PRIVATE
+        _CRT_SECURE_NO_WARNINGS
+        _CRT_NON_CONFORMING_SWPRINTFS
+        _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+        NONSTD_
+        _CONSOLE
+        WIN32
+        _WINDOWS
+        MSVC_VERSION=`${MSVC_VERSION}
+    )
+    target_compile_options(nlp_run PRIVATE /FI"StdAfx.h" /Zc:wchar_t)
+    target_link_directories(nlp_run PRIVATE "$EngineLibDirCmake")
+    target_link_libraries(nlp_run PRIVATE
+        prim kbm consh words lite
+        ICU::i18n ICU::uc ICU::data ICU::io
+    )
+endif()
 "@
 
 Set-Content -LiteralPath (Join-Path $SrcDir 'CMakeLists.txt') -Encoding utf8 -Value $cmakeLists
@@ -222,12 +263,17 @@ Write-Host "==> [3/3] cmake --build --config $Config"
 & cmake --build $BuildDir --config $Config
 if ($LASTEXITCODE -ne 0) { Fail "cmake build failed (exit $LASTEXITCODE)" }
 
-$Out = Join-Path $AnalyzerDir ("bin\{0}.dll" -f $DllBase)
-if (Test-Path -LiteralPath $Out) {
-    Write-Host ""
-    Write-Host "Built: $Out"
-    Write-Host "Run:   $NlpExe -COMPILED -ANA `"$AnalyzerDir`" -WORK `"$EngineRoot`" `"$InputFile`""
-    Write-Host ""
-} else {
-    Fail "Expected output $Out was not produced."
+$KbOut  = Join-Path $AnalyzerDir ("bin\{0}.dll" -f $KbDllBase)
+$RunOut = Join-Path $AnalyzerDir ("bin\{0}.dll" -f $RunDllBase)
+if (-not (Test-Path -LiteralPath $KbOut)) {
+    Fail "Expected output $KbOut was not produced."
 }
+Write-Host ""
+Write-Host "Built KB: $KbOut"
+if (Test-Path -LiteralPath $RunOut) {
+    Write-Host "Built run: $RunOut"
+} else {
+    Write-Host "(no run/*.cpp present - analyzer rules will run interpreted)"
+}
+Write-Host "Run:   $NlpExe -COMPILED -ANA $AnalyzerDir -WORK $EngineRoot $InputFile"
+Write-Host ""


### PR DESCRIPTION
In compiled-analyzer mode, NLP++ output operator calls of the form
`L("fname") << "text"` or `G("var") << x` produced empty files. The
literal-LHS form (`"file.txt" << "text"`) worked correctly.

Symptom in the wild: tutorial-15's init.nlp ends with
`SaveKB("dictionary.kbb", G("dictionary"), 2)`. SaveKB (a user-defined
NLP++ function in spec/KBFuncs.nlp) takes the filename as a parameter
and forwards it to DisplayKBRecurse, which writes via
`L("file") << conceptname(...)`. In interpreted mode the resulting
dictionary.kbb has the expected concept dump; under cloud-built
-COMPILED the same call produces a 0-byte file. Same root cause hits
any analyzer that opens a filename through a local/global var instead
of a string literal.

Root cause: NLP-ENGINE-499 added `ostr->flush()` after every write in
the literal-LHS Arun::out overloads (lite/Arun.cpp:8542, 8575, 8598,
8621, 8645) but missed the 5 RFASem-LHS overloads (8667, 8760, 8840,
8916, 8991) and the 5 ostream-LHS overloads (9066, 9077, 9085, 9092,
9099). The RFASem overloads are what the codegen emits for variable-
LHS writes; the ostream overloads are what chained writes
(`L("f") << a << b << c`) dispatch to from the second link onward.

Without an explicit flush the streamed bytes sit in the file's
filebuf until the stream's destructor runs at process shutdown. The
order in which Var-owned ofstreams get torn down vs. the underlying
OS file handles is fragile enough that compiled-mode runs reliably
truncated these files to 0 bytes; literal-LHS writes survived only
because NLP-ENGINE-499 had already added the flush.

Repro before this patch (local Debug build, tutorial-15):
  spec/init.nlp:
    "literal.txt"  << "x\n";
    L("f") = "variable.txt"; L("f") << "x\n";
  nlp.exe -COMPILED -ANA tutorial-15 ... -DEV
  -> literal.txt:  2 bytes  ✓
  -> variable.txt: 0 bytes  ✗

After patch:
  -> literal.txt:  2 bytes  ✓
  -> variable.txt: 2 bytes  ✓

Fix: add `ostr->flush()` after each write in the 10 overloads that
NLP-ENGINE-499 missed. Each new line is tagged with a NLP-ENGINE-505
comment so the history is greppable.

- Arun.cpp:8753  out(RFASem*, RFASem*,  Nlppp*)  flush after sem->out
- Arun.cpp:8837  out(RFASem*, _TCHAR*,  Nlppp*)  flush after *ostr<<str
- Arun.cpp:8914  out(RFASem*, long long,Nlppp*)  flush after *ostr<<num
- Arun.cpp:8993  out(RFASem*, bool,     Nlppp*)  flush after *ostr<<flag
- Arun.cpp:9071  out(RFASem*, float,    Nlppp*)  flush after *ostr<<num
- Arun.cpp:9087  out(ostream*,RFASem*,  Nlppp*)  flush after sem->out
- Arun.cpp:9100  out(ostream*,_TCHAR*,  Nlppp*)  flush after *ostr<<str
- Arun.cpp:9110  out(ostream*,long long,Nlppp*)  flush after *ostr<<num
- Arun.cpp:9120  out(ostream*,bool,     Nlppp*)  flush after *ostr<<flag
- Arun.cpp:9131  out(ostream*,float,    Nlppp*)  flush after *ostr<<num
- bump NLP_ENGINE_VERSION to 3.1.35