### PR TITLE
feat: file-system NLP++ functions (fileexists, direxists, filesize, deletefile) + 3.7.0

### DIFF
--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -402,6 +402,14 @@ switch (fnid)																	// 12/21/01 AM.
 		return fnLoaddict(args,nlppp,/*UP*/sem);						// 06/11/26 DD.
 	case FNloadkbb:
 		return fnLoadkbb(args,nlppp,/*UP*/sem);						// 06/11/26 DD.
+	case FNfileexists:
+		return fnFileexists(args,nlppp,/*UP*/sem);					// 07/03/26 DD.
+	case FNdirexists:
+		return fnDirexists(args,nlppp,/*UP*/sem);						// 07/03/26 DD.
+	case FNfilesize:
+		return fnFilesize(args,nlppp,/*UP*/sem);						// 07/03/26 DD.
+	case FNdeletefile:
+		return fnDeletefile(args,nlppp,/*UP*/sem);					// 07/03/26 DD.
 	case FNlogten:
 		return fnLogten(args,nlppp,/*UP*/sem);							// 04/29/04 AM.
 	case FNrandomint:
@@ -10968,6 +10976,155 @@ sem = new RFASem(1LL);	// 04/12/03 AM.
 return true;
 }
 
+
+/********************************************
+* FN:		FNFILEEXISTS
+* CR:		07/03/26 DD.
+* SUBJ:	Test whether a path names an existing regular file.
+* RET:	True (executed ok); sem = 1 if a regular file exists, else 0.
+* FORMS:	fileexists(path_str)
+********************************************/
+
+bool Fn::fnFileexists(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	/*UP*/
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+_TCHAR *str;
+if (!Arg::str1(_T("fileexists"), /*UP*/ (DELTS*&)args, str))
+	return false;
+if (!Arg::done((DELTS*)args, _T("fileexists"),parse))
+	return false;
+
+bool yes = false;
+if (str && *str)
+	{
+	std::error_code ec;
+	yes = std::filesystem::is_regular_file(std::filesystem::path(str), ec) && !ec;
+	}
+sem = new RFASem(yes ? 1LL : 0LL);
+return true;
+}
+
+
+/********************************************
+* FN:		FNDIREXISTS
+* CR:		07/03/26 DD.
+* SUBJ:	Test whether a path names an existing directory.
+* RET:	True (executed ok); sem = 1 if the directory exists, else 0.
+* FORMS:	direxists(path_str)
+********************************************/
+
+bool Fn::fnDirexists(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	/*UP*/
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+_TCHAR *str;
+if (!Arg::str1(_T("direxists"), /*UP*/ (DELTS*&)args, str))
+	return false;
+if (!Arg::done((DELTS*)args, _T("direxists"),parse))
+	return false;
+
+bool yes = false;
+if (str && *str)
+	{
+	std::error_code ec;
+	yes = std::filesystem::is_directory(std::filesystem::path(str), ec) && !ec;
+	}
+sem = new RFASem(yes ? 1LL : 0LL);
+return true;
+}
+
+
+/********************************************
+* FN:		FNFILESIZE
+* CR:		07/03/26 DD.
+* SUBJ:	Size of a regular file, in bytes.
+* RET:	True (executed ok); sem = byte count, or -1 if not a readable file.
+* FORMS:	filesize(path_str)
+********************************************/
+
+bool Fn::fnFilesize(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	/*UP*/
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+_TCHAR *str;
+if (!Arg::str1(_T("filesize"), /*UP*/ (DELTS*&)args, str))
+	return false;
+if (!Arg::done((DELTS*)args, _T("filesize"),parse))
+	return false;
+
+long long bytes = -1LL;
+if (str && *str)
+	{
+	std::error_code ec;
+	std::filesystem::path p(str);
+	if (std::filesystem::is_regular_file(p, ec) && !ec)
+		{
+		std::uintmax_t sz = std::filesystem::file_size(p, ec);
+		if (!ec)
+			bytes = (long long) sz;
+		}
+	}
+sem = new RFASem(bytes);
+return true;
+}
+
+
+/********************************************
+* FN:		FNDELETEFILE
+* CR:		07/03/26 DD.
+* SUBJ:	Delete a regular file.
+* RET:	True (executed ok); sem = 1 if a file was deleted, else 0.
+* NOTE:	Only removes regular files, never directories.
+* FORMS:	deletefile(path_str)
+********************************************/
+
+bool Fn::fnDeletefile(
+	Delt<Iarg> *args,
+	Nlppp *nlppp,
+	/*UP*/
+	RFASem* &sem
+	)
+{
+sem = 0;
+Parse *parse = nlppp->parse_;
+
+_TCHAR *str;
+if (!Arg::str1(_T("deletefile"), /*UP*/ (DELTS*&)args, str))
+	return false;
+if (!Arg::done((DELTS*)args, _T("deletefile"),parse))
+	return false;
+
+bool done = false;
+if (str && *str)
+	{
+	std::error_code ec;
+	std::filesystem::path p(str);
+	// Guard: never remove a directory via deletefile.
+	if (std::filesystem::is_regular_file(p, ec) && !ec)
+		done = std::filesystem::remove(p, ec) && !ec;
+	}
+sem = new RFASem(done ? 1LL : 0LL);
+return true;
+}
 
 
 /********************************************

--- a/lite/fn.h
+++ b/lite/fn.h
@@ -959,6 +959,10 @@ static bool fnStruniquechars(
 	static bool fnWriteKB(Delt<Iarg>*,Nlppp*,RFASem*&);
 	static bool fnLoadkbb(Delt<Iarg>*,Nlppp*,RFASem*&);				// 06/11/26 DD.
 	static bool fnLoaddict(Delt<Iarg>*,Nlppp*,RFASem*&);			// 06/11/26 DD.
+	static bool fnFileexists(Delt<Iarg>*,Nlppp*,RFASem*&);			// 07/03/26 DD.
+	static bool fnDirexists(Delt<Iarg>*,Nlppp*,RFASem*&);			// 07/03/26 DD.
+	static bool fnFilesize(Delt<Iarg>*,Nlppp*,RFASem*&);			// 07/03/26 DD.
+	static bool fnDeletefile(Delt<Iarg>*,Nlppp*,RFASem*&);			// 07/03/26 DD.
 	static bool fnStriscaps(Delt<Iarg>*,Nlppp*,RFASem*&);
 	static bool fnStrisupper(Delt<Iarg>*,Nlppp*,RFASem*&);			// 11/20/01 AM.
 	static bool fnStrislower(Delt<Iarg>*,Nlppp*,RFASem*&);			// 11/20/01 AM.

--- a/lite/func_defs.h
+++ b/lite/func_defs.h
@@ -357,6 +357,12 @@ enum funcDef
 	FNxmlstr,		// 05/10/03 AM.
 	FNxrename,
 
+	// File-system functions.	// 07/03/26 DD.
+	FNdeletefile,
+	FNdirexists,
+	FNfileexists,
+	FNfilesize,
+
 	FNXXYYZZ };
 
 #endif

--- a/lite/funcs.h
+++ b/lite/funcs.h
@@ -350,4 +350,9 @@ _T("xdump"),
 _T("xinc"),
 _T("xmlstr"),		// 05/10/03 AM.
 _T("xrename"),
+// File-system functions.	// 07/03/26 DD.
+_T("deletefile"),
+_T("direxists"),
+_T("fileexists"),
+_T("filesize"),
 0 };

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.6.5"
+#define NLP_ENGINE_VERSION "3.7.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Adds four new file-system built-in functions to the NLP++ language, implemented via `std::filesystem` (error_code overloads — no exceptions):

| Function | Returns | Behavior |
|---|---|---|
| `fileexists(path)` | BOOL(1,0) | 1 if the path is an existing **regular file**, else 0 (a directory returns 0) |
| `direxists(path)` | BOOL(1,0) | 1 if the path is an existing **directory**, else 0 (a file returns 0) |
| `filesize(path)` | INT | byte size of a regular file, or -1 if not a readable file |
| `deletefile(path)` | BOOL(1,0) | removes a regular file (never a directory), 1 on success |

## Implementation

Registered in the usual four places, mirroring the recent `loaddict`/`loadkbb` additions:
- `lite/funcs.h` — name array (appended before the NULL terminator)
- `lite/func_defs.h` — enum, kept index-aligned with `funcs.h`
- `lite/fn.h` — declarations
- `lite/fn.cpp` — dispatch cases + implementations

Interpreted path only (`fn.cpp`), matching the `loaddict` precedent — not wired into the compiled `fnrun.cpp` path.

## Testing

Built the Release engine and verified end-to-end via observable `deletefile` side effects:
- `fileexists` → true for a file, false for a missing path, **false for a directory**
- `direxists` → true for a directory, **false for a file**
- `filesize` → returns the real byte count (> 0) for a file
- `deletefile` → removes the target file

## Docs

Help pages + a new "Table of File Functions" category are in `visualtext-files` (separate PR).

Also bumps `NLP_ENGINE_VERSION` 3.6.5 → **3.7.0** (minor, for the new feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)