### PR TITLE
feat(lite): add loadkbb and loaddict NLP++ functions

### DIFF
--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -398,6 +398,10 @@ switch (fnid)																	// 12/21/01 AM.
 	case FNLJ:
 	case FNlj:
 		return fnLj(args,nlppp,/*UP*/sem);								// 10/02/00 AM.
+	case FNloaddict:
+		return fnLoaddict(args,nlppp,/*UP*/sem);						// 06/11/26 DD.
+	case FNloadkbb:
+		return fnLoadkbb(args,nlppp,/*UP*/sem);						// 06/11/26 DD.
 	case FNlogten:
 		return fnLogten(args,nlppp,/*UP*/sem);							// 04/29/04 AM.
 	case FNrandomint:
@@ -10493,6 +10497,121 @@ if (!dir)
 CG *cg = parse->getAna()->getCG();
 
 bool ok = cg->writeKB(dir);
+
+sem = new RFASem(ok ? 1LL : 0LL);
+return true;
+}
+
+
+/********************************************
+* FN:		FNLOADKBB
+* CR:		06/11/26 DD.
+* SUBJ:		Load a single "*.kbb" file from kb/user into the KB.
+* RET:		True if ok, else false.
+*			UP num - 1 if the file was loaded, else 0.
+* FORMS:	loadkbb(filename)
+* NOTE:		filename is the name of a file in the app's kb/user directory,
+*			eg loadkbb("extra.kbb").
+********************************************/
+
+bool Fn::fnLoadkbb(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+_TCHAR *name1=0;
+
+if (!Arg::str1(_T("loadkbb"), /*UP*/ (DELTS*&)args, name1))
+	return false;
+if (!Arg::done((DELTS*)args, _T("loadkbb"),parse))
+	return false;
+
+if (!name1)
+	{
+	_stprintf(Errbuf,_T("[loadkbb: Warning. Given no filename.]"));
+	return parse->errOut(false); // UNFIXED
+	}
+
+// Need to get the current KB.
+CG *cg = parse->getAna()->getCG();
+
+// Resolve the file relative to the app's kb/user directory.
+std::filesystem::path p(cg->getAppdir());
+p /= _T("kb");
+p /= _T("user");
+p /= name1;
+
+if (!std::filesystem::exists(p))
+	{
+	_stprintf(Errbuf,_T("[loadkbb: File not found in kb/user=%s]"),name1);
+	return parse->errOut(false); // UNFIXED
+	}
+
+bool ok = cg->readKBB(p.string());
+
+sem = new RFASem(ok ? 1LL : 0LL);
+return true;
+}
+
+
+/********************************************
+* FN:		FNLOADDICT
+* CR:		06/11/26 DD.
+* SUBJ:		Load a single "*.dict" file from kb/user into the KB.
+* RET:		True if ok, else false.
+*			UP num - 1 if the file was loaded, else 0.
+* FORMS:	loaddict(filename)
+* NOTE:		filename is the name of a file in the app's kb/user directory,
+*			eg loaddict("extra.dict").
+********************************************/
+
+bool Fn::fnLoaddict(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+_TCHAR *name1=0;
+
+if (!Arg::str1(_T("loaddict"), /*UP*/ (DELTS*&)args, name1))
+	return false;
+if (!Arg::done((DELTS*)args, _T("loaddict"),parse))
+	return false;
+
+if (!name1)
+	{
+	_stprintf(Errbuf,_T("[loaddict: Warning. Given no filename.]"));
+	return parse->errOut(false); // UNFIXED
+	}
+
+// Need to get the current KB.
+CG *cg = parse->getAna()->getCG();
+
+// Resolve the file relative to the app's kb/user directory.
+std::filesystem::path p(cg->getAppdir());
+p /= _T("kb");
+p /= _T("user");
+p /= name1;
+
+if (!std::filesystem::exists(p))
+	{
+	_stprintf(Errbuf,_T("[loaddict: File not found in kb/user=%s]"),name1);
+	return parse->errOut(false); // UNFIXED
+	}
+
+// Gather the kb/user "*.kbb" files so the dictionary can be paired with its
+// ambiguity KB (same stem), mirroring how readKB loads dictionaries.
+std::vector<std::filesystem::path> kbfiles;
+cg->openKBB(kbfiles);
+
+bool ok = cg->readDict(p.string(), kbfiles);
 
 sem = new RFASem(ok ? 1LL : 0LL);
 return true;

--- a/lite/fn.h
+++ b/lite/fn.h
@@ -957,6 +957,8 @@ static bool fnStruniquechars(
 	static bool fnStrunescape(Delt<Iarg>*,Nlppp*,RFASem*&);			// 07/24/01 DD.
 	static bool fnKbdumptree(Delt<Iarg>*,Nlppp*,RFASem*&);			// 08/06/01 AM.
 	static bool fnWriteKB(Delt<Iarg>*,Nlppp*,RFASem*&);
+	static bool fnLoadkbb(Delt<Iarg>*,Nlppp*,RFASem*&);				// 06/11/26 DD.
+	static bool fnLoaddict(Delt<Iarg>*,Nlppp*,RFASem*&);			// 06/11/26 DD.
 	static bool fnStriscaps(Delt<Iarg>*,Nlppp*,RFASem*&);
 	static bool fnStrisupper(Delt<Iarg>*,Nlppp*,RFASem*&);			// 11/20/01 AM.
 	static bool fnStrislower(Delt<Iarg>*,Nlppp*,RFASem*&);			// 11/20/01 AM.

--- a/lite/func_defs.h
+++ b/lite/func_defs.h
@@ -126,6 +126,8 @@ enum funcDef
 	FNlistnode,
 	FNLJ,
 	FNlj,
+	FNloaddict,	// 06/11/26 DD.
+	FNloadkbb,	// 06/11/26 DD.
 	FNlogten,	// 04/29/04 AM.
 	FNlook,
 	FNlookup,

--- a/lite/funcs.h
+++ b/lite/funcs.h
@@ -120,6 +120,8 @@ _T("listadd"),
 _T("listnode"),
 _T("LJ"),
 _T("lj"),
+_T("loaddict"),	// 06/11/26 DD.
+_T("loadkbb"),		// 06/11/26 DD.
 _T("logten"),		// 04/29/04 AM.
 _T("look"),
 _T("lookup"),

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.3.0"
+#define NLP_ENGINE_VERSION "3.4.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Adds two NLP++ built-in functions that expose the engine's existing KB-file loaders to rule writers. Each takes the **name of a file in the analyzer's `kb/user` directory** and loads it into the conceptual grammar (the in-memory KB):

- **`loadkbb(file_str)`** — load an indented `*.kbb` hierarchy file (via `CG::readKBB`)
- **`loaddict(file_str)`** — load a flat `word attr=val ...` `*.dict` file (via `CG::readDict`), pairing it with a same-stem `*.kbb` ambiguity KB the way `readKB` does at startup

Both resolve the argument as `<appdir>/kb/user/<file_str>`, return `1` on success / `0` otherwise, and emit a warning if the file is not found.

## Changes

- `lite/funcs.h` / `lite/func_defs.h` — register `loaddict` / `loadkbb` (kept index-synced, since the function hash table derives each id from array position)
- `lite/fn.h` — declare `fnLoadkbb` / `fnLoaddict`
- `lite/fn.cpp` — add dispatch cases and implementations (modeled on `fnTake` / `fnWriteKB`)

## Testing

- `cmake --build . --config Release` compiles `fn.cpp` / `vtrun.cpp` and links `nlp.exe` with no errors, on the `master` base.

## Docs

User-facing help (markdown) is in a companion PR on the [visualtext-files](https://github.com/ddehilster/visualtext-files) repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)