### PR TITLE
NLP-ENGINE-510 fix the OTHER stdafx.h emission sites (cloud Linux build, round 2)

### DIFF
--- a/cs/libconsh/cc_gen.cpp
+++ b/cs/libconsh/cc_gen.cpp
@@ -152,11 +152,8 @@ delete fp;
 _stprintf(s_nam, _T("%s%skb_setup.cpp%s"), dir, DIR_SEP, tail);
 fp = new std::_t_ofstream(TCHAR2A(s_nam));
 gen_file_head(fp);
-#ifdef LINUX
-*fp << _T("#include \"stdafx.h\"") << std::endl;
-#else
+// NLP-ENGINE-510: emit StdAfx.h (mixed case) on every platform.
 *fp << _T("#include \"StdAfx.h\"") << std::endl;
-#endif
 *fp << _T("#include \"Cc_code.h\"") << std::endl;
 *fp << _T("#include \"kb_setup.h\"") << std::endl;
 *fp << _T("extern \"C\" NLP_KB_EXPORT bool kb_setup(void *cg)") << std::endl;

--- a/cs/libconsh/consh_gen.cpp
+++ b/cs/libconsh/consh_gen.cpp
@@ -64,35 +64,15 @@ consh_gen_includes(
 	std::_t_ofstream *fp
 	)
 {
-#ifdef LINUX
-*fp << _T("#include \"stdafx.h\"") << std::endl;														// 06/28/00 AM.
-*fp << _T("#include <stdio.h>") << std::endl;
-*fp << _T("#include <stdlib.h>") << std::endl;
-//*fp << "#include <fstream.h>" << std::endl;								// 04/23/99 AM.
-*fp << _T("#include <iostream>") << std::endl;					// Upgrade.	// 01/24/01 AM.
-*fp << _T("#include <fstream>") << std::endl;					// Upgrade. // 01/24/01 AM.
-*fp << _T("#include \"prim\\libprim.h\"") << std::endl;
-//*fp << "#include \"prim\\mach.h\"" << std::endl;	// 04/23/99 AM.
-*fp << _T("#include \"prim\\prim.h\"") << std::endl;
-*fp << _T("#include \"prim\\str.h\"") << std::endl;
-//*fp << "#include \"cc_var.h\"" << std::endl;
-*fp << _T("#include \"kbm\\libkbm.h\"") << std::endl;
-*fp << _T("#include \"kbm\\st.h\"") << std::endl;
-*fp << _T("#include \"kbm\\sym_s.h\"") << std::endl;
-*fp << _T("#include \"kbm\\sym.h\"") << std::endl;
-*fp << _T("#include \"kbm\\con_s.h\"") << std::endl;
-*fp << _T("#include \"kbm\\con_.h\"") << std::endl;
-*fp << _T("#include \"kbm\\ptr_s.h\"") << std::endl;
-*fp << _T("#include \"kbm\\ptr.h\"") << std::endl;
-*fp << _T("#include \"consh/libconsh.h\"") << std::endl;						// 08/16/02 AM.
-*fp << _T("#include \"consh/cg.h\"") << std::endl;								// 08/16/02 AM.
-*fp << _T("#include \"") << consh_ST_BASE  << _T("_ini.h\"") << std::endl;
-*fp << _T("#include \"") << consh_SYM_BASE << _T("_ini.h\"") << std::endl;
-*fp << _T("#include \"") << consh_CON_BASE << _T("_ini.h\"") << std::endl;
-*fp << _T("#include \"") << consh_PTR_BASE << _T("_ini.h\"") << std::endl;
-*fp << _T("#include \"") << consh_CC_BASE  << _T("_code.h\"") << std::endl;
-
-#else
+// NLP-ENGINE-510: removed an `#ifdef LINUX` branch that emitted
+// `#include "stdafx.h"` (lowercase, broken on case-sensitive FS) plus
+// backslash include paths (`prim\libprim.h`, broken on Linux full stop).
+// The legacy `#else` branch below already uses forward slashes and the
+// correct `StdAfx.h` casing — it now drives every platform. This is the
+// function called from sym_gen / con_gen / ptr_gen, so it's the one
+// responsible for the kb/Sym*.cpp, kb/Con*.cpp, and kb/Ptr*.cpp headers
+// that broke the cloud Linux build with "fatal error: stdafx.h: No such
+// file or directory".
 *fp << _T("#include \"StdAfx.h\"") << std::endl;														// 06/28/00 AM.
 *fp << _T("#include <stdio.h>") << std::endl;
 *fp << _T("#include <stdlib.h>") << std::endl;
@@ -119,6 +99,5 @@ consh_gen_includes(
 *fp << _T("#include \"") << consh_CON_BASE << _T("_ini.h\"") << std::endl;
 *fp << _T("#include \"") << consh_PTR_BASE << _T("_ini.h\"") << std::endl;
 *fp << _T("#include \"") << consh_CC_BASE  << _T("_code.h\"") << std::endl;
-#endif
 }
 

--- a/cs/libconsh/st_gen.cpp
+++ b/cs/libconsh/st_gen.cpp
@@ -91,12 +91,8 @@ for (ii = 0; ii <= seg_curr; ii++)
    //   return;
 	fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
    gen_file_head(fp);
-// LINUX: Need to resolve to same capitalization in file name.	// 03/23/19 AM.
-#ifdef LINUX
-	*fp << _T("#include \"stdafx.h\"") << std::endl;	// 03/23/19 AM.
-#else
-	*fp << _T("#include \"StdAfx.h\"") << std::endl;	// 06/28/00 AM.
-#endif
+// NLP-ENGINE-510: emit StdAfx.h (mixed case) on every platform.
+*fp << _T("#include \"StdAfx.h\"") << std::endl;
 
    ptr = st_segs[ii];
    count = -1;
@@ -270,21 +266,9 @@ fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
 gen_file_head(fp);
 
-#ifdef LINUX
-*fp << _T("#include \"stdafx.h\"") << std::endl;			// 06/28/00 AM.
-*fp << _T("#include <stdio.h>") << std::endl;
-*fp << _T("#include <stdlib.h>") << std::endl;	
-//*fp << "#include <fstream.h>" << std::endl;			// 04/23/99 AM.
-*fp << _T("#include <iostream>") << std::endl;	// Upgrade.	// 01/24/01 AM.
-*fp << _T("#include <fstream>") << std::endl;	// Upgrade.	// 01/24/01 AM.
-*fp << _T("#include \"prim\\libprim.h\"") << std::endl;
-*fp << _T("#include \"prim\\prim.h\"") << std::endl;
-//*fp << "#include \"prim\\mach.h\"" << std::endl;			// 04/23/99 AM.
-*fp << _T("#include \"kbm\\libkbm.h\"") << std::endl;
-*fp << _T("#include \"kbm\\st.h\"") << std::endl;
-*fp << _T("#include \"consh\\libconsh.h\"") << std::endl;		// 08/15/02 AM.
-*fp << _T("#include \"consh\\cg.h\"") << std::endl;			// 08/15/02 AM.
-#else
+// NLP-ENGINE-510: removed `#ifdef LINUX` branch (lowercase stdafx.h +
+// backslash paths). The legacy `#else` branch below uses StdAfx.h with
+// forward slashes and works on every platform.
 *fp << _T("#include \"StdAfx.h\"") << std::endl;			// 06/28/00 AM.
 *fp << _T("#include <stdio.h>") << std::endl;
 *fp << _T("#include <stdlib.h>") << std::endl;
@@ -298,7 +282,6 @@ gen_file_head(fp);
 *fp << _T("#include \"kbm/st.h\"") << std::endl;
 *fp << _T("#include \"consh/libconsh.h\"") << std::endl;		// 08/15/02 AM.
 *fp << _T("#include \"consh/cg.h\"") << std::endl;			// 08/15/02 AM.
-#endif
 *fp << _T("#include \"") << tbase << _T("_ini.h\"") << std::endl;
 *fp << _T("\nbool cc_st_ini(void *xcg)") << std::endl;		// 08/15/02 AM.
 *fp << _T("{") << std::endl;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.39"
+#define NLP_ENGINE_VERSION "3.1.40"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The first NLP-ENGINE-510 commit only touched the `Cc_code.cpp` emit path. Cloud build of date-time still failed with the same error on a different set of generated files:

  /home/runner/.../work/kb/Ptr_ini.cpp:2:10: fatal error:
    stdafx.h: No such file or directory
  /home/runner/.../work/kb/Sym17.cpp:2:10: ...

Those headers come from cs/libconsh/consh_gen.cpp:consh_gen_includes(), which is called from sym_gen, con_gen, and ptr_gen for every kb/Sym*.cpp, kb/Con*.cpp, and kb/Ptr*.cpp file. There were also two sites in cs/libconsh/st_gen.cpp and one missed in cc_gen.cpp itself (no trailing date comment, so the earlier `replace_all` Edit didn't catch it).

Worse, two of the LINUX branches emitted backslash include paths (`prim\libprim.h`, `kbm\sym_s.h`) on top of the lowercase stdafx — those never could have compiled on a case-sensitive Linux filesystem regardless of the stdafx.h casing. The `#else` (Windows) branches were already correct: `StdAfx.h` with forward-slash paths, which gcc happily accepts.

Fix: drop the LINUX branches in all four sites and route every platform through the existing Windows-form emission.

- cc_gen.cpp: the second `#ifdef LINUX ... stdafx.h ...` block (around the kb_setup.cpp emit) collapsed to a single `#include "StdAfx.h"`.
- consh_gen.cpp::consh_gen_includes: drop the entire 30-line LINUX branch (lowercase stdafx + backslash paths). This is the function feeding sym/con/ptr_gen.
- st_gen.cpp: both `#ifdef LINUX` blocks (lines ~94 and ~269) collapsed.