### PR TITLE
fix: store quoted numeric dict attribute values as strings (#385)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -3771,6 +3771,7 @@ bool CG::parseDictLine(_TCHAR *buf, CONCEPT *ambigKB, const std::string &file, i
 		bool attrFlag = false;
 		_TCHAR cc = 0;
 		bool addValue = false;
+		bool wasQuoted = false;		// value came in double-quoted -> keep as string.
 
 		caller.file = file;
 		caller.type = DICT_CALL_FILE;
@@ -3818,6 +3819,7 @@ bool CG::parseDictLine(_TCHAR *buf, CONCEPT *ambigKB, const std::string &file, i
 				_tcsnccpy(val, &token[1], len);
 				val[len] = '\0';
 				addValue = true;
+				wasQuoted = true;
 
 			} else if (attrFlag) {
 				_tcsnccpy(val, token, lens[i]);
@@ -3838,7 +3840,9 @@ bool CG::parseDictLine(_TCHAR *buf, CONCEPT *ambigKB, const std::string &file, i
 			}
 
 			if (addValue) {
-				if (unicu::isNumeric(val)) {
+				// A double-quoted value is always a string, even if it looks
+				// numeric (at="123"): preserve the author's intent.	// #385.
+				if (!wasQuoted && unicu::isNumeric(val)) {
 					long long vnum = 0;
 					unicu::strToLong(val,vnum);
 					addVal(parentCon,attr,vnum);
@@ -3846,6 +3850,7 @@ bool CG::parseDictLine(_TCHAR *buf, CONCEPT *ambigKB, const std::string &file, i
 					addSval(parentCon,attr,val);
 				attrFlag = false;
 				addValue = false;
+				wasQuoted = false;
 			}
 		}
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.0"
+#define NLP_ENGINE_VERSION "3.7.1"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Fixes the confirmed, still-live half of #385: a **double-quoted** dictionary attribute value that looks numeric (e.g. `word at="123"`) was stored as the **number** `123` instead of the string `"123"`.

## Root cause

In [`CG::parseDictLine`](cs/libconsh/cg.cpp) the quoted-value branch strips the quotes into `val`, then the value goes through the same `unicu::isNumeric(val)` check as a bare value — so quoting information is lost and `"123"` is converted to a number. The author's explicit "this is a string" intent is discarded.

## Fix

Track whether the value arrived double-quoted (`wasQuoted`); when it did, always store it as a string via `addSval()`, skipping the numeric conversion. One-line-ish, contained to `parseDictLine`.

## Verification

Observed directly through `dicttok` node attributes (strings render quoted, numbers bare):

| Dict entry | Before | After |
|---|---|---|
| `aaq tt="123"` (quoted) | `("tt" 123)` — number | **`("tt" "123")` — string** ✅ |
| `aau tt=456` (unquoted) | `("tt" 456)` | `("tt" 456)` — unchanged ✅ |

No regression: the `emailaddress` analyzer still extracts `_email` fields correctly.

## Notes on the rest of #385

- The original **hang** on unquoted alphanumerics (`at=C123`) is **no longer reproducible** — the dict parser was rewritten to the ICU-based `parseDictLine` since 2023, and real unquoted alphanumeric values (`country=AscensionIsland`) load fine.
- Separately, `parseDictLine` has a latent fixed-buffer risk (`begins[30]`/`lens[30]` with an unbounded `tokint`) for dict lines with >30 tokens — not part of this fix; worth a follow-up guard.

Relates to #385, #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)