### PR TITLE
NLP-ENGINE-513 emit "prim/libprim.h" in generated St*.cpp (fixes _TCHAR on cloud Linux build)

### DIFF
--- a/cs/libconsh/st_gen.cpp
+++ b/cs/libconsh/st_gen.cpp
@@ -93,6 +93,11 @@ for (ii = 0; ii <= seg_curr; ii++)
    gen_file_head(fp);
 // NLP-ENGINE-510: emit StdAfx.h (mixed case) on every platform.
 *fp << _T("#include \"StdAfx.h\"") << std::endl;
+// NLP-ENGINE-513: on Linux the engine's StdAfx.h is empty (#ifndef LINUX),
+// so St*.cpp had no source for _TCHAR. libprim.h ends with my_tchar.h, which
+// defines `#define _TCHAR char` under LINUX. Without this, the cloud Linux
+// build of any analyzer fails with "'_TCHAR' does not name a type".
+*fp << _T("#include \"prim/libprim.h\"") << std::endl;
 
    ptr = st_segs[ii];
    count = -1;
@@ -180,6 +185,11 @@ for (ii = seg_curr + 1; ii < segs_tot; ii++)
 	fp = new std::_t_ofstream(TCHAR2A(s_nam));			// 04/20/99 AM.
 
    gen_file_head(fp);
+// NLP-ENGINE-513: empty-segment St*.cpp files only ever emitted the array
+// declaration (no #includes), so they had no source for _TCHAR on Linux.
+// Match the filled-segment loop above — pull in StdAfx.h + libprim.h.
+*fp << _T("#include \"StdAfx.h\"") << std::endl;
+*fp << _T("#include \"prim/libprim.h\"") << std::endl;
    gen_array_def(_T("_TCHAR"), s_tab, siz, fp);	/* Array definition. */
    //if (!file_close(s_nam, fp))
    //   return;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.42"
+#define NLP_ENGINE_VERSION "3.1.43"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Follow-up to NLP-ENGINE-512. The cloud Linux build of date-time still failed:

  /home/runner/work/nlp-compile-service/nlp-compile-service/work/kb/St0.cpp:3:1:
    error: '_TCHAR' does not name a type

Root cause: st_gen() emits St*.cpp files whose only header was `#include "StdAfx.h"`. The engine's StdAfx.h is wrapped entirely in `#ifndef LINUX`, so on Linux it expands to nothing — leaving `_TCHAR` undefined for the `_TCHAR Stable0[...]` array definitions written by gen_array_hd.

On Windows, `<tchar.h>` (pulled in by StdAfx.h) supplies `_TCHAR`. The Linux substitute is `include/Api/my_tchar.h`, which has `#define _TCHAR char` inside `#ifdef LINUX`. That header is included by `prim/libprim.h` at the tail, so emitting libprim.h alongside StdAfx.h gives us _TCHAR on every platform.

Sites fixed (both in `cs/libconsh/st_gen.cpp::st_gen()`):
  - filled-segment loop: append `#include "prim/libprim.h"` after StdAfx.h
  - empty-segment loop: also emit `StdAfx.h` + `prim/libprim.h` (previously it emitted ONLY a file head comment + array decl — relied entirely on the cmake force-include of StdAfx.h, which is empty on Linux)

Companion change in nlp-compile-service `scripts/emit-cmake.sh`: add `-DLINUX` for non-Windows builds so libStream.h's `class LIBSTREAM_API CLibStream` block (also wrapped in `#ifndef LINUX`) is skipped, otherwise `LIBSTREAM_API` expands to `__declspec(dllimport)` which gcc rejects.

Bumps NLP_ENGINE_VERSION to 3.1.43.