### PR TITLE
NLP-ENGINE-525 emit '\r' escape in St*.cpp char-array codegen

### DIFF
--- a/cs/libconsh/st_gen.cpp
+++ b/cs/libconsh/st_gen.cpp
@@ -124,6 +124,9 @@ for (ii = 0; ii <= seg_curr; ii++)
                case '\n':
                   *fp << _T("'\\n'");
                   break;
+               case '\r':
+                  *fp << _T("'\\r'");
+                  break;
                case '\t':
                   *fp << _T("'\\t'");
                   break;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.50"
+#define NLP_ENGINE_VERSION "3.1.51"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

`st_gen.cpp`'s per-character switch for the engine's compiled string table handled `'\n'`, `'\t'`, `'\\'`, `'\''` but had **no case for `'\r'`**. When a string in the KB contained a carriage-return byte (0x0D), the default branch emitted it verbatim between two single-quote bytes, producing a malformed char literal:

```cpp
'u','n','k','n','o','w','n','\0','<RAW CR>','\n',
```

MSVC silently accepted this. **g++ on Linux** (and clang on macOS, per the same strict-ISO rule that surfaced in NLP-ENGINE-519's bool-conversion bug) rejects it with `error: missing terminating ' character`, which broke local `compile-analyzer.sh` builds in [nlp-engine-linux](https://github.com/VisualText/nlp-engine-linux) and [nlp-engine-mac](https://github.com/VisualText/nlp-engine-mac) on the `telephone` analyzer.

## Fix

One extra case in the switch — emit `'\r'` the same way `'\n'` is handled.

```diff
                case '\n':
                   *fp << _T("'\\n'");
                   break;
+               case '\r':
+                  *fp << _T("'\\r'");
+                  break;
                case '\t':
                   *fp << _T("'\\t'");
                   break;
```

## Validation

Smoke-tested the full linux pipeline end-to-end in WSL against the `telephone` analyzer:

1. `nlp.exe -COMPILE` emits the analyzer C++ tree (with the fix, no raw CR bytes).
2. `compile-analyzer.sh` runs cmake + g++ against the `nlpengine-compile-libs-linux-latest` artifact.
3. Produces `data/telephone/bin/{run,runu,kb,kbu}.so` (47 MB, ICU `--whole-archive` as expected).
4. `nlp.exe -COMPILED -ANA data/telephone -WORK . data/telephone/input/text.txt` loads the .so and runs the analyzer:
   ```
   [bind_sys]: Have cg_CONCEPT=1
   [Loaded knowledge base.]
   ```

Same fix unblocks `nlp-engine-mac` (clang has the same strict-ISO behaviour).

## Version

Bumps engine to **3.1.51**.

## Follow-ups (not in this PR)

- `nlp-engine-{linux,mac,windows}` repos will pick up `nlp.exe` v3.1.51 + the matching `nlpengine-compile-libs-*.zip` via their existing auto-update workflow after the next engine release.
- `py-package-nlpengine` will pick up the fix when it bumps the `nlp-engine` submodule to v3.1.51 (likely batched with the next NLPPlus release).
