### PR TITLE
feat: single `python` pass type placeable anywhere, including pre-tokenize

### DIFF
--- a/lite/ana.cpp
+++ b/lite/ana.cpp
@@ -690,16 +690,12 @@ else if (!strcmp_i(s_algo, _T("rec")))				// 11/08/99 AM.
 
 	algo = new Rec();									// 11/08/99 AM.
 	}
-else if (!strcmp_i(s_algo, _T("python")))			// Python pass (post-tokenize).
+else if (!strcmp_i(s_algo, _T("python")))			// Python pass (any position).
 	{
 	// Second column is the script base name (spec/<name>.py).  No rules to parse.
-	algo = new Pyalgo(false);
-	}
-else if (	!strcmp_i(s_algo, _T("pythonpre"))		// Python pass (pre-tokenize).
-			|| !strcmp_i(s_algo, _T("pypre"))
-		  )
-	{
-	algo = new Pyalgo(true);
+	// May be placed anywhere, including before the tokenizer; the pre/post phase
+	// is detected automatically in Pyalgo::Execute.
+	algo = new Pyalgo();
 	}
 else if (	!strcmp_i(s_algo, _T("stub"))			// 06/23/99 AM.
 		  )

--- a/lite/python.cpp
+++ b/lite/python.cpp
@@ -4,8 +4,10 @@
 * SUBJ:	Analyzer pass that runs a Python script (gap-filler / enricher hook).
 * NOTE:	See python.h.  The pass shells out to:
 *			  python "<appdir>/spec/<script>.py" "<appdir>" "<inputfile>" pre|post
-*			Use "pythonpre" as the first pass (before the tokenizer) to update the
-*			dictionary/KB on raw text; use "python" anywhere after tokenization.
+*			A "python" pass may sit anywhere in the sequence, including before the
+*			tokenizer (e.g. to update the dictionary/KB on raw text).  The pre|post
+*			argument is detected automatically: a parse tree exists only after
+*			tokenization, so no tree => "pre", tree present => "post".
 *******************************************************************************/
 
 #include "StdAfx.h"
@@ -33,17 +35,15 @@ static _TCHAR algo_name[] = _T("python");
 * FN:		Special Functions for Pyalgo class.
 ********************************************/
 
-Pyalgo::Pyalgo(bool pre)			// Default constructor.
+Pyalgo::Pyalgo()					// Default constructor.
 	: Algo(algo_name)
 {
-pre_ = pre;
 }
 
 Pyalgo::Pyalgo(const Pyalgo &orig)	// Copy constructor.
 {
 name = orig.name;
 debug_ = orig.debug_;
-pre_ = orig.pre_;
 }
 
 /********************************************
@@ -86,13 +86,16 @@ if (!script || !*script)
 _TCHAR *appdir = parse->getAppdir();
 _TCHAR *input  = parse->getInput();
 
+// Detect phase: a parse tree exists only after tokenization.
+bool pre = (parse->getTree() == 0);
+
 _TCHAR cmd[8192];
 _stprintf(cmd, _T("python \"%s/spec/%s.py\" \"%s\" \"%s\" %s"),
 			(appdir ? appdir : _T(".")),
 			script,
 			(appdir ? appdir : _T(".")),
 			(input ? input : _T("")),
-			(pre_ ? _T("pre") : _T("post")));
+			(pre ? _T("pre") : _T("post")));
 
 if (parse->Verbose())
 	*gout << _T("[python pass: ") << cmd << _T("]") << std::endl;

--- a/lite/python.h
+++ b/lite/python.h
@@ -2,12 +2,12 @@
 * NAME:	PYTHON.H
 * FILE:	lite\python.h
 * SUBJ:	Analyzer pass that runs a Python script (gap-filler / enricher hook).
-* NOTE:	Two flavors, both implemented by this one Algo:
-*			  "python"     - normal pass; runs at its position in the sequence
-*			                 (after tokenization, tree available).
-*			  "pythonpre"  - pre-tokenization pass; runs before the tokenizer on
-*			                 the raw input (e.g. to update the dictionary before
-*			                 dictionary-driven tokenization/segmentation).
+* NOTE:	A single "python" pass type that may be placed anywhere in the
+*			sequence, including before the tokenizer (which is normally first).
+*			When it runs before tokenization it sees the raw input (e.g. to
+*			update the dictionary before dictionary-driven tokenization); when
+*			it runs after, the parse tree is available.  The phase is detected
+*			automatically (a parse tree exists only after tokenization).
 *			The pass's second sequence column is the script base name; the engine
 *			runs  python "<appdir>/spec/<name>.py" "<appdir>" "<inputfile>" pre|post
 *******************************************************************************/
@@ -28,15 +28,12 @@ class Seqn;		// Forward reference.
 class Pyalgo : public Algo
 {
 public:
-	Pyalgo(bool pre = false);				// Default constructor.
+	Pyalgo();									// Default constructor.
 	Pyalgo(const Pyalgo &orig);			// Copy constructor.
 
 	virtual Algo &dup();
 	virtual void setup(_TCHAR *s_data);
 	virtual bool Execute(Parse *, Seqn *);
-
-private:
-	bool pre_;		// true = pre-tokenization flavor.
 };
 
 #endif

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.5.8"
+#define NLP_ENGINE_VERSION "3.5.10"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Eliminates the separate `pythonpre`/`pypre` pass keyword. There is now a single `python` pass type that can be placed **anywhere** in the analyzer sequence, including before the tokenizer (which is normally the first pass).

## What changed

- **`lite/ana.cpp`** — Removed the `pythonpre`/`pypre` branch; the `python` branch constructs `new Pyalgo()` with no flavor flag.
- **`lite/python.h`** — Dropped the `bool pre` constructor parameter and the `pre_` member.
- **`lite/python.cpp`** — The pre|post phase is now detected automatically at runtime: a parse tree exists only after tokenization, so `parse->getTree() == 0` => `"pre"`, otherwise `"post"`.

## Why this is sufficient

- The tokenizer (`Tok::Tokenize`) is what creates the parse tree, so `getTree()` reliably distinguishes the two phases.
- The sequence loader never enforced tokenize-first, so no ordering change was required — passes already run in the order listed.
- The script contract is unchanged:
  ```
  python "<appdir>/spec/<script>.py" "<appdir>" "<inputfile>" pre|post
  ```
  so existing scripts keep working.

> Note: this PR is based on `master`, which does not yet contain the python-pass feature commit (#673) or the 3.5.8/3.5.9 version bumps, so those commits also appear in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)