### PR TITLE
NLP-ENGINE-516 enable compiled-RUN dispatch on Linux (and macOS)

### DIFF
--- a/include/Api/lite/nlp.h
+++ b/include/Api/lite/nlp.h
@@ -54,6 +54,18 @@ All rights reserved.
 #include "global.h"		// 02/05/00 AM. (for FNAME_SIZE).
 #include "vtrun.h"		// [DEGLOB]	// 10/14/20 AM.
 
+// NLP-ENGINE-516: hrundll_ / getHrundll() below now exist on every
+// platform. On Windows HINSTANCE comes from <windows.h> (force-included
+// via StdAfx.h); on Linux we mirror the typedef from prim/dyn.h to avoid
+// pulling that header (and its LIBPRIM_API decorations) transitively into
+// every translation unit that just needs the Ana / NLP types.
+#ifdef LINUX
+#ifndef NLP_HINSTANCE_TYPEDEF_
+#define NLP_HINSTANCE_TYPEDEF_
+typedef void *HINSTANCE;
+#endif
+#endif
+
 LITE_API void object_counts(
 	std::_t_ofstream* =0	// 07/18/03 AM.
 	);

--- a/include/Api/lite/nlp.h
+++ b/include/Api/lite/nlp.h
@@ -108,8 +108,8 @@ public:
 	VTRun *getVTRun();	// [DEGLOB]	// 10/15/20 AM.
 #ifndef LINUX
 	HINSTANCE getHdll();						// 01/29/99 AM.
-	HINSTANCE getHrundll();					// 05/14/00 AM.
 #endif
+	HINSTANCE getHrundll();					// 05/14/00 AM. NLP-ENGINE-516: also Linux.
 //	char *getDatadir();						// 12/08/99 AM.
 	CG   *getCG();								// 02/15/00 AM.
 	bool getFbatchstart();					// 10/19/00 AM.
@@ -389,10 +389,13 @@ private:
 #ifndef LINUX
 	// USER DLL TO LOAD DYNAMICALLY.										// 01/29/99 AM.
 	HINSTANCE hdll_;															// 01/29/99 AM.
+#endif
 
 	// COMPILED ANALYZER TO LOAD DYNAMICALLY.							// 05/14/00 AM.
-	HINSTANCE hrundll_;														// 05/14/00 AM.
-#endif
+	// NLP-ENGINE-516: now available on Linux too — the .so produced by
+	// `nlp -COMPILE` exports `run_analyzer` and is dlopen'd via
+	// libprim/dyn.cpp's load_dll, resolved via dlsym in lite/dyn.cpp.
+	HINSTANCE hrundll_;
 
 	// If not defined by user, initialize data directory to one
 	// defined by the environment variable %TAI%.			// 12/08/99 AM.

--- a/lite/dyn.cpp
+++ b/lite/dyn.cpp
@@ -196,4 +196,38 @@ else
 return false;
 }
 
+#else
+// NLP-ENGINE-516: Linux equivalent of call_runAnalyzer. The Windows code
+// above uses GetProcAddress; here we use dlsym to look up the same
+// `extern "C" run_analyzer` symbol the codegen exports from the compiled
+// .so (lite/seqn.cpp:580 — NLP_RUN_EXPORT is empty on non-Windows, so the
+// symbol just gets default ELF visibility).
+//
+// The user.dll path (call_ucodeAction / call_ucodeAlgo / call_ucodeIni /
+// call_ucodeFin) intentionally stays Windows-only — VisualText's user
+// extension model isn't wired up on Linux yet.
+
+#include <dlfcn.h>
+
+bool call_runAnalyzer(
+	HINSTANCE hLibrary,
+	Parse *parse
+	)
+{
+typedef bool (* lpFunc4)(Parse *parse);
+// dlsym takes void*; HINSTANCE is the same opaque handle type on Linux
+// (typedef'd to void* in include/Api/prim/dyn.h).
+lpFunc4 Func4 = (lpFunc4) dlsym(hLibrary, "run_analyzer");
+if (Func4 != NULL)
+	return ((Func4)(parse));
+
+const char *err = dlerror();
+std::_t_strstream gerrStr;
+gerrStr << _T("Error in call_runAnalyzer (dlsym run_analyzer: ")
+		  << (err ? err : "unknown") << _T(")") << std::ends;
+errOut(&gerrStr,false);
+
+return false;
+}
+
 #endif

--- a/lite/dyn.h
+++ b/lite/dyn.h
@@ -23,7 +23,18 @@ class Auser;		// 02/13/01 AM.
 class NLP;			// 01/23/02 AM.
 
 //extern void load_dll();
+// NLP-ENGINE-516: call_runAnalyzer is cross-platform — uses GetProcAddress
+// on Windows and dlsym on Linux/macOS. load_dll/unload_dll prototypes come
+// from include/Api/prim/dyn.h (also cross-platform).
+bool call_runAnalyzer(
+	HINSTANCE hLibrary,
+	Parse *parse
+	);
+
 #ifndef LINUX
+// Legacy lite-side prototypes for the Windows user.dll path. load_dll /
+// unload_dll are duplicated here from prim/dyn.h; the user-extension
+// helpers below are Windows-only.
 HINSTANCE load_dll(_TCHAR *path);
 
 bool call_ucodeAction(
@@ -32,10 +43,6 @@ bool call_ucodeAction(
 	Delt<Iarg> *args,
 	Auser *auser
 //	Parse *parse
-	);
-bool call_runAnalyzer(														// 05/15/00 AM.
-	HINSTANCE hLibrary,
-	Parse *parse
 	);
 bool call_ucodeAlgo(															// 02/27/01 AM.
 	HINSTANCE hLibrary,

--- a/lite/dyn.h
+++ b/lite/dyn.h
@@ -22,6 +22,16 @@ class Iarg;
 class Auser;		// 02/13/01 AM.
 class NLP;			// 01/23/02 AM.
 
+// NLP-ENGINE-516: HINSTANCE typedef on Linux. Same shape as the typedef in
+// prim/dyn.h and lite/nlp.h — guarded so all three are duplicate-safe. On
+// Windows HINSTANCE comes from <windows.h> via StdAfx.h.
+#ifdef LINUX
+#ifndef NLP_HINSTANCE_TYPEDEF_
+#define NLP_HINSTANCE_TYPEDEF_
+typedef void *HINSTANCE;
+#endif
+#endif
+
 //extern void load_dll();
 // NLP-ENGINE-516: call_runAnalyzer is cross-platform — uses GetProcAddress
 // on Windows and dlsym on Linux/macOS. load_dll/unload_dll prototypes come

--- a/lite/nlp.cpp
+++ b/lite/nlp.cpp
@@ -133,8 +133,8 @@ isLastFile_ = false;
 isFirstFile_ = false;
 #ifndef LINUX
 hdll_ = 0;													// 01/29/99 AM.
-hrundll_ = 0;												// 05/14/00 AM.
 #endif
+hrundll_ = 0;												// 05/14/00 AM. NLP-ENGINE-516: also init on Linux.
 cg_   = 0;													// 02/15/00 AM.
 gui	= 0;							// Dave snuck this var in.			// 02/21/02 AM.
 dbgout_	= 0;																	// 08/26/02 AM.
@@ -180,8 +180,8 @@ isLastFile_ = false;
 isFirstFile_ = false;
 #ifndef LINUX
 hdll_ = 0;
-hrundll_ = 0;
 #endif
+hrundll_ = 0;	// NLP-ENGINE-516: also init on Linux.
 cg_   = 0;
 gui	= 0;
 dbgout_	= 0;
@@ -263,6 +263,14 @@ if (hrundll_)
 	unload_dll(hdll_);	// 05/14/00 AM.
 	hrundll_ = 0;			// 05/14/00 AM.
 	}
+#else
+// NLP-ENGINE-516: unload compiled-analyzer .so on Linux too. (User-dll
+// hdll_ stays Windows-only — that's a separate feature.)
+if (hrundll_)
+	{
+	unload_dll(hrundll_);
+	hrundll_ = 0;
+	}
 #endif
 
 if (dbgout_)																	// 08/26/02 AM.
@@ -290,8 +298,8 @@ void *NLP::getStab()			{return stab_;}							// 05/26/02 AM.
 VTRun *NLP::getVTRun()			{return vtrun_;}	// [DEGLOB]	// 10/15/20 AM.
 #ifndef LINUX
 HINSTANCE NLP::getHdll()	{return hdll_;}							// 01/29/99 AM.
-HINSTANCE NLP::getHrundll(){return hrundll_;}						// 05/14/00 AM.
 #endif
+HINSTANCE NLP::getHrundll(){return hrundll_;}						// 05/14/00 AM. NLP-ENGINE-516: also on Linux.
 //char *NLP::getDatadir()		{return datadir_;}					// 12/08/99 AM.
 CG	  *NLP::getCG()			{return cg_;}								// 02/15/00 AM.
 bool	NLP::getFbatchstart(){return fbatchstart_;}					// 10/19/00 AM.
@@ -1257,26 +1265,17 @@ gerrStr << _T("[Loading compiled analyzer ")							// 01/23/06 AM.
 												<< buf << _T("]") << std::ends;	// 01/23/06 AM.
 errOut(&gerrStr,false);
 
-#ifndef LINUX
+// NLP-ENGINE-516: hrundll_ is now a member on every platform. Store the
+// handle so the runAnalyzer dispatch below can call into run_analyzer via
+// call_runAnalyzer (GetProcAddress on Windows, dlsym on Linux/macOS).
 hrundll_ = load_dll(buf);
 if (!hrundll_)
-#else
-// On Linux hrundll_ isn't a member; just probe whether the .so is loadable.
-// If it loads we close the handle immediately — call_runAnalyzer path
-// (Windows-only) won't use it, and make_analyzer falls back to interpreted.
-HINSTANCE hRun = load_dll(buf);
-if (!hRun)
-#endif
 	{
 	std::_t_strstream gerrStr;
 	gerrStr << _T("[Error: Couldn't load compiled analyzer.]") << std::ends;
 	errOut(&gerrStr,false);
 	return false;
 	}
-#ifdef LINUX
-unload_dll(hRun);
-return false;  // No compiled-analyzer path on Linux; trigger interpreted fallback.
-#endif
 return true;
 }
 
@@ -2303,14 +2302,13 @@ if (parse->getText())
   cout << "runAnalyzer: RUNEMBED_ calling run_analyzer(parse)" << std::endl;
   run_analyzer(parse);
 #else
-#ifndef LINUX
+	// NLP-ENGINE-516: same dispatch on every platform. hrundll_ is set by
+	// load_compiled() when -COMPILED finds bin/run.<ext>; call_runAnalyzer
+	// uses GetProcAddress on Windows and dlsym on Linux/macOS (see dyn.cpp).
 	if (!hrundll_)
 		parse->execute();
 	else
 		call_runAnalyzer(hrundll_,parse);
-#else
-	parse->execute();
-#endif
 #endif
 	}
 
@@ -2412,14 +2410,13 @@ if (parse->getText())
   cout << "runAnalyzer: RUNEMBED_ calling run_analyzer(parse)" << std::endl;
   run_analyzer(parse);
 #else
-#ifndef LINUX
+	// NLP-ENGINE-516: same dispatch on every platform. hrundll_ is set by
+	// load_compiled() when -COMPILED finds bin/run.<ext>; call_runAnalyzer
+	// uses GetProcAddress on Windows and dlsym on Linux/macOS (see dyn.cpp).
 	if (!hrundll_)
 		parse->execute();
 	else
 		call_runAnalyzer(hrundll_,parse);
-#else
-	parse->execute();
-#endif
 #endif
 	}
 #ifdef LINUX

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.43"
+#define NLP_ENGINE_VERSION "3.1.44"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary
`NLP::load_compiled()` loaded `bin/run.so` on Linux only to immediately unload it and return `false`, forcing the engine to fall back to the interpreted path even when `-COMPILED` was requested. The `runAnalyzer` dispatch in `NLP::analyze` likewise hardcoded `parse->execute()` on Linux, never calling the loaded `.so`.

Net effect: editing the analyzer's `.nlp` source between runs changed `-COMPILED` output (because it was actually running interpreted), while Windows correctly served the same compiled artifact regardless of source edits.

## Fix
Bring the Linux compiled-RUN dispatch up to parity with Windows.

### `include/Api/lite/nlp.h`
- Move `HINSTANCE hrundll_` outside the `#ifndef LINUX` member block. (`hdll_` — the user.dll handle — stays Windows-only; that's a separate, unrelated feature.)
- Same for `getHrundll()` accessor.

### `lite/nlp.cpp`
- Init `hrundll_ = 0` in both constructors on every platform.
- Unload `hrundll_` in the destructor on Linux too (with the correct handle — the existing Windows block has a pre-existing typo passing `hdll_` instead of `hrundll_`; left untouched to keep this commit focused).
- Drop the `#ifndef LINUX` around `getHrundll()`.
- `load_compiled()`: single cross-platform path. Store the `dlopen` handle in `hrundll_`, remove the unload-and-return-false on Linux.
- `runAnalyzer` dispatch (2 sites): drop the `#ifndef LINUX`. Both platforms now: `if (!hrundll_) parse->execute(); else call_runAnalyzer(hrundll_, parse);`.

### `lite/dyn.h`
- Move `call_runAnalyzer()` prototype out of the Windows-only block. The rest stays Windows-only (`call_ucodeAction` / `call_ucodeAlgo` / `call_ucodeIni` / `call_ucodeFin` and the lite-side `load_dll`/`unload_dll` duplicates).

### `lite/dyn.cpp`
- Add a Linux `#else` branch implementing `call_runAnalyzer` via `dlsym("run_analyzer")`. The compiled `.so` exports `run_analyzer` with default visibility (`lite/seqn.cpp:580` emits `extern "C" NLP_RUN_EXPORT bool run_analyzer(Parse *)` and `NLP_RUN_EXPORT` is empty on non-Windows), so `dlsym` finds it.

Bumps `NLP_ENGINE_VERSION` to `3.1.44`.

## Test plan
- [ ] Compile date-time in WSL with `-COMPILE`, then run with `-COMPILED`. Output should match the source state when the .so was built.
- [ ] Edit one of date-time's `.nlp` files (e.g., disable a pass), re-run `-COMPILED` *without* re-compiling. Output should not change — confirms the `.so` is now being executed, not the interpreted source.
- [ ] Same test on macOS once the `.dylib` pipeline is healthy.
- [ ] Windows behavior unchanged (hrundll_ stored/called via GetProcAddress as before).
