### PR TITLE
feat: report analyzer, KB, and dictionary load times

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -249,7 +249,11 @@ if (compiled)																	// 04/27/01 AM.
 		}
 
 	*cgerr << _T("[Loading compiled kb: ") << bin << _T("]") << std::endl;			// 05/06/01 AM.
-	clock_t ckb_s_time = clock();											// Compiled KB load timing.	// 06/18/26 DD.
+	// Split decl/assign (as readKB does) so the earlier `goto interp` may skip
+	// this scalar legally -- jumping across an initialization is ill-formed
+	// under GCC (crosses initialization of 'ckb_s_time').				// 06/18/26 DD.
+	clock_t ckb_s_time;
+	ckb_s_time = clock();													// Compiled KB load timing.
 	hkbdll_ = load_dll(bin);												// 05/06/01 AM.
 	if (hkbdll_)
 		{

--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -249,6 +249,7 @@ if (compiled)																	// 04/27/01 AM.
 		}
 
 	*cgerr << _T("[Loading compiled kb: ") << bin << _T("]") << std::endl;			// 05/06/01 AM.
+	clock_t ckb_s_time = clock();											// Compiled KB load timing.	// 06/18/26 DD.
 	hkbdll_ = load_dll(bin);												// 05/06/01 AM.
 	if (hkbdll_)
 		{
@@ -269,6 +270,12 @@ if (compiled)																	// 04/27/01 AM.
 			*cgerr << _T("[Couldn't bind vars to compiled kb.]") << std::endl;
 			loaded = false;
 			unload_dll(hkbdll_);
+			}
+		// Report compiled-KB load time (DLL load + kb_setup + bind).	// 06/18/26 DD.
+		if (loaded)
+			{
+			double ckb_tot = (double)(clock() - ckb_s_time) / CLOCKS_PER_SEC;
+			std::_t_cerr << _T("[Loaded compiled KB library: ") << ckb_tot << _T(" sec]") << std::endl;
 			}
 		}
 	else																			// 05/07/01 AM.
@@ -694,9 +701,11 @@ return true;
 
 void CG::outputTime(_TCHAR *timeMsg, clock_t s_time) {
 clock_t e_time = clock();
-*cgerr << timeMsg << _T(" ")
-	  << (double) (e_time - s_time)/CLOCKS_PER_SEC
-	  << _T(" sec]") << std::endl;
+double secs = (double) (e_time - s_time)/CLOCKS_PER_SEC;
+*cgerr << timeMsg << _T(" ") << secs << _T(" sec]") << std::endl;
+// Also surface KB/dictionary load timings on the visible log stream so the
+// interpreted-KB times appear alongside [Loaded knowledge base: ...].	// 06/18/26 DD.
+std::_t_cerr << timeMsg << _T(" ") << secs << _T(" sec]") << std::endl;
 }
 
 /********************************************

--- a/lite/nlp_engine.cpp
+++ b/lite/nlp_engine.cpp
@@ -317,6 +317,7 @@ int NLP_ENGINE::init(
         // Create an analyzer dynamically using the sequence file and rules files
         // under appdir\spec.
 
+        clock_t ana_s_time = clock();                                 // Analyzer load timing.
         if (!m_nlp->make_analyzer(m_seqfile, m_anadir, m_develop,
             silent,              // Debug/log file output.             // 06/16/02 AM.
             0,
@@ -330,6 +331,13 @@ int NLP_ENGINE::init(
     //        VTRun::deleteVTRun(m_vtrun);                                 // 07/21/03 AM.
             return -1;
             }
+
+        // Report analyzer load time. `compiled` loads bin/run.<ext>; otherwise
+        // the analyzer is built/interned from spec/ rules.            // 06/18/26 DD.
+        double ana_tot = (double)(clock() - ana_s_time) / CLOCKS_PER_SEC;
+        std::_t_cerr << _T("[Loaded ")
+                     << (compiled ? _T("compiled analyzer: ") : _T("analyzer: "))
+                     << ana_tot << _T(" sec]") << std::endl;
         }   // end ELSE...
 
     /////////////////////////////

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.6.3"
+#define NLP_ENGINE_VERSION "3.6.4"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Extends the KB load-time reporting (#680) to also cover the **analyzer** and the **dictionary**, and to distinguish the **compiled vs interpreted** load paths so every `-COMPILED` combination reports its load time to the log.

## Changes

- **[nlp_engine.cpp](lite/nlp_engine.cpp)** — time `make_analyzer` and report `[Loaded analyzer: N sec]`, or `[Loaded compiled analyzer: N sec]` when running a compiled analyzer (`make_analyzer` internally loads `bin/run.<ext>`).
- **[cg.cpp](cs/libconsh/cg.cpp) `CG` ctor** — time the compiled-KB DLL load (`load_dll` + `kb_setup` + `bind_all`) and report `[Loaded compiled KB library: N sec]`.
- **[cg.cpp](cs/libconsh/cg.cpp) `outputTime`** — also emit the interpreted dict/kbb read times to the visible log stream; previously they went only to `logs/cgerr.log`.

## Scenarios now covered

| Mode | Lines reported |
|---|---|
| KB + analyzer compiled | `[Loaded compiled KB library]` + `[Loaded compiled analyzer]` |
| only analyzer compiled | `[READ dict files time]` + `[Loaded knowledge base]` + `[Loaded compiled analyzer]` |
| only KB compiled | `[Loaded compiled KB library]` + `[Loaded analyzer]` |
| fully interpreted | `[READ dict files time]` + `[Loaded knowledge base]` + `[Loaded analyzer]` |

## Testing

Rebuilt `nlp.exe` (Release). Verified the interpreted path on the real `emailaddress` analyzer:
```
[READ dict files time= 0.006 sec]
[Loaded knowledge base: 0.008 sec]
[Loaded analyzer: 0.566 sec]
```
Compiled-path timing strings are compiled in (`EMBEDED_KB` is defined, so the compiled-KB branch in `CG::CG` is live). The compiled-KB/compiled-analyzer lines require compiled `kb`/`run` DLLs to observe at runtime (built via `scripts/compile-analyzer.ps1`); the timing code is straightforward `clock()` wrapping around the existing load calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)