### PR TITLE
NLP-ENGINE-526 implement make_dir / rm_dir on Linux (and macOS)

### DIFF
--- a/cs/libprim/dir.cpp
+++ b/cs/libprim/dir.cpp
@@ -10,7 +10,11 @@ All rights reserved.
 *
 *******************************************************************************/
 #include "StdAfx.h"
-#ifndef LINUX
+#ifdef LINUX
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#else
 #include <direct.h>
 #endif
 #include <stdlib.h>
@@ -30,7 +34,10 @@ make_dir(_TCHAR *dir)
 {
 if (!dir || !*dir)
 	return false;
-#ifndef LINUX
+#ifdef LINUX
+if (mkdir(dir, 0755) == 0)
+	return true;
+#else
 if (_tmkdir(dir) == 0)
 	return true;
 #endif
@@ -50,7 +57,10 @@ rm_dir(_TCHAR *dir)
 {
 if (!dir || !*dir)
 	return false;
-#ifndef LINUX
+#ifdef LINUX
+if (rmdir(dir) == 0)
+	return true;
+#else
 if (_trmdir(dir) == 0)
 	return true;
 #endif

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.52"
+#define NLP_ENGINE_VERSION "3.1.53"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Follow-up to **PR #637 / v3.1.52**. That PR added `make_dir(rundir)` to `NLP::make_analyzer` so `-COMPILE` creates `run/` before opening the analyzer-pass output files. The Windows path of that fix is correct; the **Linux and macOS paths silently no-op'd** because `cs/libprim/dir.cpp::make_dir` had never been implemented outside Windows:

```cpp
LIBPRIM_API bool
make_dir(_TCHAR *dir)
{
if (!dir || !*dir) return false;
#ifndef LINUX
if (_tmkdir(dir) == 0) return true;
#endif
return false;                       // every non-Windows build
}
```

Same shape for `rm_dir`. Both `CMakeLists.txt` files in this repo set `-DLINUX` on the macOS branch too (`if(WIN32) ... else()`), so this affects **both Linux and macOS**.

## Symptom

On Linux v3.1.52, with the `telephone` analyzer:

1. `nlp.exe -COMPILE` populates only `data/telephone/kb/`. The `run/` directory is never created.
2. `compile-analyzer.sh` cmake-globs `run/*.cpp` + `kb/*.cpp`, finds only `kb/*`, and links a `run.so` that exports `kb_setup` but **not** `run_analyzer`.
3. `nlp.exe -COMPILED` loads the library (no dlopen error), prints `[Loaded knowledge base.]`, then dispatch silently misses `dlsym("run_analyzer")` and the analyzer "runs" in microseconds producing an empty `final.tree`.

Confirmed by pre-creating `data/telephone/run/` manually before `nlp.exe -COMPILE`: the engine then emits `run/analyzer.cpp` (with `extern "C" run_analyzer`), `run/pass2.cpp` ... `run/pass9.cpp`, the `nm -D` symbol shows up in the linked .so, and `-COMPILED -DEV` produces the per-pass tree files matching interpreted mode.

## Why the macOS PR-#637 testing reported success

PR #637's verification on macOS reported "manually pre-creating `run/` before `-COMPILE` makes the engine emit the full pass trees", which is exactly the workaround above and confirms the same underlying bug. The engine-side `make_dir(rundir)` call added by that PR doesn't actually create anything on macOS for the same reason it doesn't on Linux. Apparent end-to-end success on macOS likely came from `run/` being left over from a prior interactive run or other side effect, not from `make_dir` actually working.

## Fix

Give `make_dir` and `rm_dir` POSIX implementations under `#ifdef LINUX`:

```cpp
#ifdef LINUX
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>
#else
#include <direct.h>
#endif

LIBPRIM_API bool
make_dir(_TCHAR *dir)
{
if (!dir || !*dir) return false;
#ifdef LINUX
if (mkdir(dir, 0755) == 0) return true;
#else
if (_tmkdir(dir) == 0) return true;
#endif
return false;
}
```

Symmetric change for `rm_dir`. **No Windows-path behavior change** — the `#else` branch is byte-identical to the prior code.

## Verification

- Root-cause reproduced on Linux with v3.1.52 by manually pre-creating `run/` and confirming the codegen-then-build-then-run pipeline produces a non-empty final tree.
- Localized POSIX-shim. Code review of the diff is the validation path; full build + smoke is deferred to CI.

## Version

Bumps engine to **3.1.53**.

## Follow-ups (not in this PR)

- After v3.1.53 ships and the platform repos auto-update, smoke compile-mode end-to-end on both Linux and macOS to confirm the per-pass tree output matches interpreted mode.
- `py-package-nlpengine` submodule bump to v3.1.53 (next NLPPlus release).
