### PR TITLE
NLP-ENGINE-519 cast RSSTR/RSNAME/RSKB* string emits to _TCHAR* (fixes macOS << bool-overload bug)

### DIFF
--- a/lite/rfasem.cpp
+++ b/lite/rfasem.cpp
@@ -657,7 +657,19 @@ switch (type_)
 	{
 	case RSNAME:
 	case RSSTR:
-		*fcode << _T("_T(\"")
+		// NLP-ENGINE-519: cast to _TCHAR* so the generated string literal can
+		// match overloads taking `_TCHAR*` (e.g. Arun::out(_TCHAR*, _TCHAR*,
+		// Nlppp*)) instead of falling through to the `bool` overload via
+		// pointer-to-bool conversion. macOS clang strictly applies C++'s
+		// "string literal is const char[N]" rule, so without this cast,
+		// _T("...") can't convert to char* (qualification conversion only
+		// adds const, never removes) but CAN convert to bool — and clang
+		// picks bool as the only viable overload, producing output like '1'
+		// instead of the intended string. gcc with -Wno-write-strings and
+		// MSVC's relaxed string handling hide the problem on Linux/Windows;
+		// clang only suppresses the warning, not the strict type. Same fix
+		// pattern as iaction.cpp:1019 (which the IASTR path already uses).
+		*fcode << _T("(_TCHAR*)_T(\"")
 				 << c_str(val_.name_, buff, MAXSTR)
 				 << _T("\")");
 		return true;
@@ -725,7 +737,10 @@ switch (type_)
 	case RS_KBPHRASE:
 	case RS_KBATTR:
 	case RS_KBVAL:
-		*fcode << _T("_T(\"") << val_.name_ << _T("\")");
+		// NLP-ENGINE-519: same cast as RSNAME/RSSTR above, for the same
+		// reason. KB-typed semantic names emitted as bare _T("...") would
+		// fall through to the bool overload on macOS clang.
+		*fcode << _T("(_TCHAR*)_T(\"") << val_.name_ << _T("\")");
 		return true;
 
 	///////// PARSE TREE OBJECTS.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.46"
+#define NLP_ENGINE_VERSION "3.1.47"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary
`RFASem::genEval` emitted string-typed semantics (RSNAME, RSSTR, and the KB-typed RS_KB* family) as bare `_T("...")` — **without** a `(_TCHAR*)` cast. On Linux/Windows this worked because gcc with `-Wno-write-strings` and MSVC's relaxed string-literal handling implicitly converted the `const char[N]` to `char*` at the call site. On macOS **clang doesn't**:

- Standard C++ says `"..."` is `const char[N]`.
- `const char[N]` → `char*` (`_TCHAR*`) requires a const-removing qualification conversion, which the standard does not allow.
- `const char[N]` → `bool` is valid (array-to-pointer decay then boolean conversion).

So for `Arun::out(_TCHAR*, ...)` with overloads taking `_TCHAR*` OR `bool` as the second arg, clang picks the **bool overload** as the only viable one. The user's `"file" << "string"` compiled into a `bool=true` write, producing the single byte `1` instead of the intended string.

## User-visible failure
```nlp
"moose.txt" << "This \ntest thist\n\nand this"
```
- macOS compiled output of `moose.txt`: literally just `1`
- Interpreted mode AND Linux/Windows compiled: correct text with newlines

The date-time analyzer's missing verbose summary section has the same root cause: every `<<` write with a string literal RHS silently writes `1` on macOS instead of the intended text. The "compact" KB-dump portion of `datetimes.kbb` survives because it's written via a different path that uses `Arun::sem(...)` wrappers (which produce `RFASem*` arguments, dispatching to the `Arun::out(_TCHAR*, RFASem*, Nlppp*)` overload — no bool ambiguity there).

## Fix
Emit `(_TCHAR*)_T("...")` instead of `_T("...")` for the string cases. Same pattern `lite/iaction.cpp:1019` already uses for IASTR action-arg emission — which is why action-arg string passing worked while expression-level string emission didn't.

### Sites
- `lite/rfasem.cpp` ~660: RSNAME / RSSTR
- `lite/rfasem.cpp` ~728: RS_KBCONCEPT / RS_KBPHRASE / RS_KBATTR / RS_KBVAL

## Behavior
- **Linux / Windows:** no change (the implicit conversion was already happening).
- **macOS:** restores intended string-overload dispatch.

Bumps `NLP_ENGINE_VERSION` to `3.1.47`.

## Test plan
- [ ] On Mac, after auto-updater pulls 3.1.47, re-compile date-time.
- [ ] Run `"moose.txt" << "This \ntest thist\n\nand this"` test → `moose.txt` should contain the actual text with newlines.
- [ ] Re-run full date-time `-COMPILED` → `datetimes.kbb` should contain BOTH sections (compact + verbose), matching Linux/Windows output.
- [ ] Verify Linux/Windows behavior unchanged.

## Follow-up
NLP-ENGINE-518's verbose pass-catch diagnostic can be reverted once this is confirmed working — its purpose (finding the silent failure) is fulfilled. Or kept as a useful breadcrumb for future stuck cases.
