### PR TITLE
NLP-ENGINE-520 revert 518 verbose pass-catch (diagnostic no longer needed)

### DIFF
--- a/lite/irule.cpp
+++ b/lite/irule.cpp
@@ -1881,13 +1881,7 @@ if (posts)																	// 09/15/08 AM.
 	{
 	*fcode << indent;														// 09/15/08 AM.
 //	*fcode << _T("} catch (...) {}");						// 09/15/08 AM.
-	// NLP-ENGINE-518: log the exception code instead of swallowing silently.
-	// Diagnoses why date-time's verbose summary section is missing on macOS
-	// compiled mode while the compact KB-dump section writes fine: an
-	// int exception (one of Arun's ex_EXITPASS / ex_FAIL / ex_SUCCEED) is
-	// almost certainly being thrown mid-pass and caught here. Knowing the
-	// code tells us which Arun:: function bailed.
-	*fcode << _T("} catch (int e) {std::_t_cerr << _T(\"[pass post catch: int e=\") << e << _T(\"]\") << std::endl;}");
+	*fcode << _T("} catch (int e) {e=e;}");						// 09/16/08 AM.
 	Gen::nl(fcode);														// 09/15/08 AM.
 	}
 
@@ -2005,9 +1999,7 @@ for (dcode = codes->getFirst(); dcode; dcode = dcode->Right())
 	}
 
 //*fcode << _T("} catch (...) {}");								// 09/15/08 AM.
-// NLP-ENGINE-518: log the exception code instead of swallowing silently.
-// Same rationale as the post-action catch above.
-*fcode << _T("} catch (int e) {std::_t_cerr << _T(\"[pass code catch: int e=\") << e << _T(\"]\") << std::endl;}");
+*fcode << _T("} catch (int e) {e=e;}");						// 09/16/08 AM.
 Gen::nl(fcode);														// 09/15/08 AM.
 
 return true;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.47"
+#define NLP_ENGINE_VERSION "3.1.48"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Reverts the diagnostic logging added in #629 (NLP-ENGINE-518). Now that #630 (NLP-ENGINE-519) has root-caused and fixed the macOS truncation, the verbose catch handler is just noise — every NLP++ succeed/fail action logs `[pass post catch: int e=0]` / `[... e=1]` lines in `err.log` on every run. Restore the original silent swallow `catch (int e) {e=e;}`.

Bumps `NLP_ENGINE_VERSION` to `3.1.48`.