### PR TITLE
Track upstream branches in .gitmodules (for nightly submodule auto-bump)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "analyzers"]
 	path = analyzers
 	url = https://github.com/VisualText/analyzers.git
+	branch = master
 	
 [submodule "vckpg"]
 	path = vcpkg


### PR DESCRIPTION
Adds `branch =` lines to the VisualText submodules so `git submodule update --remote` follows the correct branch. Prerequisite for the nightly submodule auto-bump workflow. vcpkg is intentionally left untouched (stays pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)