### PR TITLE
NLP-ENGINE-523 make NLP_ENGINE::close() idempotent

### DIFF
--- a/lite/nlp_engine.cpp
+++ b/lite/nlp_engine.cpp
@@ -533,6 +533,17 @@ int NLP_ENGINE::close()
     // Compiled analyzers: need to close the user.dll for the application also.
     // Shutdown the runtime manager.
 
+    // NLP-ENGINE-523: make close() idempotent so it can be called explicitly
+    // before ~NLP_ENGINE without double-tearing-down. The Python binding in
+    // py-package-nlpengine exposes this as Engine.close() so callers (and
+    // Engine.__del__ / __exit__) can deterministically release the open
+    // <workfolder>/logs/cgerr.log file handle before TemporaryDirectory
+    // cleanup runs at interpreter shutdown — on Windows that handle blocks
+    // the temp-dir delete and surfaces as PermissionError, currently
+    // band-aided in NLPPlus via TemporaryDirectory(ignore_cleanup_errors=True).
+    if (!m_vtrun)
+        return 0;
+
 //    VTRun::deleteVTRun(VTRun_Ptr);                      // 9/27/20 AM.
 //    VTRun_Ptr = 0;      // Clear out static var.        // 09/27/20 AM.
     VTRun::deleteVTRun(m_vtrun);    // [DEGLOB]	// 10/15/20 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.54"
+#define NLP_ENGINE_VERSION "3.1.55"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Background

NLPPlus's `Engine(working_folder=None, ...)` creates a `tempfile.TemporaryDirectory` to hold a freshly-initialized analyzer tree. On Windows, when the Python process exits, `TemporaryDirectory.__del__` runs at atexit and tries to `shutil.rmtree(<workfolder>)`. The engine's global `cgerr` (a `std::_t_ofstream *` in `cs/libconsh/cg_global.cpp`) still holds `<workfolder>/logs/cgerr.log` open at that point — nanobind hasn't torn down the C++ `NLP_ENGINE` instance yet — and Windows refuses to delete a directory that contains an open file. Symptom: `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`.

The current band-aid (py-package-nlpengine [PR #24](https://github.com/VisualText/py-package-nlpengine/pull/24)) is `TemporaryDirectory(prefix=..., ignore_cleanup_errors=True)`, which silences the error but leaks the temp dir on disk. The proper fix is to let Python call `Engine.close()` deterministically before the temp dir cleanup runs.

## What this PR does

Makes `NLP_ENGINE::close()` (`lite/nlp_engine.cpp`) idempotent so it can be called any number of times safely — once by the explicit `Engine.close()` from Python, once by `~NLP_ENGINE` on the way out, and any defensive double-calls in between.

```diff
 int NLP_ENGINE::close()
 {
+    if (!m_vtrun)
+        return 0;
+
     VTRun::deleteVTRun(m_vtrun);
     m_vtrun = 0;
     std::_t_cout << _T("[AFTER VTRUN DELETE: ]") << std::endl;
     return 0;
 }
```

`VTRun::deleteVTRun(nullptr)` is already a safe no-op (returns false), so a double call wouldn't double-free today, but the diagnostic message would print twice and any future cleanup added inside this function risks a real double-tear-down. The guard makes the contract explicit.

## What this enables (separate PR in py-package-nlpengine)

1. `bindings.cpp` adds `.def("close", &NLP_ENGINE::close, ...)`.
2. `NLPPlus.Engine` gets `close()`, `__enter__`, `__exit__`, and an `__del__` that calls `self.engine.close()` *before* `self.tmpdir.cleanup()`.
3. After that lands, the `ignore_cleanup_errors=True` band-aid becomes defense-in-depth (for users who don't context-manage their engine) rather than load-bearing.

## Version

Bumps engine to **3.1.55**.

## Out of scope

A deeper refactor of `cgerr` itself — making it a per-CG instance member instead of a global, or lazily reopening per-write — would also fix the underlying handle-lifetime issue but touches dozens of `*cgerr << ...` call sites across `cs/libconsh` and `cs/libqconsh`. The idempotent-close approach gets the same end-user outcome (no `PermissionError`) for ~12 lines of total change across two repos.
