### PR TITLE
feat(lite): add pnpush NLP++ parse-tree function (3.5.0)

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -1660,6 +1660,11 @@ public:
 	static RFASem *pnmove(Nlppp*,NODE*,RFASem*,RFASem*);      // 10/06/13 AM.
 	static RFASem *pnmove(Nlppp*,RFASem*,RFASem*,RFASem*);    // 10/06/13 AM.
 
+	static RFASem *pnpush(Nlppp*,NODE*,_TCHAR*);             // 06/14/26 AM.
+	static RFASem *pnpush(Nlppp*,RFASem*,_TCHAR*);           // 06/14/26 AM.
+	static RFASem *pnpush(Nlppp*,NODE*,RFASem*);             // 06/14/26 AM.
+	static RFASem *pnpush(Nlppp*,RFASem*,RFASem*);           // 06/14/26 AM.
+
 	static bool dbopen(Nlppp*,_TCHAR*,_TCHAR*,_TCHAR*);					// 06/15/02 AM.
 	static bool dbopen(Nlppp*,RFASem*,_TCHAR*,_TCHAR*);					// 06/15/02 AM.
 	static bool dbopen(Nlppp*,_TCHAR*,RFASem*,_TCHAR*);					// 06/15/02 AM.

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -6160,6 +6160,103 @@ return Arun::group(nlppp,from,to,name);
 
 
 /********************************************
+* FN:		PNPUSH
+* CR:		06/14/26 AM.
+* SUBJ:	Interpose a new suggested node above a parse tree node.
+* RET:	sem - The new (parent) node, else 0.
+* FORMS:	pnpush(pnode, name_str)
+*	Builds a new node named name_str in the place of pnode, and makes
+*	pnode (keeping its own subtree) the single child of the new node.
+*	Implemented as a single-node group(), so it carries the same
+*	rule-scanner bookkeeping and is safe to call from @POST.
+********************************************/
+
+RFASem *Arun::pnpush(
+	Nlppp *nlppp,
+	NODE *pn_nd,
+	_TCHAR *name_str
+	)
+{
+Node<Pn> *pn_node = (Node<Pn> *) pn_nd;
+
+if (!pn_node || !name_str || !*name_str)
+	return 0;
+
+if (*name_str != '_')
+	{
+	_stprintf(Errbuf,_T("[pnpush: Only nonliteral node name allowed.]"));
+	errOut(false); // UNFIXED
+	return 0;
+	}
+
+Parse *parse = nlppp->getParse();
+_TCHAR *name1=0;
+parse->internStr(name_str, /*UP*/name1);	// Intern the name.
+
+// pnpush == group a single node under a new suggested parent.
+Node<Pn> *new_node = Pat::group(pn_node, pn_node, name1, nlppp);
+if (!new_node)
+	return 0;
+
+return new RFASem(new_node);	// Return the new (parent) node.
+}
+
+// VARIANT
+RFASem *Arun::pnpush(
+	Nlppp *nlppp,
+	RFASem *pn_sem,
+	_TCHAR *name_str
+	)
+{
+if (!pn_sem)
+	return 0;
+NODE *pn_nd = pn_sem->sem_to_node();
+delete pn_sem;
+return pnpush(nlppp,pn_nd,name_str);
+}
+
+// VARIANT
+RFASem *Arun::pnpush(
+	Nlppp *nlppp,
+	NODE *pn_nd,
+	RFASem *name_sem
+	)
+{
+if (!name_sem)
+	return 0;
+_TCHAR *name_str = name_sem->sem_to_str();
+delete name_sem;
+return pnpush(nlppp,pn_nd,name_str);
+}
+
+// VARIANT
+RFASem *Arun::pnpush(
+	Nlppp *nlppp,
+	RFASem *pn_sem,
+	RFASem *name_sem
+	)
+{
+if (!pn_sem)
+	{
+	if (name_sem)
+		delete name_sem;
+	return 0;
+	}
+if (!name_sem)
+	{
+	if (pn_sem)
+		delete pn_sem;
+	return 0;
+	}
+NODE *pn_nd = pn_sem->sem_to_node();
+delete pn_sem;
+_TCHAR *name_str = name_sem->sem_to_str();
+delete name_sem;
+return pnpush(nlppp,pn_nd,name_str);
+}
+
+
+/********************************************
 * FN:		EXCISE
 * CR:		05/11/00 AM.
 * SUBJ:	Runtime variant of excise post action.

--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -488,6 +488,8 @@ switch (fnid)																	// 12/21/01 AM.
 		return fnPnnext(args,nlppp,/*UP*/sem);							// 10/18/00 AM.
 	case FNpnprev:
 		return fnPnprev(args,nlppp,/*UP*/sem);							// 10/18/00 AM.
+	case FNpnpush:
+		return fnPnpush(args,nlppp,/*UP*/sem);							// 06/14/26 AM.
 	case FNpnpushval:
 		return fnPnpushval(args,nlppp,/*UP*/sem);					// 12/12/14 AM.
 	case FNpnremoveval:
@@ -13626,6 +13628,88 @@ else
 	tree->insertLeft(*pn_node, *pos_node);
 
 sem = new RFASem(pn_node);	// Return the node.
+return true;
+}
+
+
+/********************************************
+* FN:		FNPNPUSH
+* CR:		06/14/26 AM.
+* SUBJ:	Interpose a new suggested node above a parse tree node.
+* RET:	True if ok, else false.
+* FORMS:	pnpush(pnode, name_str)
+*	Builds a new node named name_str in the place of pnode, and makes
+*	pnode (keeping its own subtree) the single child of the new node.
+*	name_str must be a nonliteral (suggested) name, beginning with '_'.
+********************************************/
+
+bool Fn::fnPnpush(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	/*UP*/
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+RFASem *pn_sem;
+_TCHAR *name_str=0;
+
+if (!Arg::sem1(_T("pnpush"),nlppp,(DELTS*&)args,pn_sem))
+	return false;
+if (!Arg::str1(_T("pnpush"), /*UP*/ (DELTS*&)args, name_str))
+	return false;
+if (!Arg::done((DELTS*)args, _T("pnpush"),parse))
+	return false;
+
+if (!pn_sem)
+	{
+	_stprintf(Errbuf,_T("[pnpush: Warning. Given no pnode.]"));
+	return parse->errOut(true); // UNFIXED
+	}
+
+if (!name_str)
+	{
+	_stprintf(Errbuf,_T("[pnpush: Warning. Given no node name.]"));
+	return parse->errOut(true); // UNFIXED
+	}
+
+if (pn_sem->getType() != RSNODE)
+	{
+	_stprintf(Errbuf,_T("[pnpush: Bad semantic arg.]"));
+	return parse->errOut(false); // UNFIXED
+	}
+
+Node<Pn> *pn_node = pn_sem->sem_to_node();
+
+if (!pn_node)
+	{
+	_stprintf(Errbuf,_T("[pnpush: Couldn't fetch node.]"));
+	return parse->errOut(false); // UNFIXED
+	}
+
+if (*name_str != '_')
+	{
+	_stprintf(Errbuf,_T("[pnpush: Only nonliteral node name allowed.]"));
+	return parse->errOut(false); // UNFIXED
+	}
+
+// pnpush is "group a single node under a new suggested parent."
+// Reuse Pat::group so the parse-tree splice AND the rule-scanner
+// bookkeeping (first_/last_/rightmost_/restart_) are handled exactly
+// as the group() builtin does -- needed for use in @POST regions.
+_TCHAR *name1=0;
+parse->internStr(name_str, /*UP*/name1);	// Intern the name.
+Node<Pn> *new_node = Pat::group(pn_node, pn_node, name1, nlppp);
+
+if (!new_node)
+	{
+	_stprintf(Errbuf,_T("[pnpush: Couldn't build node.]"));
+	return parse->errOut(false); // UNFIXED
+	}
+
+sem = new RFASem(new_node);	// Return the new (parent) node.
 return true;
 }
 

--- a/lite/fn.h
+++ b/lite/fn.h
@@ -1003,6 +1003,7 @@ static bool fnStruniquechars(
 	static bool fnLevenshtein(Delt<Iarg>*,Nlppp*,RFASem*&);		// 03/06/07 AM.
 	static bool fnPninsert(Delt<Iarg>*,Nlppp*,RFASem*&);        // 07/14/08 AM.
 	static bool fnPnmove(Delt<Iarg>*,Nlppp*,RFASem*&);          // 10/06/13 AM.
+	static bool fnPnpush(Delt<Iarg>*,Nlppp*,RFASem*&);          // 06/14/26 AM.
 
 	static bool fnPermuten(Delt<Iarg>*,Nlppp*,RFASem*&);			// 03/10/04 AM.
 	static bool fnLogten(Delt<Iarg>*,Nlppp*,RFASem*&);          // 04/29/04 AM.

--- a/lite/func_defs.h
+++ b/lite/func_defs.h
@@ -171,6 +171,7 @@ enum funcDef
 	FNpnname,
 	FNpnnext,
 	FNpnprev,
+	FNpnpush,		// 06/14/26 AM.
 	FNpnpushval,	// 12/12/14 AM.
 	FNpnremoveval,
 	FNpnrename,

--- a/lite/funcs.h
+++ b/lite/funcs.h
@@ -165,6 +165,7 @@ _T("pnmove"),	   // 10/06/13 AM.
 _T("pnname"),
 _T("pnnext"),
 _T("pnprev"),
+_T("pnpush"),	// 06/14/26 AM.
 _T("pnpushval"),	// 12/12/14 AM.
 _T("pnremoveval"),
 _T("pnrename"),

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.4.0"
+#define NLP_ENGINE_VERSION "3.5.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Adds a new NLP++ parse-tree function **`pnpush(pnode, name_str)`**: it creates a new *suggested* node named `name_str` in the place of `pnode`, and re-parents `pnode` (keeping its whole subtree) as the single child of that new node. Returns the new parent node.

```
   before              after
   ─────               ─────
   pnode               _name_str
     └─ ...      →         └─ pnode
                                └─ ...
```

## Implementation

`pnpush` is "group a single node under a new parent", so it delegates to the engine's proven `Pat::group(pnode, pnode, name, nlppp)`. This was the key correctness decision: a naive `replaceSubs`+`linkNodes` splices the tree correctly but skips the rule-scanner bookkeeping (`first_`/`last_`/`rightmost_`/`restart_`), which would restart the scanner into a detached child node and risk an infinite loop in `@POST`. Reusing `group()` handles all of that, so `pnpush` is safe in both `@POST` and `@CODE`.

Wired through every integration point:
- `funcs.h` / `func_defs.h` — name + enum (parallel tables aligned)
- `fn.h` / `fn.cpp` — interpreted dispatch + `fnPnpush`
- `Arun.h` / `Arun.cpp` — 4 compiled-mode `Arun::pnpush` overloads (NODE/RFASem × string/RFASem)

Bumps `NLP_ENGINE_VERSION` to **3.5.0**.

## Testing

- `nlp.exe` builds clean (0 warnings / 0 errors); `nlp.exe --version` → `3.5.0`.
- Ran a full real-world Portuguese parser (`parse-pt-br`) that uses `pnpush` per-word in a `@POST` (`lexico` pass) to attach part-of-speech nodes. Completed with exit 0, empty `err.log`, no infinite loop.
- Output parse tree is structurally correct: every token is wrapped in its POS node (`_determinante > A`, `_substantivo > cidade`, `_verbo > acordava`, `_adjetivo > fria`, …) with all dictionary attributes preserved on the token, and all downstream passes (`_SN`/`_SP`/`_SV`/`_FRASE`) built correctly on top.

Compiled-mode overloads compile cleanly; runtime-tested in interpreted mode (a `-COMPILED` round-trip requires compiling the analyzer to native libs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)