### PR TITLE
NLP-ENGINE-517 use .dylib extension on macOS for compiled analyzer + KB loads

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -825,8 +825,14 @@ _TCHAR *fname = _T("kbu");										// kbu.dll		// 01/17/06 AM.
 
 #endif
 
+// NLP-ENGINE-517: same three-way split as lite/nlp.cpp's load_compiled.
+// macOS gets LINUX defined by the engine's cmake but the actual KB file
+// next to the analyzer is kb.dylib (not kb.so), so the load path needs
+// the platform-correct extension.
 #ifndef LINUX
 const _TCHAR *libext = _T("dll");
+#elif defined(__APPLE__)
+const _TCHAR *libext = _T("dylib");
 #else
 const _TCHAR *libext = _T("so");
 #endif

--- a/lite/nlp.cpp
+++ b/lite/nlp.cpp
@@ -1252,8 +1252,15 @@ _TCHAR *fname = _T("run");								// run.dll		// 01/23/06 AM.
 
 #endif
 
+// NLP-ENGINE-517: three-way split. The engine cmake defines LINUX on every
+// non-Windows platform (lite/CMakeLists.txt etc.), so macOS would hit the
+// LINUX branch and look for bin/run.so — but cmake on Darwin actually
+// produces <analyzer>.dylib (and the extension stages it as bin/run.dylib).
+// Detect Apple separately so the load path matches the real artifact.
 #ifndef LINUX
 const _TCHAR *libext = _T("dll");
+#elif defined(__APPLE__)
+const _TCHAR *libext = _T("dylib");
 #else
 const _TCHAR *libext = _T("so");
 #endif

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.44"
+#define NLP_ENGINE_VERSION "3.1.45"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary
On macOS the engine looked for `bin/run.so` / `kb/kb.so` but the artifact on disk is `.dylib`. The two load paths (`NLP::load_compiled` in `lite/nlp.cpp` and `CG::loadCompiledKB` in `cs/libconsh/cg.cpp`) gated on `#ifndef LINUX` for Windows vs `#else` for Linux. Since the engine cmake defines `LINUX` on every non-Windows platform (`lite/CMakeLists.txt`), macOS collapsed into the Linux path and looked for `.so`.

User-visible failure:
```
Couldn't load library: .../bin/run.so
```
even though `bin/run.dylib` was present.

## Fix
Three-way split, in both files:
```cpp
#ifndef LINUX
const _TCHAR *libext = _T("dll");
#elif defined(__APPLE__)
const _TCHAR *libext = _T("dylib");
#else
const _TCHAR *libext = _T("so");
#endif
```

`__APPLE__` is set by clang/gcc on Darwin independently of the engine's `LINUX` macro, so:
- Windows: `#ifndef LINUX` true → `dll`
- macOS: `#ifndef LINUX` false, `defined(__APPLE__)` true → `dylib`
- Linux: both false → `so`

Bumps `NLP_ENGINE_VERSION` to 3.1.45.

## Test plan
- [ ] Cloud-compile an analyzer on macOS, run with `-COMPILED`, confirm `bin/run.dylib` loads.
- [ ] KB load also picks up `kb/kb.dylib`.
- [ ] Linux / Windows unchanged.
