### PR TITLE
fix: re-entrant analyze() use-after-free on m_nlp (3.6.1)

### DIFF
--- a/lite/nlp_engine.cpp
+++ b/lite/nlp_engine.cpp
@@ -282,6 +282,7 @@ int NLP_ENGINE::init(
             std::_t_cerr << _T("[Couldn't make knowledge base.]") << std::endl;  // 07/21/03 AM.
             m_vtrun->rmAna(m_nlp);  // 09/27/20 AM.
             m_vtrun->deleteNLP(m_nlp);                                     // 07/21/03 AM.
+            m_nlp = 0;  // avoid dangling ptr; analyze() must not deref a deleted NLP.
     //        VTRun::deleteVTRun(m_vtrun);                                 // 07/21/03 AM.
             return -1;
         }
@@ -315,6 +316,7 @@ int NLP_ENGINE::init(
             std::_t_cerr << _T("[Couldn't build analyzer.]") << std::endl;
             m_vtrun->rmAna(m_nlp);  // 09/27/20 AM.
             m_vtrun->deleteNLP(m_nlp);                                     // 07/21/03 AM.
+            m_nlp = 0;  // avoid dangling ptr; analyze() must not deref a deleted NLP.
     //        VTRun::deleteVTRun(m_vtrun);                                 // 07/21/03 AM.
             return -1;
             }
@@ -351,11 +353,20 @@ int NLP_ENGINE::analyze(
     bool compileAna
 	)
 {
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna);
+    // Respect init() failure. On a re-entrant analyze() in a long-lived process
+    // (e.g. the node/python addon), a name-collision in addAna can leave a fresh
+    // NLP unregistered; if make_analyzer/makeCG then fails, init() deletes m_nlp
+    // and returns -1. Charging ahead used to deref the freed m_nlp below and
+    // SIGSEGV (deterministic on Linux). Bail out cleanly.
+    if (NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna) < 0)
+        return -1;
 
     // Compile mode: C++ code generation is done in init(); do not run analysis.
     if (m_compile || m_compileKB || m_compileAna)
         return 0;
+
+    if (!m_nlp)  // defensive: never analyze without a live analyzer object.
+        return -1;
 
     readFiles(infile);
     std::string file;
@@ -448,10 +459,16 @@ int NLP_ENGINE::analyze(
 	)
 {
 
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna);
+    // Respect init() failure (see file-I/O overload above): bail instead of
+    // dereferencing a freed m_nlp.
+    if (NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna) < 0)
+        return -1;
 
     if (m_compile || m_compileKB || m_compileAna)
         return 0;
+
+    if (!m_nlp)  // defensive: never analyze without a live analyzer object.
+        return -1;
 
     // Analyzer can output to a stream.
     _TCHAR ofstr[MAXSTR];
@@ -498,10 +515,16 @@ int NLP_ENGINE::analyze(
 	)
 {
 
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna);
+    // Respect init() failure (see file-I/O overload above): bail instead of
+    // dereferencing a freed m_nlp.
+    if (NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB,compileAna) < 0)
+        return -1;
 
     if (m_compile || m_compileKB || m_compileAna)
         return 0;
+
+    if (!m_nlp)  // defensive: never analyze without a live analyzer object.
+        return -1;
 
     // Analyzer can output to a stream.
     _TCHAR ofstr[MAXSTR];

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.6.0"
+#define NLP_ENGINE_VERSION "3.6.1"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem
On a re-entrant `analyze()` in a long-lived process (the node/python addon), the engine deterministically SIGSEGVs on Linux:

```
[addAna: Named analyzer already present: emailaddress]
[Couldn't build analyzer.]
SIGSEGV
```

Use-after-free on `m_nlp`, from a lookup-key asymmetry:
1. `init` looks up the existing analyzer via `findAna(analyzer)` keyed on the **path-ish `analyzer` arg** → misses on re-entry → builds a **fresh** `m_nlp`.
2. `addAna` dedups on **`nlp->getName()`** → hits → returns `true` **without pushing** the new nlp.
3. `make_analyzer`/`makeCG` then fails → init runs `deleteNLP(m_nlp); return -1;` but **never nulls `m_nlp`**.
4. All **three** `analyze()` overloads **discarded** init()'s `-1` and dereferenced the freed `m_nlp` → **SIGSEGV**.

## Fix
- All three `analyze()` overloads bail when `init()` returns `< 0`, plus a defensive `if (!m_nlp) return -1;` before the first deref.
- Null `m_nlp` after `deleteNLP` in both `init()` failure paths.
- Bump `NLP_ENGINE_VERSION` `3.6.0 → 3.6.1`.

## Why here (not the fork)
The npm/PyPI packages (`npm-package-nlpengine`, `py-package-nlpengine`) build **this** repo from source via the `nlp-engine` submodule. The fix had to land on `VisualText/nlp-engine` 3.6.x to actually reach shipped packages. (A parallel fix was applied earlier on the `ddehilster/nlp-engine` 3.1.x fork, but nothing downstream consumes that line.)

## Follow-up
Reconcile `init`'s `findAna(analyzer)` vs `addAna`'s `findAna(getName())` keys so re-entrant `analyze()` *reloads* the existing analyzer instead of orphaning a fresh one (re-analysis works, not just doesn't crash).

## Testing
- [ ] Linux build (cibuildwheel / cmake) green.
- [ ] Addon repro: repeated `analyze("emailaddress", ...)` in one process no longer SIGSEGVs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)