### PR TITLE
NLP-ENGINE-510 emit StdAfx.h on Linux too (fixes cloud compile)

### DIFF
--- a/cs/libconsh/cc_gen.cpp
+++ b/cs/libconsh/cc_gen.cpp
@@ -80,11 +80,12 @@ _stprintf(s_nam, _T("%s%s%s_code.cpp%s"), dir, DIR_SEP, consh_CC_BASE, tail);
 fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
 gen_file_head(fp);
-#ifdef LINUX
-*fp << _T("#include \"stdafx.h\"") << std::endl;								// 05/05/01 AM.
-#else
-*fp << _T("#include \"StdAfx.h\"") << std::endl;								// 05/05/01 AM.
-#endif
+// NLP-ENGINE-510: emit StdAfx.h (mixed case) on every platform. Linux is
+// case-sensitive, and the compile-service (cloud + local Linux/Mac scripts)
+// drops a StdAfx.h next to the generated sources; emitting a lowercase
+// `#include "stdafx.h"` for LINUX broke the cloud build with
+// `fatal error: stdafx.h: No such file or directory`.
+*fp << _T("#include \"StdAfx.h\"") << std::endl;
 *fp << _T("extern bool cc_st_ini(void*);") << std::endl;						// 08/15/02 AM.
 *fp << _T("extern bool cc_sym_ini(void*);") << std::endl;					// 08/15/02 AM.
 *fp << _T("extern bool cc_con_ini(void*);") << std::endl;					// 08/15/02 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.38"
+#define NLP_ENGINE_VERSION "3.1.39"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The compile-service's Linux build (and the local nlp-engine-linux / nlp-engine-mac compile-analyzer scripts) drops a StdAfx.h next to the generated sources and force-includes it. But cs/libconsh/cc_gen.cpp's header-emission code had a `#ifdef LINUX` branch that wrote `#include "stdafx.h"` (lowercase) into the generated kb/Sym*.cpp and kb/Con0.cpp etc., while emitting `#include "StdAfx.h"` (mixed case) everywhere else.

Linux/macOS filesystems are case-sensitive, so the lowercase include couldn't find the mixed-case header. The cloud build for date-time (and any other analyzer compiled from a Linux nlp.exe) failed with:

  /home/runner/work/nlp-compile-service/nlp-compile-service/work/kb/
    Con0.cpp:2:10: fatal error: stdafx.h: No such file or directory
      2 | #include "stdafx.h"
        |          ^~~~~~~~~~

Windows tolerated the same mismatch only because NTFS is case-insensitive.

Fix: drop the LINUX-only lowercase branch in cc_gen.cpp and emit `#include "StdAfx.h"` on every platform. Matches what nlp-compile-service/scripts/emit-cmake.sh's `-include StdAfx.h` (line 130) and the Linux/Mac `compile-analyzer.sh` scripts' `cat > StdAfx.h` have always produced.

- cc_gen.cpp: remove the two `#ifdef LINUX ... stdafx.h ... #else ... StdAfx.h ... #endif` blocks, leaving a single `#include "StdAfx.h"` emission with a NLP-ENGINE-510 comment.
- bump NLP_ENGINE_VERSION to 3.1.39