### PR TITLE
NLP-ENGINE-522 fix test-nlp post-build copy on VS multi-config generators

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.49"
+#define NLP_ENGINE_VERSION "3.1.50"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,11 +15,27 @@ endif()
 if(WIN32)
     add_executable(test-nlp main.cpp)
     target_link_libraries(test-nlp prim kbm consh words lite)
+    # NLP-ENGINE-522: use a generator expression for the source path so
+    # this works under both single-config (Makefiles / Ninja, where
+    # CMAKE_BUILD_TYPE is set at configure time) AND multi-config
+    # generators (Visual Studio, where CMAKE_BUILD_TYPE is empty and the
+    # config is chosen at build time). The original
+    #   ${CMAKE_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}/test-nlp.exe
+    # expanded to `bin//test-nlp.exe` under VS and the copy failed,
+    # taking the whole build with it — which is what blocked
+    # py-package-nlpengine from building locally on Windows.
     add_custom_command(TARGET test-nlp POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}/test-nlp.exe ${CMAKE_SOURCE_DIR}/bin/test-nlp.exe)
+        COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_FILE:test-nlp>
+            ${CMAKE_SOURCE_DIR}/bin/test-nlp.exe)
 else()
     add_executable(test-nlp.exe main.cpp)
     target_link_libraries(test-nlp.exe prim kbm consh words lite ${ICU_LIBRARIES} ${DL_LIBRARY})
+    # NLP-ENGINE-522: the non-Windows branch was copying a file onto
+    # itself (`bin/test-nlp.exe -> bin/test-nlp.exe`). Use the actual
+    # target output path so this self-copy noise goes away too.
     add_custom_command(TARGET test-nlp.exe POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/bin/test-nlp.exe ${CMAKE_SOURCE_DIR}/bin/test-nlp.exe)
+        COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_FILE:test-nlp.exe>
+            ${CMAKE_SOURCE_DIR}/bin/test-nlp.exe)
 endif()


### PR DESCRIPTION
## Summary
The test-nlp target's POST_BUILD command on Windows used `\` to locate the just-built binary:

```cmake
\/bin/\/test-nlp.exe
```

That variable is empty under multi-config generators (Visual Studio is the common one) — the config is chosen at build time, not configure time. The expansion collapses to `bin//test-nlp.exe`, the file does not exist, and the whole build fails with MSB3073 errors out of `test-nlp.vcxproj`. **This blocked py-package-nlpengine from building locally on Windows** (it pulls in the engine as a submodule and triggers `add_subdirectory(test)`).

## Fix
Use `\$<TARGET_FILE:test-nlp>` instead — a generator expression that resolves to the actual on-disk path under both single-config and multi-config generators.

Also fixes the non-Windows branch, which was copying `bin/test-nlp.exe` onto itself (a no-op self-copy that produced confusing build log noise).

Bumps `NLP_ENGINE_VERSION` to `3.1.50`.

## Test plan
- [ ] Build the engine standalone via VS generator on Windows — confirms the post-build step succeeds.
- [ ] `pip install -e .` py-package-nlpengine on Windows (with VCPKG_ROOT set) — should now reach the bindings module.
- [ ] Linux/macOS builds unchanged.