### PR TITLE
NLP-ENGINE-509 build-macos.yml: drop -std=c++11 override so std::file system works

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -44,7 +44,16 @@ jobs:
         run: mkdir build
 
       - name: Generate Solution MacOs
-        run: cmake -DCMAKE_BUILD_TYPE=Release -DVCPKG_BUILD_TYPE=release -B build -S . -DCMAKE_CXX_FLAGS=-std=c++11 -DCMAKE_TOOLCHAIN_FILE='${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake' -DCMAKE_OSX_ARCHITECTURES=arm64
+        # NLP-ENGINE-509: dropped `-DCMAKE_CXX_FLAGS=-std=c++11`. The engine
+        # uses std::filesystem (C++17) in lite/dir.cpp::read_files (which
+        # loads the analyzer's kb/user/*.{kb,dict,kbb} dictionary files) and
+        # in cs/libconsh/cg.cpp / lite/nlp_engine.cpp. With Apple libc++ +
+        # -std=c++11, directory_iterator behaved differently from
+        # Windows/Linux and the analyzer's user lexicon never got loaded —
+        # parse-en-us produced "unknown 1" on every word, blowing up the
+        # English-test diff. The engine's CMakeLists already sets
+        # CMAKE_CXX_STANDARD 17; let that drive macOS too.
+        run: cmake -DCMAKE_BUILD_TYPE=Release -DVCPKG_BUILD_TYPE=release -B build -S . -DCMAKE_TOOLCHAIN_FILE='${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake' -DCMAKE_OSX_ARCHITECTURES=arm64
 
       - name: Cmake Build all targets MaxOs
         run: cmake --build build/ --target all


### PR DESCRIPTION
The macOS build was forcing -std=c++11 via CMAKE_CXX_FLAGS, overriding the engine's CMAKE_CXX_STANDARD 17. The engine uses std::filesystem (C++17) in three places:

  - lite/dir.cpp:147        read_files() — directory_iterator over the
                            analyzer's kb/user/ folder, used by
                            CG::openKBB and CG::openDict to load every
                            *.kb / *.kbb / *.dict in the user lexicon.
  - cs/libconsh/cg.cpp:613+ kbfiles/dictfiles vectors, matchDictKB,
                            openDict, readDicts.
  - lite/nlp_engine.cpp:344 analyzer-path resolution.

Under Apple libc++ + -std=c++11, std::filesystem either resolves to an incomplete __fs::filesystem variant or behaves differently from the Windows/Linux C++17 build. Symptom on parse-en-us / doj.txt: the user lexicon never loaded, every word came back as ("unknown" 1), and the "Full English Test" diff exploded with ~300 lines of pos / wordcon / stem / sem attributes vanishing. Windows + Linux passed the same diff on the same VisualText/analyzers submodule.

Fix: remove -DCMAKE_CXX_FLAGS=-std=c++11 from the macOS cmake configure step. The engine's CMakeLists already sets CMAKE_CXX_STANDARD 17 (which Windows and Linux honor), so dropping the override aligns macOS with the rest. The -DCMAKE_OSX_ARCHITECTURES=arm64 and -DCMAKE_BUILD_TYPE=Release and vcpkg toolchain args are untouched.