### PR TITLE
chore: bump NLP_ENGINE_VERSION to 3.6.2

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.5.10"
+#define NLP_ENGINE_VERSION "3.6.2"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Bump `NLP_ENGINE_VERSION` `3.5.10` → `3.6.2` so the engine version matches the next release tag.

This is the version bump for the unquoted `_xVAR(attr)` fix (#677), which merged without a bump.

## Why 3.6.2

`main.cpp` had regressed to `3.5.10` when #676 merged — **below** the highest release tag `v3.6.1` (v3.6.0/v3.6.1 are on master with matching `main.cpp`). 3.6.2 puts the version back ahead of the latest tag.

## After merge

Tagging `v3.6.2` on `nlp-engine` fires the percolation chain (`move-assets.yml` → `nlp-engine-release` → `py-package-nlpengine` bumps its engine submodule + tags → `publish.yml` → PyPI), shipping the `_xVAR` feature + unquoted fix in the `NLPPlus` wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)