### PR TITLE
feat(lite): pnpush copies pnode attributes to the new parent node (3.5.1)

### DIFF
--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -6198,6 +6198,12 @@ Node<Pn> *new_node = Pat::group(pn_node, pn_node, name1, nlppp);
 if (!new_node)
 	return 0;
 
+// Copy all of pn_node's attributes up onto the new parent node.
+Dlist<Ipair> *fmlist = pn_node->getData()->getDsem();
+Dlist<Ipair> *tolist = new_node->getData()->getDsem();
+Var::copy_vars(fmlist, /*DU*/ tolist);
+new_node->getData()->setDsem(tolist);
+
 return new RFASem(new_node);	// Return the new (parent) node.
 }
 

--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -13709,6 +13709,12 @@ if (!new_node)
 	return parse->errOut(false); // UNFIXED
 	}
 
+// Copy all of pn_node's attributes up onto the new parent node.
+Dlist<Ipair> *fmlist = pn_node->getData()->getDsem();
+Dlist<Ipair> *tolist = new_node->getData()->getDsem();
+Var::copy_vars(fmlist, /*DU*/ tolist);
+new_node->getData()->setDsem(tolist);
+
 sem = new RFASem(new_node);	// Return the new (parent) node.
 return true;
 }

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.5.0"
+#define NLP_ENGINE_VERSION "3.5.1"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Follow-up to #653. When `pnpush(pnode, name_str)` interposes a new suggested parent above `pnode`, it now **copies all of `pnode`'s attributes up onto the new parent node**, so the parent carries every attribute the child had at push time.

## Implementation

After `Pat::group` builds the new parent, both the interpreted (`fn.cpp`) and compiled (`Arun.cpp`) paths copy the pushed node's attribute (Dsem var) list up via `Var::copy_vars` — the same mechanism the engine's `pncopyvars` builtin uses:

```cpp
Dlist<Ipair> *fmlist = pn_node->getData()->getDsem();
Dlist<Ipair> *tolist = new_node->getData()->getDsem();
Var::copy_vars(fmlist, /*DU*/ tolist);
new_node->getData()->setDsem(tolist);
```

Bumps `NLP_ENGINE_VERSION` to **3.5.1**.

## Testing

- `nlp.exe` builds clean (0 warnings / 0 errors); `nlp.exe --version` → `3.5.1`.
- Re-ran the `parse-pt-br` analyzer (uses `pnpush` per-word in a `@POST`): exit 0, empty `err.log`. Every POS parent node (`_determinante`, `_substantivo`, `_preposicao`, …) now carries the full attribute set copied from its token, e.g. `_determinante [...] ("cap" 1) ("s" 1) ("pron" 1) ("art" 1) ("pos num" 4) ("meaning" concept:"a")`.

Note: the parent receives every attribute present **at push time**; attributes the analyzer assigns to the child *after* the push (e.g. `"texto"`) remain on the child only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)