### PR TITLE
chore: bump NLP_ENGINE_VERSION to 3.5.9

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.5.8"
+#define NLP_ENGINE_VERSION "3.5.9"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Bumps `NLP_ENGINE_VERSION` from 3.5.8 to 3.5.9.

This carries the native **python pass type** (#673) into the next release. The matching VSCode extension support (Python icon + "New Pass → Python" insertion) is in VisualText/vscode-nlp#1038.

Targets `fix/string-funcs-unicode` since that is where #673 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)