### PR TITLE
fix: quiet con_add_root stderr noise; realign version to 3.5.3

### DIFF
--- a/cs/libconsh/consh_kb.cpp
+++ b/cs/libconsh/consh_kb.cpp
@@ -71,7 +71,10 @@ bool dirt;	// 06/29/03 AM.
 
 if (cg->cg_CONCEPT)
    {
-   std::_t_cerr << _T("[con_add_root: Root concept of kb already exists.]") << std::endl;
+   // Root already exists: re-issuing ADD ROOT on an initialized KB is an
+   // expected, harmless no-op (every kb/dict and lazy "*-full" load re-runs
+   // it), so skip silently instead of spamming stderr. Uncomment to trace.
+   // std::_t_cerr << _T("[con_add_root: Root concept of kb already exists.]") << std::endl;
    return;
    }
 

--- a/cs/libqconsh/consh_kb.cpp
+++ b/cs/libqconsh/consh_kb.cpp
@@ -76,7 +76,10 @@ XCON_S *con = &con_x;	// 02/14/07 AM.
 
 if (cg->cg_CONCEPT)
    {
-   _t_cerr << _T("[con_add_root: Root concept of kb already exists.]") << endl;
+   // Root already exists: re-issuing ADD ROOT on an initialized KB is an
+   // expected, harmless no-op (every kb/dict and lazy "*-full" load re-runs
+   // it), so skip silently instead of spamming stderr. Uncomment to trace.
+   // _t_cerr << _T("[con_add_root: Root concept of kb already exists.]") << endl;
    return;
    }
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.6.2"
+#define NLP_ENGINE_VERSION "3.5.3"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## What
Two things, both small:

1. **Quiet `con_add_root` noise.** It's an idempotency guard — if the KB root concept already exists it returns harmlessly — but it logged `[con_add_root: Root concept of kb already exists.]` to stderr on every redundant call. The engine re-issues `ADD ROOT` on every kb/dict load and each lazy `*-full` open, so a normal run spams it. Commented out the stderr line in both twins (`libconsh` + `libqconsh`); the guard is unchanged.

2. **Version realignment → `3.5.3`.** The version string had drifted to `3.6.x` (an over-eager minor bump on the analyzer-only feature). Brought it back onto the `3.5.x` line. This PR ships as **3.5.3**.

## Verified
Rebuilt `nlp.exe` (0/0); re-ran `parse-pt-br`: the `Root concept…` message is gone (0×), lazy-loading still works, exit 0.

## Net diff vs master
- `cs/libconsh/consh_kb.cpp`, `cs/libqconsh/consh_kb.cpp` — quiet the message
- `nlp/main.cpp` — `3.6.2` → `3.5.3`

After squash-merge, tag `v3.5.3` → percolation (#660, already on master) fans out to the 3 platform repos + npm + PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)