### PR TITLE
feat(lite): add -COMPILEANA analyzer-only compile mode (3.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ You can get help on nlp.exe:
       usage: nlp [--version] [--help]
                  [-INTERP][-COMPILED] INTERP is the default
                  [-COMPILE] compile analyzer and KB to C++ (does not run analyzer)
+                 [-COMPILEKB] compile only the KB to C++ (does not load grammar or run analyzer)
+                 [-COMPILEANA] compile only the analyzer to C++ (does not regenerate the KB or run analyzer)
                  [-ANA analyzer] name or path to NLP++ analyzer folder
                  [-IN infile] input text file path
                  [-OUT outdir] output directory
@@ -45,6 +47,8 @@ Switch | Function
 ------------ | -------------
 -INTERP / -COMPILED | Runs NLP++ code interpreted or compiled
 -COMPILE | Generates C++ code for the analyzer rules and KB (does not run the analyzer). Use -COMPILED after the C++ is compiled externally to run the compiled analyzer.
+-COMPILEKB | Generates C++ code for the KB only (does not load the grammar or run the analyzer). Use when only the KB changed.
+-COMPILEANA | Generates C++ code for the analyzer rules only, skipping KB regeneration (does not run the analyzer). Use when only the rules changed and the KB is already compiled.
 -ANA | name of the analyzer or path to the analyzer folder
 -IN | Input file
 -OUT | Output directory

--- a/include/Api/lite/nlp_engine.h
+++ b/include/Api/lite/nlp_engine.h
@@ -88,6 +88,7 @@ public:
     bool m_compile;
     bool m_compiled;
     bool m_compileKB;
+    bool m_compileAna;
 
     void setWorkingFolder(_TCHAR *workingFolder);
     void zeroInit();
@@ -99,7 +100,8 @@ public:
         bool silent=false,
         bool compile=false,
         bool compiled=false,
-        bool compileKB=false
+        bool compileKB=false,
+        bool compileAna=false
     );
 
     int analyze(
@@ -110,7 +112,8 @@ public:
         bool silent=false,
         bool compile=false,
         bool compiled=false,
-        bool compileKB=false
+        bool compileKB=false,
+        bool compileAna=false
     );
 
     int analyze(
@@ -123,7 +126,8 @@ public:
         bool silent=false,
         bool compile=false,
         bool compiled=false,
-        bool compileKB=false
+        bool compileKB=false,
+        bool compileAna=false
     );
 
     int analyze(
@@ -134,7 +138,8 @@ public:
         bool silent=false,
         bool compile=false,
         bool compiled=false,
-        bool compileKB=false
+        bool compileKB=false,
+        bool compileAna=false
     );
 
     int close();

--- a/lite/nlp_engine.cpp
+++ b/lite/nlp_engine.cpp
@@ -106,6 +106,7 @@ void NLP_ENGINE::zeroInit()
     m_compile = false;
     m_compiled = false;
     m_compileKB = false;
+    m_compileAna = false;
 
     #ifdef TEST_RUG_
     m_gram = 0;
@@ -143,7 +144,8 @@ int NLP_ENGINE::init(
 	bool silent,
     bool compile,
     bool compiled,
-    bool compileKB
+    bool compileKB,
+    bool compileAna
 )
 {
 //     NLP_ENGINE::zeroInit();    // [DEGLOB]	// 10/15/20 AM.
@@ -160,6 +162,7 @@ int NLP_ENGINE::init(
     m_compile = compile;
     m_compiled = compiled;
     m_compileKB = compileKB;
+    m_compileAna = compileAna;
 
     struct stat st;
     char str[MAXPATH] = _T("");
@@ -285,7 +288,7 @@ int NLP_ENGINE::init(
 
         std::_t_cerr << _T("[Loaded knowledge base.]") << std::endl;             // 02/19/19 AM.
 
-        // Compile the KB if requested.
+        // Compile the KB if requested. Analyzer-only compile skips this.
         if (m_compile || m_compileKB)
             {
             std::_t_cerr << _T("[Compiling knowledge base.]") << std::endl;
@@ -306,7 +309,7 @@ int NLP_ENGINE::init(
         if (!m_nlp->make_analyzer(m_seqfile, m_anadir, m_develop,
             silent,              // Debug/log file output.             // 06/16/02 AM.
             0,
-            m_compile,           // Compile analyzer while loading.
+            m_compile || m_compileAna, // Compile analyzer while loading.
             compiled))           // Compiled/interp analyzer.
             {
             std::_t_cerr << _T("[Couldn't build analyzer.]") << std::endl;
@@ -344,13 +347,14 @@ int NLP_ENGINE::analyze(
 	bool silent,
     bool compile,
     bool compiled,
-    bool compileKB
+    bool compileKB,
+    bool compileAna
 	)
 {
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB);
+    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna);
 
     // Compile mode: C++ code generation is done in init(); do not run analysis.
-    if (m_compile || m_compileKB)
+    if (m_compile || m_compileKB || m_compileAna)
         return 0;
 
     readFiles(infile);
@@ -439,13 +443,14 @@ int NLP_ENGINE::analyze(
 	bool silent,
     bool compile,
     bool compiled,
-    bool compileKB
+    bool compileKB,
+    bool compileAna
 	)
 {
 
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB);
+    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna);
 
-    if (m_compile || m_compileKB)
+    if (m_compile || m_compileKB || m_compileAna)
         return 0;
 
     // Analyzer can output to a stream.
@@ -488,13 +493,14 @@ int NLP_ENGINE::analyze(
 	bool silent,
     bool compile,
     bool compiled,
-    bool compileKB
+    bool compileKB,
+    bool compileAna
 	)
 {
 
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB);
+    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna);
 
-    if (m_compile || m_compileKB)
+    if (m_compile || m_compileKB || m_compileAna)
         return 0;
 
     // Analyzer can output to a stream.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,9 +15,9 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.5.1"
+#define NLP_ENGINE_VERSION "3.6.0"
 
-bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
+bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);
 
 #ifdef LINUX
@@ -41,13 +41,14 @@ int _tmain(
 	bool compiled = false;  // Run compiled/interp analyzer.
 	bool silent = false;    // No log/debug output files.
 	bool compileKB = false; // Compile only the KB to C++.
+	bool compileAna = false; // Compile only the analyzer to C++.
 
 	/////////////////////////////////////////////////
 	// GET APP INFORMATION
 	/////////////////////////////////////////////////
 
 	// Get analyzer name, input and output filenames from command line.
-	if (!cmdReadArgs(argc, argv, analyzerpath, input, output, workdir, develop, compile, compiled, silent, compileKB))
+	if (!cmdReadArgs(argc, argv, analyzerpath, input, output, workdir, develop, compile, compiled, silent, compileKB, compileAna))
 		exit(1);
 
 	NLP_ENGINE *nlpEngine = new NLP_ENGINE(workdir);
@@ -57,7 +58,7 @@ int _tmain(
 		// Analysis is not run; the generated C++ must be compiled externally
 		// (e.g. via the NLP++ language extension) before running with -COMPILED.
 		std::_t_cout << _T("[Compiling analyzer and KB: ") << analyzerpath << _T("]") << std::endl;
-		nlpEngine->init(analyzerpath, develop, silent, compile, compiled, compileKB);
+		nlpEngine->init(analyzerpath, develop, silent, compile, compiled, compileKB, compileAna);
 		std::_t_cout << _T("[Compile complete.]") << std::endl;
 	}
 	else if (compileKB)
@@ -65,12 +66,20 @@ int _tmain(
 		// KB-only compile: generate C++ code for the KB.
 		// The analyzer grammar is not loaded.
 		std::_t_cout << _T("[Compiling KB only: ") << analyzerpath << _T("]") << std::endl;
-		nlpEngine->init(analyzerpath, develop, silent, compile, compiled, compileKB);
+		nlpEngine->init(analyzerpath, develop, silent, compile, compiled, compileKB, compileAna);
 		std::_t_cout << _T("[KB compile complete.]") << std::endl;
+	}
+	else if (compileAna)
+	{
+		// Analyzer-only compile: generate C++ code for the analyzer rules.
+		// The KB is loaded but not regenerated/recompiled.
+		std::_t_cout << _T("[Compiling analyzer only: ") << analyzerpath << _T("]") << std::endl;
+		nlpEngine->init(analyzerpath, develop, silent, compile, compiled, compileKB, compileAna);
+		std::_t_cout << _T("[Analyzer compile complete.]") << std::endl;
 	}
 	else
 	{
-		nlpEngine->analyze(analyzerpath, input, output, develop, silent, compile, compiled, compileKB);
+		nlpEngine->analyze(analyzerpath, input, output, develop, silent, compile, compiled, compileKB, compileAna);
 	}
 	delete nlpEngine;
 }
@@ -94,7 +103,8 @@ bool cmdReadArgs(
 	bool &compile,	   // true - compile analyzer and KB.
 	bool &compiled,	   // true - compiled ana. false=interp(DEFAULT).
 	bool &silent,	   // true == only output files specified by analyzer.
-	bool &compileKB    // true - compile only the KB to C++.
+	bool &compileKB,   // true - compile only the KB to C++.
+	bool &compileAna   // true - compile only the analyzer to C++.
 )
 {
 	_TCHAR *ptr;
@@ -114,6 +124,7 @@ bool cmdReadArgs(
 	compiled = false;  // INTERP ANALYZER BY DEFAULT
 	silent = false;	   // Produce debug files, etc. by default.		// 06/16/02 AM.
 	compileKB = false; // Don't compile KB-only by default.
+	compileAna = false; // Don't compile analyzer-only by default.
 
 	for (--argc, parg = &(argv[1]); argc > 0; --argc, ++parg)
 	{
@@ -217,6 +228,10 @@ bool cmdReadArgs(
 			{
 				compileKB = true;
 			}
+			else if (!strcmp_i(ptr, _T("compileana"))) // Compile only the analyzer to C++.
+			{
+				compileAna = true;
+			}
 		}
 		else if (flag) // Expected an argument value.
 		{
@@ -303,6 +318,7 @@ void cmdHelpargs(_TCHAR *name)
 				 << _T("           [-INTERP][-COMPILED] INTERP is the default") << std::endl
 				 << _T("           [-COMPILE] compile analyzer and KB to C++ (does not run analyzer)") << std::endl
 				 << _T("           [-COMPILEKB] compile only the KB to C++ (does not load grammar or run analyzer)") << std::endl
+				 << _T("           [-COMPILEANA] compile only the analyzer to C++ (does not regenerate the KB or run analyzer)") << std::endl
 				 << _T("           [-ANA analyzer] name or path to NLP++ analyzer folder") << std::endl
 				 << _T("           [-IN infile] input text file path") << std::endl
 				 << _T("           [-OUT outdir] output directory") << std::endl


### PR DESCRIPTION
## Summary

Adds a third analyzer compile mode. Previously the engine could compile:

- **`-COMPILE`** — analyzer **and** KB → C++
- **`-COMPILEKB`** — **KB only** → C++

This adds:

- **`-COMPILEANA`** — **analyzer only** → C++ (generates `run/*.cpp`, skips KB codegen)

Useful when only the rules changed and the KB is already compiled — you skip the (often expensive) KB regeneration.

## Implementation

A `compileAna` flag is plumbed through:
- **`nlp/main.cpp`** — new `-COMPILEANA` arg, dispatch branch (`[Compiling analyzer only: ...]`), `cmdReadArgs` signature, and `--help` text.
- **`include/Api/lite/nlp_engine.h`** — new `m_compileAna` member + trailing `compileAna=false` param on `init()` and the `analyze()` overloads (backward-compatible defaults).
- **`lite/nlp_engine.cpp`** — in `init()`: KB codegen still gated on `m_compile || m_compileKB` (so analyzer-only skips it), and `make_analyzer` now compiles when `m_compile || m_compileAna`. The `analyze()` overloads treat `compileAna` like the other compile modes (generate, don't run analysis).

Bumps `NLP_ENGINE_VERSION` to **3.6.0**.

## Testing

Built clean (0 warnings / 0 errors). `--help` lists the new mode; `--version` → `3.6.0`.

Ran all three modes on the same analyzer from a clean tree and counted generated sources:

| Mode | `run/*.cpp` (analyzer) | `kb/*.cpp` (KB) |
|------|------|------|
| `-COMPILEKB` | 0 | 58 |
| `-COMPILE` | 24 | 58 |
| **`-COMPILEANA`** | **24** | **0** |

`-COMPILEANA` is the exact complement of `-COMPILEKB`; the two existing modes are unchanged.

## Note on versioning

This branch bumps `master`'s 3.5.0 → **3.6.0**. The separate open PR #654 bumps to 3.5.1; whichever merges second will need a one-line version conflict resolved to keep 3.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)