### PR TITLE
ci: attach the release binary built from the tagged commit

### DIFF
--- a/.github/workflows/build-enginefiles.yml
+++ b/.github/workflows/build-enginefiles.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Build the tagged commit so release assets match the tagged version.
+  push:
+    tags:
+      - '*'
 
 jobs:
   zip_files:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Build the tagged commit so the release binary carries the right version.
+  push:
+    tags:
+      - '*'
 
 jobs:
   build_engine:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-  
+  # Build the tagged commit so the release binary carries the right version.
+  push:
+    tags:
+      - '*'
+
 jobs:
   build_engine:
     name: Build NLP-ENGINE

--- a/.github/workflows/build-visualfiles.yml
+++ b/.github/workflows/build-visualfiles.yml
@@ -4,8 +4,12 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-    
-jobs:    
+  # Build the tagged commit so release assets match the tagged version.
+  push:
+    tags:
+      - '*'
+
+jobs:
   zip_files:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,6 +6,10 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - master
+  # Build the tagged commit itself so the release binary carries the right
+  # version. (A `tags:` filter under `pull_request` is ignored by GitHub --
+  # it must live under `push:`.)
+  push:
     tags:
       - '*'
 

--- a/.github/workflows/move-assets.yml
+++ b/.github/workflows/move-assets.yml
@@ -5,14 +5,24 @@ permissions:
   actions: write
 
 on:
+  # Manual re-release: pass an explicit tag (e.g. v3.5.4) to rebuild that
+  # release's assets from the exact tagged commit.
   workflow_dispatch:
-  workflow_run:
-    workflows: ["build-windows.yml", "build-macos.yml", "build-enginefiles.yml", "build-visualfiles.yml", "build-linux.yml"]
-    types:
-      - completed
+    inputs:
+      tag:
+        description: "Tag to (re)build release assets for, e.g. v3.5.4. Defaults to the latest tag."
+        required: false
+        type: string
+  # Primary trigger: a tag push. We then WAIT for that tag's builds to finish
+  # (see "Find workflow run IDs") rather than grabbing whatever build is newest.
   push:
     tags:
     - '*'
+
+# Never let two asset-moves touch the same release at once.
+concurrency:
+  group: move-assets-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   download_assets:
@@ -25,56 +35,81 @@ jobs:
         fetch-depth: 0  # Fetch all history and tags
 
     
-    - name: Extract tag name from ref or get latest tag
+    - name: Extract tag name and resolve its commit
       id: get_tag
       run: |
-        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-          # When directly triggered by a tag push
+        git fetch --tags --force
+        if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+          # Manual re-release for a specific tag.
+          TAG_NAME="${{ github.event.inputs.tag }}"
+          echo "Using tag from workflow_dispatch input: $TAG_NAME"
+        elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          # Triggered by a tag push.
           TAG_NAME=${GITHUB_REF#refs/tags/}
           echo "Using tag from push trigger: $TAG_NAME"
         else
-          # When triggered by workflow_run or workflow_dispatch
-          # Get the latest tag from the repository
-          git fetch --tags
+          # Fallback: latest tag.
           TAG_NAME=$(git describe --tags --abbrev=0)
-          
-          # If no tag found, use timestamp
-          if [ -z "$TAG_NAME" ]; then
-            TIMESTAMP=$(date +'%Y.%m.%d-%H%M')
-            TAG_NAME="v${TIMESTAMP}"
-            echo "No tag found, using generated version: $TAG_NAME"
-          else
-            echo "Using latest tag from repository: $TAG_NAME"
-          fi
+          echo "Using latest tag from repository: $TAG_NAME"
         fi
-        
-        # Store the tag name for later use
+
+        if [ -z "$TAG_NAME" ]; then
+          echo "ERROR: could not determine a tag to release." >&2
+          exit 1
+        fi
+
+        # The commit this tag points to. The release MUST attach binaries built
+        # from THIS commit, not whatever build happened to be newest -- that bug
+        # stapled a 3.5.3 binary onto the v3.5.4 release.
+        TAG_SHA=$(git rev-list -n1 "$TAG_NAME")
         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
-        
-        # Debug output
-        echo "Selected TAG_NAME: $TAG_NAME"
-    - name: Find workflow run IDs
-      run: |
-        echo "Finding most recent successful workflow runs..."
-        
-        WIN_RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/build-windows.yml/runs --paginate | jq -r ".workflow_runs[] | select(.conclusion == \"success\") | .id" | head -n 1)
-        echo "Windows run ID: $WIN_RUN_ID"
-        echo "WIN_RUN_ID=$WIN_RUN_ID" >> $GITHUB_ENV
-    
-        LINUX_RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/build-linux.yml/runs --paginate | jq -r ".workflow_runs[] | select(.conclusion == \"success\") | .id" | head -n 1)
-        echo "Linux run ID: $LINUX_RUN_ID"
-        echo "LINUX_RUN_ID=$LINUX_RUN_ID" >> $GITHUB_ENV
-        
-        MAC_RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/build-macos.yml/runs --paginate | jq -r ".workflow_runs[] | select(.conclusion == \"success\") | .id" | head -n 1)
-        echo "MAC_RUN_ID=$MAC_RUN_ID" >> $GITHUB_ENV
-    
-        ENGINE_RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/build-enginefiles.yml/runs --paginate | jq -r ".workflow_runs[] | select(.conclusion == \"success\") | .id" | head -n 1)
-        echo "ENGINE_RUN_ID=$ENGINE_RUN_ID" >> $GITHUB_ENV
-    
-        VISUAL_RUN_ID=$(gh api repos/${{ github.repository }}/actions/workflows/build-visualfiles.yml/runs --paginate | jq -r ".workflow_runs[] | select(.conclusion == \"success\") | .id" | head -n 1)
-        echo "VISUAL_RUN_ID=$VISUAL_RUN_ID" >> $GITHUB_ENV
+        echo "TAG_SHA=$TAG_SHA" >> $GITHUB_ENV
+        echo "Selected TAG_NAME=$TAG_NAME -> TAG_SHA=$TAG_SHA"
+    - name: Find workflow run IDs for the tagged commit
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        # Pick the build run whose head_sha == this tag's commit, and WAIT for it
+        # to finish. Previously this grabbed the newest *successful* build of any
+        # branch/PR, which stapled a stale (wrong-version) binary onto the
+        # release. Each build workflow now triggers on the tag push, so a run for
+        # $TAG_SHA exists; we just have to wait for it to go green.
+        wait_for_run() {
+          local wf="$1"
+          local timeout=5400 interval=30 waited=0   # up to 90 min
+          while true; do
+            local json id pending bad
+            json=$(gh api "repos/${{ github.repository }}/actions/workflows/$wf/runs?head_sha=$TAG_SHA&per_page=100" 2>/dev/null || echo '{}')
+            id=$(echo "$json" | jq -r '(.workflow_runs // []) | map(select(.conclusion=="success")) | .[0].id // empty')
+            if [ -n "$id" ]; then echo "$id"; return 0; fi
+            pending=$(echo "$json" | jq -r '(.workflow_runs // []) | map(select(.status!="completed")) | length')
+            bad=$(echo "$json" | jq -r '(.workflow_runs // []) | map(select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out" or .conclusion=="startup_failure")) | .[0].id // empty')
+            if [ "$pending" = "0" ] && [ -n "$bad" ]; then
+              echo "ERROR: $wf for $TAG_SHA finished without success (run $bad)." >&2
+              return 1
+            fi
+            if [ "$waited" -ge "$timeout" ]; then
+              echo "ERROR: timed out after ${timeout}s waiting for a successful $wf run for $TAG_SHA." >&2
+              return 1
+            fi
+            echo "Waiting for $wf build of $TAG_SHA to succeed... (${waited}s elapsed)" >&2
+            sleep "$interval"; waited=$((waited+interval))
+          done
+        }
+
+        WIN_RUN_ID=$(wait_for_run build-windows.yml)
+        echo "WIN_RUN_ID=$WIN_RUN_ID" >> $GITHUB_ENV
+        LINUX_RUN_ID=$(wait_for_run build-linux.yml)
+        echo "LINUX_RUN_ID=$LINUX_RUN_ID" >> $GITHUB_ENV
+        MAC_RUN_ID=$(wait_for_run build-macos.yml)
+        echo "MAC_RUN_ID=$MAC_RUN_ID" >> $GITHUB_ENV
+        ENGINE_RUN_ID=$(wait_for_run build-enginefiles.yml)
+        echo "ENGINE_RUN_ID=$ENGINE_RUN_ID" >> $GITHUB_ENV
+        VISUAL_RUN_ID=$(wait_for_run build-visualfiles.yml)
+        echo "VISUAL_RUN_ID=$VISUAL_RUN_ID" >> $GITHUB_ENV
+
+        echo "Resolved runs for $TAG_SHA: win=$WIN_RUN_ID linux=$LINUX_RUN_ID mac=$MAC_RUN_ID engine=$ENGINE_RUN_ID visual=$VISUAL_RUN_ID"
 
     # Windows artifacts with specific run ID
     - name: Fetch Windows exe
@@ -277,7 +312,9 @@ jobs:
         name: "Release ${{ env.TAG_NAME }}"
         body: |
           NLP Engine Release ${{ env.TAG_NAME }}
-        
+
+          Built from commit ${{ env.TAG_SHA }}
+
           Build information:
           - Windows build: ${{ env.WIN_RUN_ID }}
           - Linux build: ${{ env.LINUX_RUN_ID }}

--- a/docs/PERCOLATION.md
+++ b/docs/PERCOLATION.md
@@ -61,7 +61,7 @@ which has a workflow triggered by `repository_dispatch: types: [<event>]`.
 | package-analyzers | `v*` tag (auto-created by `tag-on-push.yml` on any analyzer edit pushed to main, or by `update-parse-en-us.yml` on a parse-en-us release) | `package-analyzers-release` | npm-package-nlpengine, py-package-nlpengine | `dispatch-update-package-analyzers.yml` |
 | analyzer-templates | `v*` tag | `analyzer-templates-release` | nlp-engine-{linux,windows,mac}, visualtext-files | `dispatch-update-analyzer-templates.yml` |
 | analyzers | end of its bump job | `analyzers-release` | nlp-engine | `parse-en-us.yml` (final step) |
-| nlp-engine | release / build complete | `nlp-engine-release` | nlp-engine-{linux,windows,mac}, npm-package-nlpengine, py-package-nlpengine | `move-assets.yml` |
+| nlp-engine | `v*` tag push | `nlp-engine-release` | nlp-engine-{linux,windows,mac}, npm-package-nlpengine, py-package-nlpengine | `move-assets.yml` |
 
 ## Who listens for what
 
@@ -139,6 +139,32 @@ its submodule pointer is already current.
    [<repo>-release]` to the workflow that updates that submodule, defaulting any
    version bump to `patch` on a ping (a `repository_dispatch` event has no
    `inputs.bump`).
+
+## Engine release binaries: attach the build of the *tagged* commit
+
+The engine's per-platform binaries (`nlpw.exe`, `nlpm.exe`, Linux zips, ICU/compile
+libs) are built by `build-windows.yml` / `build-macos.yml` / `build-linux.yml` /
+`build-enginefiles.yml` / `build-visualfiles.yml`, then collected onto the GitHub
+Release by `move-assets.yml`.
+
+Two rules keep the attached binary's version in sync with the tag:
+
+1. **Each build workflow triggers on the tag push** (`push: tags: ['*']`), so the
+   tagged commit itself is compiled. (`NLP_ENGINE_VERSION` is baked into the binary
+   at compile time, so the binary must be built *from the release commit*.)
+2. **`move-assets.yml` selects the build run whose `head_sha` == the tag's commit**
+   and *waits* for it to go green, instead of grabbing whatever build is newest.
+
+> **History:** these workflows originally only built on `pull_request` (the
+> `build-windows.yml` `tags:` filter was mis-nested under `pull_request`, where
+> GitHub ignores it), and `move-assets` grabbed the *most recent successful* build
+> of any branch. The result: v3.5.4 shipped a binary from an older PR whose
+> `main.cpp` still said 3.5.3. Tag-SHA pinning + tag-triggered builds fix this.
+
+To **re-release a tag** (e.g. fix a bad asset): Actions → "Move Assets to Release"
+→ Run workflow, and set the **`tag`** input (e.g. `v3.5.4`). It resolves that tag's
+commit, waits for that commit's builds, and re-attaches. If those builds don't
+exist yet, dispatch each `build-*` workflow on the tag ref first.
 
 ## Gotcha: re-attaching a submodule that workflows fetch manually
 


### PR DESCRIPTION
## Problem

`nlp.exe --version` on the **v3.5.4** release prints **3.5.3**, even though the v3.5.4 tag commit bakes in `3.5.4`. The version is compiled into the binary, so the release got a binary built from the *wrong commit*.

### Root cause — two compounding CI defects

1. **The build workflows never built the tagged commit.** In `build-windows.yml` the `tags:` filter was nested under `pull_request:` (GitHub ignores tag filters there), and `build-macos/linux/enginefiles/visualfiles` only triggered on `pull_request`. So Windows/Mac/Linux builds **only ran for PRs** — never for a release tag. There is no build for the v3.5.4 commit `61260fb`.

2. **`move-assets.yml` grabbed the newest *successful* build of any branch** (`select(.conclusion=="success") | head -n1`), with no link to the tag. On a fresh tag push the tag's own build is still in progress, so it stapled the **previous** version's binary (3.5.3) onto the v3.5.4 release.

## Fix

- **Add `push: tags: ['*']`** to all five build workflows so the tagged commit is actually compiled.
- **Pin `move-assets` to the tag's commit**: resolve `TAG_SHA = git rev-list -n1 <tag>` and select the build run whose `head_sha == TAG_SHA`, **waiting** (poll loop, up to 90 min) for that exact run to go green. No more "newest successful".
- Drop the racy `workflow_run` trigger; add a per-tag **`concurrency`** group and a **`workflow_dispatch` `tag` input** for manual re-releases.
- Release body records the source commit; `docs/PERCOLATION.md` documents the mechanism + how to re-release a tag.

## After merge
Re-release **v3.5.4** (dispatch the `build-*` workflows on the `v3.5.4` ref, then run *Move Assets to Release* with `tag: v3.5.4`), and ship **v3.5.5** (PR #665) through the corrected pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)