### PR TITLE
NLP-ENGINE-506 guard null cgerr in CG::popVal warnings (fixes compiled-mode SEGV)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -1684,7 +1684,11 @@ vals = (VAL *) ((PTR *)vals)->next;
 
 if (ptr->kind != pST)
 	{
-	*cgerr << _T("[popVal: Attribute not a string.]") << std::endl;
+	// NLP-ENGINE-506: cgerr can be null when the @CODE-block runtime
+	// hits a type-mismatched value (e.g. compiled NLP++ doing
+	// `getstrval(numAttrVal)` on a pNUM value) before any CG instance
+	// has reopened the cgerr.log stream. Guard the deref.
+	if (cgerr) *cgerr << _T("[popVal: Attribute not a string.]") << std::endl;
 	return;
 	}
 
@@ -1704,7 +1708,8 @@ vals = (VAL *) ((PTR *)vals)->next;
 
 if (ptr->kind != pNUM)
 	{
-	*cgerr << _T("[popVal: Attribute not a num.]") << std::endl;
+	// NLP-ENGINE-506: see popVal(_TCHAR*) above.
+	if (cgerr) *cgerr << _T("[popVal: Attribute not a num.]") << std::endl;
 	return;
 	}
 val = ptr->v.vnum;
@@ -1723,7 +1728,8 @@ vals = (VAL *) ((PTR *)vals)->next;
 
 if (ptr->kind != pFLOAT)
 	{
-	*cgerr << _T("[popVal: Attribute not a float.]") << std::endl;
+	// NLP-ENGINE-506: see popVal(_TCHAR*) above.
+	if (cgerr) *cgerr << _T("[popVal: Attribute not a float.]") << std::endl;
 	return;
 	}
 val = ptr->v.vfloat;
@@ -1742,7 +1748,8 @@ vals = (VAL *) ((PTR *)vals)->next;
 
 if (ptr->kind != pCON)
 	{
-	*cgerr << _T("[popVal: Attribute not a concept.]") << std::endl;
+	// NLP-ENGINE-506: see popVal(_TCHAR*) above.
+	if (cgerr) *cgerr << _T("[popVal: Attribute not a concept.]") << std::endl;
 	return;
 	}
 val = ptr->v.vcon;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.34"
+#define NLP_ENGINE_VERSION "3.1.36"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Compiled analyzers running -COMPILED hit a SEGV inside CG::popVal when an NLP++ @CODE block called getstrval/getnumval/getconval on a value whose underlying VAL kind didn't match the requested type. Repro: parse-en-us' pass 136 (displayKB) calls user-defined DisplayAttributes from spec/KBFuncs.nlp which, for every attribute value, tries all three:

  L("val") = getstrval(L("vals"));   # cg->popVal(val, _TCHAR*)
  L("num") = getnumval(L("vals"));   # cg->popVal(val, long long&)
  L("con") = getconval(L("vals"));   # cg->popVal(val, CONCEPT*&)

For a string-valued attribute (kind=pST), getstrval returns the string cleanly, but the next two each hit the type-mismatch warning branch:

  if (ptr->kind != pNUM)
    {
    *cgerr << _T("[popVal: Attribute not a num.]") << std::endl;  // SEGV
    return;
    }

cgerr is declared `std::_t_ofstream *cgerr = 0;` in cs/libconsh/ cg_global.cpp and only gets opened to logs/cgerr.log by the FIRST CG ctor (count_==0). The earlier KB-load messages went through cgerr fine, but by the time the compiled @CODE block ran, the CG instance that opened the log had been torn down and cgresetErr() had zeroed cgerr — yet the rest of cg.cpp still does unguarded `*cgerr << ...` everywhere.

The cascade in DisplayAttributes was halted mid-write at `type=[` because getnumval SEGV'd before the loop body could finish. catch(int) in the generated code didn't catch the SEH, so the exception propagated past Pat::Execute (no try/catch around `(*pass->code)(nlppp)` at lite/pat.cpp:3577) and aborted the pass — visible as a truncated ana136.kbb and a missing pass-136 timing line in dbg.log.

Fix: null-check cgerr at the four popVal warning sites (_TCHAR*/long long&/float&/CONCEPT*&). The 62 other unguarded `*cgerr <<` writes in cg.cpp are reached only during KB setup, when cgerr is known to be valid; leaving them un-guarded preserves the existing log output and avoids broader risk. If a value type mismatch trips one of these popVal branches and cgerr is null, the warning is silently dropped (caller observes the value default — empty string / -1 / null concept — which is what callers already handle).

Verification:
  parse-en-us / test.txt:
    before: pass 136 SEGV mid-write -> ana136.kbb = 85 bytes (truncated
            at "type=[", no Pass 136 entry in dbg.log)
    after:  pass 136 completes (0.016 sec entry in dbg.log)
            ana136.kbb = 134 bytes (vs 152 interpreted; the remaining
            delta is one missing `zone=[0]` attribute, traced to a
            separate codegen issue in the compiled KB's attribute list
            link for clause1 — unrelated to this fix)

  tutorial-15 / text.txt:
    before/after: dictionary.kbb 90 bytes, byte-identical to interp
                  (sanity-check: this fix did not regress the
                  NLP-ENGINE-505 path)

- bump NLP_ENGINE_VERSION to 3.1.36