### PR TITLE
NLP-ENGINE-512 emit forward-slash include paths in generated ehead.h/rhead.h and per-pass headers

### DIFF
--- a/lite/gen.cpp
+++ b/lite/gen.cpp
@@ -360,11 +360,13 @@ bool Gen::writeHeaders()
 // user.h / Ucode.h are optional legacy user-extension headers (paired with user.dll).
 // Most analyzers don't define them; guard with __has_include so the generated C++ still
 // compiles when the user/ subdirectory is absent.
-*fcode_ << _T("#if __has_include(\"..\\user\\user.h\")") << std::endl;
-*fcode_ << _T("#include \"..\\user\\user.h\"") << std::endl;				// 02/13/01 AM.
+// NLP-ENGINE-512: use forward slashes (case-sensitive Linux FS treats `\` as a literal
+// character, not a path separator, so the include silently misses).
+*fcode_ << _T("#if __has_include(\"../user/user.h\")") << std::endl;
+*fcode_ << _T("#include \"../user/user.h\"") << std::endl;
 *fcode_ << _T("#endif") << std::endl;
-*fcode_ << _T("#if __has_include(\"..\\user\\Ucode.h\")") << std::endl;
-*fcode_ << _T("#include \"..\\user\\Ucode.h\"") << std::endl;				// 02/13/01 AM.
+*fcode_ << _T("#if __has_include(\"../user/Ucode.h\")") << std::endl;
+*fcode_ << _T("#include \"../user/Ucode.h\"") << std::endl;
 *fcode_ << _T("#endif") << std::endl;
 
 // analyzer.h file
@@ -400,7 +402,7 @@ bool Gen::writeHeaders()
 *ehead_  << _T("// Automatically generated: ") << today() << std::endl;
 *ehead_ << _T("#include <stdlib.h>") << std::endl;
 *ehead_ << _T("#include <stdio.h>") << std::endl;
-*ehead_ << _T("#include \"lite\\Arun.h\"") << std::endl;
+*ehead_ << _T("#include \"lite/Arun.h\"") << std::endl;	// NLP-ENGINE-512: forward slash
 
 *edata_  << _T("// Automatically generated: ") << today() << std::endl;
 *edata_ << _T("// INCLUDED IN EHASH.CPP ONLY.") << std::endl;
@@ -417,7 +419,7 @@ bool Gen::writeHeaders()
 *rhead_  << _T("// Automatically generated: ") << today() << std::endl;
 *rhead_ << _T("#include <stdlib.h>") << std::endl;
 *rhead_ << _T("#include <stdio.h>") << std::endl;
-*rhead_ << _T("#include \"lite\\Arun.h\"") << std::endl;
+*rhead_ << _T("#include \"lite/Arun.h\"") << std::endl;	// NLP-ENGINE-512: forward slash
 
 *rdata_  << _T("// Automatically generated: ") << today() << std::endl;
 *rdata_ << _T("// INCLUDED IN RHASH.CPP ONLY.") << std::endl;

--- a/lite/ifile.cpp
+++ b/lite/ifile.cpp
@@ -480,11 +480,12 @@ _TCHAR *algo = parse->getAlgo();											// 05/31/00 AM.
 *fcode << _T("#include \"data.h\"") << std::endl;					// 04/03/09 AM.
 // Same legacy user-extension headers as gen.cpp::writeHeaders — guard with __has_include
 // so per-pass files compile when the user/ subdirectory is absent.
-*fcode << _T("#if __has_include(\"..\\user\\user.h\")") << std::endl;
-*fcode << _T("#include \"..\\user\\user.h\"") << std::endl;	// 04/03/09 AM.
+// NLP-ENGINE-512: forward slashes so the include resolves on Linux.
+*fcode << _T("#if __has_include(\"../user/user.h\")") << std::endl;
+*fcode << _T("#include \"../user/user.h\"") << std::endl;
 *fcode << _T("#endif") << std::endl;
-*fcode << _T("#if __has_include(\"..\\user\\Ucode.h\")") << std::endl;
-*fcode << _T("#include \"..\\user\\Ucode.h\"") << std::endl;	// 04/03/09 AM.
+*fcode << _T("#if __has_include(\"../user/Ucode.h\")") << std::endl;
+*fcode << _T("#include \"../user/Ucode.h\"") << std::endl;
 *fcode << _T("#endif") << std::endl;
 
 // Point to the corresponding header file.					// 04/04/09 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.41"
+#define NLP_ENGINE_VERSION "3.1.42"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Follow-up to NLP-ENGINE-511 (which fixed `analyzer.h`). The cloud Linux build of date-time still failed on the per-pass C++ files:

  /home/runner/.../work/run/ehead.h:4:10: fatal error:
    lite\Arun.h: No such file or directory
      4 | #include "lite\Arun.h"

Same root cause as 511: the codegen for `ehead.h`, `rhead.h`, and the per-pass cpp files in `lite/gen.cpp` and `lite/ifile.cpp` still emitted backslash include paths. Windows tolerated them because NTFS accepts either separator; Linux ext4 does not.

Sites fixed (all in the .cpp-emit code, so they only affect the generated output, not engine sources):

- lite/gen.cpp:363-368   `#if __has_include("../user/user.h")` + include,
                         and the matching Ucode.h pair (in the per-pass
                         file header). Were `"..\user\user.h"` and
                         `"..\user\Ucode.h"`.
- lite/gen.cpp:403       `*ehead_ << #include "lite/Arun.h"`.
                         Was `"lite\Arun.h"`. This is what the cloud
                         compiler tripped over.
- lite/gen.cpp:420       same fix in the `*rhead_` emit.
- lite/ifile.cpp:483-488 same `__has_include`+include pair for the
                         per-pass file (Ifile::writeIncludes), now with
                         forward slashes.

Final sweep with `grep '_T(.*#include.*\\\\' --include=*.cpp lite/ cs/` returns no matches.

- bump NLP_ENGINE_VERSION to 3.1.42 so the round-4 binaries are distinguishable from the 3.1.41 build that NLP-ENGINE-511 produced (which only had the analyzer.h forward-slash + tchar.h gate).