### PR TITLE
NLP-ENGINE-518 log swallowed int exception in pass catch (diagnostic)

### DIFF
--- a/lite/irule.cpp
+++ b/lite/irule.cpp
@@ -1881,7 +1881,13 @@ if (posts)																	// 09/15/08 AM.
 	{
 	*fcode << indent;														// 09/15/08 AM.
 //	*fcode << _T("} catch (...) {}");						// 09/15/08 AM.
-	*fcode << _T("} catch (int e) {e=e;}");						// 09/16/08 AM.
+	// NLP-ENGINE-518: log the exception code instead of swallowing silently.
+	// Diagnoses why date-time's verbose summary section is missing on macOS
+	// compiled mode while the compact KB-dump section writes fine: an
+	// int exception (one of Arun's ex_EXITPASS / ex_FAIL / ex_SUCCEED) is
+	// almost certainly being thrown mid-pass and caught here. Knowing the
+	// code tells us which Arun:: function bailed.
+	*fcode << _T("} catch (int e) {std::_t_cerr << _T(\"[pass post catch: int e=\") << e << _T(\"]\") << std::endl;}");
 	Gen::nl(fcode);														// 09/15/08 AM.
 	}
 
@@ -1999,7 +2005,9 @@ for (dcode = codes->getFirst(); dcode; dcode = dcode->Right())
 	}
 
 //*fcode << _T("} catch (...) {}");								// 09/15/08 AM.
-*fcode << _T("} catch (int e) {e=e;}");						// 09/16/08 AM.
+// NLP-ENGINE-518: log the exception code instead of swallowing silently.
+// Same rationale as the post-action catch above.
+*fcode << _T("} catch (int e) {std::_t_cerr << _T(\"[pass code catch: int e=\") << e << _T(\"]\") << std::endl;}");
 Gen::nl(fcode);														// 09/15/08 AM.
 
 return true;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.45"
+#define NLP_ENGINE_VERSION "3.1.46"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary
Diagnostic-only change. Pass-level codegen emits `} catch (int e) {e=e;}` at the end of each `@CODE` block and after the per-rule post-action sequence. These swallow Arun's int-typed control-flow exceptions (`ex_EXITPASS`, `ex_FAIL`, `ex_SUCCEED`) silently.

That's fine in production, but it hides the cause when something goes wrong — most recently the **date-time analyzer's verbose summary section silently disappears when run in compiled mode on macOS**, while the compact KB-dump section (written by the same `SaveKB` call before the throw point) makes it to disk. The catch handler silently absorbs the exception and the rest of the writes never happen.

## Change
Replace the silent swallow with a one-line stderr log:

```cpp
} catch (int e) {
    std::_t_cerr << _T("[pass post catch: int e=") << e << _T("]") << std::endl;
}
```

(Same for the code-region catch with `[pass code catch: ...]` prefix so the two sites are distinguishable in logs.)

Once the cause of the macOS truncation is identified and fixed, this commit can be reverted or the log gated behind a debug flag.

## Sites
- `lite/irule.cpp:1884` (post-action catch)
- `lite/irule.cpp:2002` (code-region catch)

Bumps `NLP_ENGINE_VERSION` to `3.1.46`.

## Test plan
- [ ] Compile date-time on macOS with the new engine. Re-run with `-COMPILED`.
- [ ] Check `err.log` for `[pass code catch: int e=N]` or `[pass post catch: int e=N]` lines. The value `N` tells us which control-flow exception is firing (compare against `ex_EXITPASS`, `ex_FAIL`, `ex_SUCCEED` constants in `lite/Arun.h`).
- [ ] Linux/Windows behavior unchanged aside from any messages that were already being silently swallowed (now logged — expected to be quiet on a normal run).
