### PR TITLE
fix: accept unquoted _xVAR(attr) in the rule compiler

### DIFF
--- a/data/rfb/spec/xvar.nlp
+++ b/data/rfb/spec/xvar.nlp
@@ -1,16 +1,21 @@
 ###############################################
 # FILE:     XVAR.PAT
-# SUBJ:     Merge _xVAR("attr") into a single nonliteral match-list token.
+# SUBJ:     Merge _xVAR("attr") / _xVAR(attr) into a single nonliteral token.
 # NOTE:     Runs after bigtok forms _NONLIT/_STR and whitespace is zapped,
 #           and before list collects parenthesized match lists, so the inner
-#           parens of _xVAR("attr") never reach the list grammar.  The merged
+#           parens of _xVAR(attr) never reach the list grammar.  The merged
 #           token _xVAR("attr") then flows through as one restricted-wildcard
 #           match-list entry; Pat::modeMatch1 tests the node attribute at
-#           runtime.
+#           runtime.  The attribute may be quoted (_STR) or an unquoted bareword
+#           (_LIT/_NUM); Pat::xvarMatch strips the optional quotes either way.
 ###############################################
 
 @POST
 	rfaxvar(1,3)
 	single()
 @RULES
+# Quoted attr:    _xVAR("attr")
 _NONLIT [base] <- _NONLIT \( _STR \) @@
+# Unquoted attr:  _xVAR(attr)  /  _xVAR(123)
+_NONLIT [base] <- _NONLIT \( _LIT \) @@
+_NONLIT [base] <- _NONLIT \( _NUM \) @@

--- a/lite/postrfa.cpp
+++ b/lite/postrfa.cpp
@@ -689,18 +689,25 @@ if (nlppp->sem_)
 	return errOut(&gerrStr,false);
 	}
 
-// Get the nonliteral name (eg, _xVAR) and the string content (eg, attr).
-RFASem *sem1, *sem2;
-if (!(sem1 = (RFASem *) n1->getData()->getSem())
- || !(sem2 = (RFASem *) n2->getData()->getSem()))
+// Get the nonliteral name (eg, _xVAR).  The nonliteral always carries a sem.
+RFASem *sem1;
+if (!(sem1 = (RFASem *) n1->getData()->getSem()))
 	{
 	std::_t_strstream gerrStr;
 	gerrStr << _T("[rfaxvar: Missing semantic object.]") << std::ends;
 	return errOut(&gerrStr,false);
 	}
-
 _TCHAR *name1 = sem1->getName();		// Eg, _xVAR
-_TCHAR *name2 = sem2->getName();		// Eg, attr (string content, no quotes)
+
+// Get the attribute name (eg, attr).  Quoted form is a _STR whose sem holds
+// the unquoted content; the unquoted form is a _LIT/_NUM bareword with no sem,
+// where the literal text is the node's name (see postRFAname).	// 06/18/26 DD.
+_TCHAR *name2;
+RFASem *sem2 = (RFASem *) n2->getData()->getSem();
+if (sem2)
+	name2 = sem2->getName();			// Eg, attr (string content, no quotes)
+else
+	name2 = n2->getData()->getName();	// Eg, attr (unquoted bareword text)
 if (!name1 || !name2)
 	{
 	std::_t_strstream gerrStr;


### PR DESCRIPTION
## Summary

The runtime ([`Pat::xvarMatch`](lite/pat.cpp)) already strips optional quotes and accepts **both** `_xVAR("attr")` and `_xVAR(attr)`, but the rfb rule compiler only parsed the quoted form. An unquoted `_xVAR(attr)` failed to compile with `[Couldn't build analyzer.]`.

## Root cause (two layers)

1. **Grammar** — [`data/rfb/spec/xvar.nlp`](data/rfb/spec/xvar.nlp) only matched `_NONLIT \( _STR \)`. An unquoted bareword isn't a `_STR`; it's a `_LIT`/`_NUM` (see [bigtok.nlp:116](data/rfb/spec/bigtok.nlp#L116)). The merge never fired, the bare `(` leaked into the `list` grammar, and the build died.
2. **Action** — [`postRFAxvar`](lite/postrfa.cpp) required a semantic object on arg 3. A `_LIT`/`_NUM` from a plain word has no sem.

## Fix

- `xvar.nlp`: also match `_NONLIT \( _LIT \)` and `_NONLIT \( _NUM \)`.
- `postRFAxvar`: when arg 3 has no sem, read the literal text from the node (`pn->getName()`, mirroring `postRFAname`). Produces the same `_xVAR("attr")` token as the quoted path, so runtime matching is identical.

## Testing

Rebuilt `nlp.exe` (Release) and verified with the interpreter:

| Form | Before | After |
|---|---|---|
| `_xVAR("mytag")` (quoted) | builds | builds |
| `_xVAR(mytag)` (unquoted alpha) | **fails** | builds |
| `_xVAR(123)` (unquoted num) | **fails** | builds |

Real `emailaddress` and `links` analyzers (which use `_xVAR("...")`) still build clean — no regression.

## Known limitation

An unquoted **alphanumeric** name like `_xVAR(ec1)` tokenizes as `_LIT _NUM` (`ec` + `1`) — two inner tokens — and is **not** merged; such names must still be quoted (`_xVAR("ec1")`). Pure-alpha and pure-numeric unquoted names work. All existing analyzers quote these names, so this is not a regression. Can extend the grammar to arbitrary inner content if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)