### PR TITLE
feat(lite): allow digits in underscore-prefixed NLP++ token names

### DIFF
--- a/data/rfb/spec/bigtok.nlp
+++ b/data/rfb/spec/bigtok.nlp
@@ -96,7 +96,7 @@ _soRULES [base layer=(_startMark)] <- \@ RULES [t] @@
 	rfanonlit(2)
 	single()
 @RULES
-_NONLIT [base] <- \_ _xWILD [s one match=(_xALPHA _xEMOJI)] @@
+_NONLIT [base] <- \_ _xWILD [s plus match=(_xALPHA _xEMOJI _xNUM)] @@	# 06/11/26 DD. plus + _xNUM: allow digits in names (_B2, _34, _C25g).
 
 @RULES
 _ARROW [base] <- \< \- @@

--- a/lite/postrfa.cpp
+++ b/lite/postrfa.cpp
@@ -520,8 +520,8 @@ return true;
 * CR:		11/10/98 AM.
 * SUBJ:	Create a semantic object to hold nonlit node's proper name.
 * RET:	True if ok, else false.
-* RULE:	_NONLIT <- \_ _xALPHA @@
-* FORM:	postRFAnonlit("2") -- arg is for the rhs alphabetic token.
+* RULE:	_NONLIT <- \_ _xWILD [s plus match=(_xALPHA _xEMOJI _xNUM)] @@
+* FORM:	postRFAnonlit("2") -- arg is for the rhs alpha/emoji/numeric token(s).
 * NOTE:	Could have a generic glom text action, but keeping this for
 *			RFA-specific semantic work, if any.
 ********************************************/
@@ -593,31 +593,28 @@ while (--num1 > 0)
 coll1 = colls;
 
 
-// Get needed stuff from each collect.
-Node<Pn> *nelt;
-nelt = coll1->Down();
+// Get needed stuff from the collect.  The name may span one or more
+// adjacent alpha/numeric tokens (eg, _C25g => "_" "C" "25" "g").	// 06/11/26 DD.
+Node<Pn> *nelts, *nend;
+nelts = coll1->Down();
+nend  = coll1->eDown();
 
 if (Verbose())
 	*gout << _T("   [Executing RFA nonlit action.]") << std::endl;
 
+if (!nelts || !nend)
+	return false;
+
 if (Debug())
 	{
-	*gout << _T("token=") << *nelt << std::endl;
+	*gout << _T("token=") << *nelts << std::endl;
 	}
 
 ////////////////////////
 // BUILD SEM FOR NONLIT
 ////////////////////////
 
-// GET DATA.
-Pn *pn;
-_TCHAR *text;
-long len;
-pn = nelt->getData();
-text = pn->getText();
-len = pn->getEnd() - pn->getStart() + 1;
-
-// Glom underscore back onto node's text.
+// Glom underscore back onto the gathered token text.
 _TCHAR buf[MAXSTR];					// Build string in here.
 _TCHAR *ptr;
 long count;
@@ -625,8 +622,21 @@ count = MAXSTR;					// Track space left in buffer.
 buf[0] = '\0';
 ptr = &(buf[0]);					// Track first empty loc in buffer.
 strcat_e(ptr, _T("_"), count);
-if (!strncat_e(ptr, text, len, count))
-	return false;
+
+// Traverse the matched tokens, gathering their covered text.
+Node<Pn> *bound;
+bound = nend->Right();			// One past the last matched token.
+Pn *pn;
+_TCHAR *text;
+long len;
+for (; nelts != bound; nelts = nelts->Right())
+	{
+	pn = nelts->getData();
+	text = pn->getText();
+	len = pn->getEnd() - pn->getStart() + 1;
+	if (!strncat_e(ptr, text, len, count))
+		return false;
+	}
 
 _TCHAR *name;
 //name = make_str(buf);		// 11/19/98 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.2.1"
+#define NLP_ENGINE_VERSION "3.3.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

NLP++ nonliteral names (tokens starting with `_`) previously accepted **only alphabetic characters** after the underscore, so names like `_B2`, `_34`, or `_C25g` failed to parse. This PR allows digits in those names.

The tokenizer splits such a name into adjacent alpha/numeric tokens (`_C25g` → `_` `C` `25` `g`), but the `_NONLIT` rule in the self-hosted RFA grammar matched **exactly one** alphabetic token after the `_`.

## Changes

- **`data/rfb/spec/bigtok.nlp`** — the live `_NONLIT` tokenization rule:
  ```diff
  -_NONLIT [base] <- \_ _xWILD [s one match=(_xALPHA _xEMOJI)] @@
  +_NONLIT [base] <- \_ _xWILD [s plus match=(_xALPHA _xEMOJI _xNUM)] @@
  ```
  - Added `_xNUM` so digit tokens after `_` match.
  - `one` (exactly one token) → `plus` (one or more), so multi-token names gather.
- **`lite/postrfa.cpp`** (`postRFAnonlit`) — concatenate the covered text of **all** matched tokens (`Down`..`eDown`) instead of just the first, so `_` + `C` + `25` + `g` reassembles into `_C25g`.
- **`nlp/main.cpp`** — bump `NLP_ENGINE_VERSION` to `3.3.0`.

## Note on approach

The obvious target, the hardcoded grammar in `lite/rfa.cpp`, is **legacy/bootstrap code** with no runtime effect on user rule files. The grammar that actually parses rule files is self-hosted as NLP++ passes under `data/rfb/spec/` (`bigtok.nlp`). Edits to `rfa.cpp`/`pat.cpp` were tried first, had no effect, and were reverted.

## Verification

- `_B2`, `_34`, `_C25g` create correctly-named nodes (confirmed in `final.tree`).
- Single-trailing-digit (`_tag2`) and mixed (`_t2ag42`) names parse and fire rules.
- Regression: tutorials 04/05/07 and the full **parse-en-us** analyzer (thousands of `_noun`/`_np`/`_clause`… nonliteral rules) build and parse cleanly with no errors.

Minor behavior note: because `one`→`plus`, adjacent emojis in a name now group into one name (e.g. `_😀😀`) — a negligible, arguably-more-correct edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
