### PR TITLE
ci: draft-guard empty pre-existing release in move-assets

### DIFF
--- a/.github/workflows/move-assets.yml
+++ b/.github/workflows/move-assets.yml
@@ -65,6 +65,29 @@ jobs:
         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
         echo "TAG_SHA=$TAG_SHA" >> $GITHUB_ENV
         echo "Selected TAG_NAME=$TAG_NAME -> TAG_SHA=$TAG_SHA"
+
+    - name: Hide any empty pre-existing release during the build wait
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        # If a release for this tag was created up front (e.g. via the GitHub UI)
+        # it is published but empty until the builds finish ~15 min later. An
+        # update-checker hitting /releases/latest (the VS Code NLP++ extension
+        # does this) would see a new version with no downloadable assets and
+        # break for that window. Mark such a release a draft now; the "Create
+        # Release" step below republishes it with assets (draft: false). If a
+        # build fails, it safely stays a draft instead of shipping empty.
+        rel=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG_NAME" 2>/dev/null || echo '{}')
+        is_draft=$(echo "$rel" | jq -r '.draft // empty')
+        n_assets=$(echo "$rel" | jq -r '(.assets // []) | length')
+        if [ "$is_draft" = "false" ] && [ "${n_assets:-0}" = "0" ]; then
+          echo "Release $TAG_NAME is published but empty -> drafting it until assets are ready."
+          gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --draft
+        else
+          echo "Nothing to hide (exists=$([ -n "$is_draft" ] && echo yes || echo no), draft=$is_draft, assets=${n_assets:-0})."
+        fi
+
     - name: Find workflow run IDs for the tagged commit
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -310,6 +333,9 @@ jobs:
       with:
         tag_name: ${{ env.TAG_NAME }}
         name: "Release ${{ env.TAG_NAME }}"
+        # Publish (un-draft) now that the assets below are attached. This also
+        # re-publishes a release the draft-guard step hid at the start.
+        draft: false
         body: |
           NLP Engine Release ${{ env.TAG_NAME }}
 

--- a/.github/workflows/move-assets.yml
+++ b/.github/workflows/move-assets.yml
@@ -366,7 +366,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    # Percolate downstream only on a genuine new release (tag push). A manual
+    # re-release (workflow_dispatch, e.g. re-attaching an old tag's binary) must
+    # NOT re-bump downstream packages to that older engine version.
     - name: Trigger nlp-engine-windows workflow
+      if: github.event_name == 'push'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.CLASSIC_PAT }}
@@ -376,6 +380,7 @@ jobs:
       continue-on-error: true
 
     - name: Trigger nlp-engine-mac workflow
+      if: github.event_name == 'push'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.CLASSIC_PAT }}
@@ -385,6 +390,7 @@ jobs:
       continue-on-error: true
 
     - name: Trigger nlp-engine-linux workflow
+      if: github.event_name == 'push'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.CLASSIC_PAT }}
@@ -397,6 +403,7 @@ jobs:
     # so an engine release must bump that submodule + republish. See
     # docs/PERCOLATION.md ("nlp-engine -> npm/py packages").
     - name: Trigger py-package-nlpengine workflow
+      if: github.event_name == 'push'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.CLASSIC_PAT }}
@@ -406,6 +413,7 @@ jobs:
       continue-on-error: true
 
     - name: Trigger npm-package-nlpengine workflow
+      if: github.event_name == 'push'
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.CLASSIC_PAT }}


### PR DESCRIPTION
Two changes that make creating/re-creating engine releases safe — motivated by the v3.5.5 incident where a pre-created release briefly broke the VS Code NLP++ extension's auto-updater.

## 1. Draft-guard an empty pre-existing release

If a release for the tag is created **up front** (GitHub "Draft a new release" UI), it's published immediately but **empty** until the per-platform builds finish ~15 min later. An update-checker hitting `/releases/latest` (the VS Code NLP++ extension does this) sees a new version with **no downloadable assets** and breaks for that window.

Fix: an early step marks such a release a **draft**; the "Create Release" step (`softprops`, now explicit `draft: false`) republishes it **with** assets once the tagged commit's builds are green. If a build fails, it safely stays a draft.

**Validated live on v3.5.5**: drafting the empty published release and letting `move-assets` run republished it `draft=false` with all 17 assets; published `nlpw.exe --version` → `3.5.5`.

## 2. Don't re-percolate downstream on a manual re-release

The `repository-dispatch` steps that bump the npm/PyPI/platform repos should fire only on a **genuine new release (tag push)**. A manual re-release (`workflow_dispatch`, e.g. re-attaching a corrected binary to an older tag like **v3.5.4**) must not re-bump downstream packages back to that older engine. Guarded all five with `if: github.event_name == 'push'`.

## Note
The clean path is still **tag-only** — `move-assets` then creates the release already-populated, no empty window. These guards make pre-creating / re-releasing harmless too, and unblock re-fixing the v3.5.4 binary without downstream regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)