### PR TITLE
NLP-ENGINE-511 gate <tchar.h>/<streamClasses.h> behind #ifndef LINUX in analyzer.h emit

### DIFF
--- a/lite/gen.cpp
+++ b/lite/gen.cpp
@@ -369,15 +369,24 @@ bool Gen::writeHeaders()
 
 // analyzer.h file
 //*fhead_ << "#include \"stdafx.h\"" << std::endl;
+// NLP-ENGINE-510: <windows.h>, <tchar.h>, and <streamClasses.h> are
+// Windows-only — keep them gated. <my_tchar.h> provides the _TCHAR / _T()
+// substitutes on Linux. Also switch lite\\Arun.h to a forward-slash path
+// so the include compiles on Linux (NTFS lets you spell either separator;
+// ext4 does not).
 #ifndef LINUX
 *fhead_ << _T("#include <windows.h>") << std::endl;
 #endif
 *fhead_ << _T("#include <stdlib.h>") << std::endl;
 *fhead_ << _T("#include <stdio.h>") << std::endl;
+#ifndef LINUX
 *fhead_ << _T("#include <tchar.h>") << std::endl;				// Unicode	// 02/07/05 AM.
+#endif
 *fhead_ << _T("#include <my_tchar.h>") << std::endl;			// Unicode	// 02/07/05 AM.
+#ifndef LINUX
 *fhead_ << _T("#include <streamClasses.h>") << std::endl;	// Unicode	// 02/07/05 AM.
-*fhead_ << _T("#include \"lite\\Arun.h\"") << std::endl;
+#endif
+*fhead_ << _T("#include \"lite/Arun.h\"") << std::endl;
 *fhead_ << std::endl;
 
 *faux_ << _T("#include \"analyzer.h\"") << std::endl;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.40"
+#define NLP_ENGINE_VERSION "3.1.41"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Follow-up to NLP-ENGINE-510 (which merged at 3.1.40). After the StdAfx.h emissions were fixed, the next cloud Linux build hit:

  /home/runner/.../work/run/analyzer.h:4:10: fatal error:
    tchar.h: No such file or directory
      4 | #include <tchar.h>

The generated `analyzer.h` (from `lite/gen.cpp` in the section that writes the analyzer-side header) unconditionally emitted <tchar.h> and <streamClasses.h>, both Windows-only. <windows.h> was already gated behind `#ifndef LINUX`, but the two related headers weren't. Also `#include "lite\Arun.h"` used a backslash separator which ext4 won't resolve.

Fix:
- gate <tchar.h> and <streamClasses.h> behind `#ifndef LINUX`. On Linux `<my_tchar.h>` already provides the _TCHAR / _T() polyfill (see include/Api/my_tchar.h).
- emit `lite/Arun.h` with a forward slash so the include compiles on every platform.
- bump NLP_ENGINE_VERSION to 3.1.41 so the round-3 binaries are identifiable downstream and don't collide with the 3.1.40 artifacts shipped by NLP-ENGINE-510 (which only had rounds 1 and 2).