### PR TITLE
ci: dispatch nlp-engine-release to the npm and python packages

### DIFF
--- a/.github/workflows/move-assets.yml
+++ b/.github/workflows/move-assets.yml
@@ -328,4 +328,23 @@ jobs:
         repository: VisualText/nlp-engine-linux
         event-type: nlp-engine-release
         client-payload: '{"tag_name": "${{ env.TAG_NAME }}"}'
-      continue-on-error: true  
+      continue-on-error: true
+
+    - name: Trigger npm-package-nlpengine workflow
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.CLASSIC_PAT }}
+        repository: VisualText/npm-package-nlpengine
+        event-type: nlp-engine-release
+        client-payload: '{"tag_name": "${{ env.TAG_NAME }}"}'
+      continue-on-error: true
+
+    - name: Trigger py-package-nlpengine workflow
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.CLASSIC_PAT }}
+        repository: VisualText/py-package-nlpengine
+        event-type: nlp-engine-release
+        client-payload: '{"tag_name": "${{ env.TAG_NAME }}"}'
+      continue-on-error: true
+


### PR DESCRIPTION
## Problem
When `nlp-engine` is tagged, `move-assets.yml` only dispatches `nlp-engine-release` to the three platform distribution repos (`nlp-engine-windows/-mac/-linux`). The **npm** and **PyPI** packages were never pinged — so tagging a new engine (e.g. v3.6.1) updated the binaries but left `nlpplus` / `NLPPlus` on the old engine.

## Fix
Add two more `repository_dispatch` steps (same `nlp-engine-release` event-type) targeting:
- `VisualText/npm-package-nlpengine`
- `VisualText/py-package-nlpengine`

Their `update-nlp-engine.yml` listeners then auto-bump the `nlp-engine` submodule, tag, and publish to npm / PyPI.

> Pairs with: npm already has its listener; py-package's listener is added in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)