### PR TITLE
Create run/ output dir before analyzer-pass codegen

### DIFF
--- a/lite/nlp.cpp
+++ b/lite/nlp.cpp
@@ -1046,6 +1046,19 @@ if (compile)																	// 05/10/00 AM.
 	{
 	// Build a gen object to control code gen and compilation.
 
+	// Ensure the run/ output directory exists before generating into it.
+	// The std::ofstreams below open run/<file> directly, and the C++
+	// runtime does NOT create the parent directory: on a fresh analyzer
+	// (no run/ yet) every open silently fails, so -COMPILE emits no
+	// analyzer-pass code and the staged run library ends up with no
+	// run_analyzer entry point -> empty tree at runtime. Mirror the
+	// outdir/logdir handling in NLP::init and create it up front.
+	_TCHAR rundir[MAXSTR];
+	_stprintf(rundir, _T("%s%c%s"),
+				ana_->getAppdir(), DIR_CH, DEFAULT_RUNDIR);
+	if (!dir_exists(rundir))
+		make_dir(rundir);
+
 	// Set up an output file for code generation.
 	_stprintf(buf, _T("%s%c%s%canalyzer.cpp"),
 				ana_->getAppdir(), DIR_CH, DEFAULT_RUNDIR, DIR_CH);

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.51"
+#define NLP_ENGINE_VERSION "3.1.52"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem

`-COMPILE` (full analyzer) generated only the `kb/` C++ trees, never the `run/` analyzer-pass trees. The resulting compiled library had no `run_analyzer` entry point, so `-COMPILED` produced an **empty final tree and no per-pass dumps** while interpreted mode worked. At runtime `load_compiled()` still succeeded (the library loads and `kb_setup` resolves), so the engine skipped the interpreted fallback and dispatched into a null `run_analyzer`.

## Root cause

`make_analyzer` (`lite/nlp.cpp`) opens `run/<pass>.cpp` via `std::ofstream` **without creating the `run/` directory first**. No C++ standard library creates parent directories on open, so on a fresh analyzer (no `run/` yet) every open silently fails (failbit, no file). The downstream CMake/glob build then links a kb-only library. The failure mode is identical on Linux, macOS, and Windows.

## Fix

Create `run/` up front in the `if (compile)` block using `dir_exists`/`make_dir`, mirroring the existing `outdir`/`logdir` handling in `NLP::init`. 13 lines, no behavior change when `run/` already exists.

## Verification

On macOS, manually pre-creating `run/` before `-COMPILE` makes the engine emit the full pass trees (`run/pass*.cpp`, `run/analyzer.cpp` with a real `run_analyzer`), and `-COMPILED -DEV` then produces a final tree **byte-identical to interpreted mode** (verified end-to-end with the telephone analyzer producing the expected `_telephone` node). This patch performs exactly that directory creation inside the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Version

Bumps `NLP_ENGINE_VERSION` 3.1.51 -> 3.1.52 (nlp/main.cpp).
