### PR TITLE
fix: string-function bugs — strwrap drops chars (#544) + strtrim all-spaces (#506)

### DIFF
--- a/lite/str.cpp
+++ b/lite/str.cpp
@@ -1592,6 +1592,8 @@ _TCHAR *str_wrap(_TCHAR *str, long wrapSize, _TCHAR *buf)
 buf[0] = '\0';
 if (empty(str))
 	return 0;
+if (wrapSize < 1)		// Guard against an infinite hard-wrap loop.
+	wrapSize = 1;
 _TCHAR *ptr;
 ptr = &(buf[0]);
 _TCHAR *lastSpace = NULL;
@@ -1612,19 +1614,29 @@ while (*str)
 		{
 		if (lastSpace)
 			{
+			// Break at the last space: turn it into a newline and
+			// resume from the character right after it.
 			str = lastSpace;
 			ptr = lastNewSpace;
+			*ptr++ = '\n';
+			++str;
 			}
-
-		*ptr++ = '\n';
-		++str;
+		else
+			{
+			// No space to break on (a word longer than wrapSize):
+			// hard-break *before* the current character. #544: the old
+			// code did ++str here too, silently dropping one character
+			// at every hard wrap (the first char of each wrapped line).
+			// Leave str on the current char so it starts the new line.
+			*ptr++ = '\n';
+			}
 		count = 0;
 		lastSpace = NULL;
 		lastNewSpace = NULL;
+		continue;	// reprocess the current char; the newline isn't counted
 		}
-	else
-		*ptr++ = *str++;
 
+	*ptr++ = *str++;
 	++count;
 	}
 

--- a/lite/str.cpp
+++ b/lite/str.cpp
@@ -2470,9 +2470,11 @@ if (_istspace((_TUCHAR)*str))
 	{
 	while (_istspace((_TUCHAR)*++str))
 		;
-	if (!*str)      // String was all whitespace.
+	if (!*str)      // String was all whitespace -> empty after trimming.
 		{
-		*buf++ = ' ';   // Convert to one space.
+		// #506: the old code wrote "*buf++ = ' '" here, leaving a single
+		// space. strtrim() removes leading AND trailing whitespace, so an
+		// all-whitespace string must trim to the empty string.
 		*buf = '\0';
 		return true;
 		}

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.5.4"
+#define NLP_ENGINE_VERSION "3.5.5"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Two string-function bug fixes in `lite/str.cpp`, both verified against a live analyzer (`DollarText`):

## #544 — `strwrap()` drops a character at every hard wrap (priority: high)
`str_wrap()` did an unconditional `++str` after a wrap newline. On a hard (mid-word) break that skipped the current char, dropping the first char of every wrapped line and the last char:
```
strwrap("1234567890123456",5)  ->  12345 / 7890 / 2345   (lost 6 and 1)
```
Fix: only advance past the char when breaking at a space; on a hard break leave it to start the next line (reprocess via `continue`). Guard `wrapSize < 1`. Now:
```
strwrap("1234567890123456",5)  ->  12345 / 67890 / 12345 / 6
strwrap("hello world foo",8)   ->  hello / world / foo
```

## #506 — `strtrim()` of an all-whitespace string returns `" "` instead of `""`
`str_trim()` special-cased an all-whitespace input by writing a single space. Per the docs it removes leading/trailing whitespace, so an all-space string trims to empty. Now:
```
strtrim("      ")        ->  []        (was [ ])
strtrim("   spaces   ")  ->  [spaces]
```

Bumps version to **3.5.5**. Fixes #544, #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)