### PR TITLE
fix: tokenize currency/symbol chars as punct, not control chars (#500)

### DIFF
--- a/cs/libprim/unicu.cpp
+++ b/cs/libprim/unicu.cpp
@@ -27,6 +27,21 @@ bool unicu::isPunct128(UChar32 c) {
 	);
 }
 
+// Printable symbol characters: currency ($ EUR GBP JPY), math, modifier, and
+// other symbols. Tokenizers treat these like punctuation instead of dropping
+// them into the PNCTRL (control-char) bucket -- see #500.
+bool unicu::isSymbol(UChar32 c) {
+	switch (u_charType(c)) {
+		case U_CURRENCY_SYMBOL:
+		case U_MATH_SYMBOL:
+		case U_MODIFIER_SYMBOL:
+		case U_OTHER_SYMBOL:
+			return true;
+		default:
+			return false;
+	}
+}
+
 bool unicu::isSingle(UChar32 c) {
 	return isChinese(c) || isEmoji(c);
 }

--- a/include/Api/prim/unicu.h
+++ b/include/Api/prim/unicu.h
@@ -24,6 +24,7 @@ namespace unicu
     bool isWhiteSpace(UChar32 c);
     bool isPunct(UChar32 c);
     bool isPunct128(UChar32 c);
+    bool isSymbol(UChar32 c);
     bool isSingle(UChar32 c);
     bool isGlyph(UChar32 c);
     bool isChinese(UChar32 c);

--- a/lite/tok.cpp
+++ b/lite/tok.cpp
@@ -424,6 +424,10 @@ void Tok::nextTok(
 			typ = PNWHITE;
 			++ulen;
 		}
+		else if (unicu::isSymbol(c)) {	// currency/symbol chars, e.g. $ £ ¥ € -- #500.
+			typ = PNPUNCT;
+			++ulen;
+		}
 		else {
 			typ = PNCTRL;
 			++ulen;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.1"
+#define NLP_ENGINE_VERSION "3.7.2"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Fixes #500: currency symbols like `£ ¥ €` were tokenized as **control characters** instead of symbols.

## Root cause

`£` (U+00A3, Unicode category **Sc** = currency symbol) isn't matched by `unicu::isPunct` (ICU's `u_ispunct` excludes Sc), nor by the alpha/num/white checks — so `Tok::nextTok` fell through to the `PNCTRL` (control-char) bucket ([tok.cpp](lite/tok.cpp)). `dicttok` then stamped a bogus `("CTRL" <lead-byte>)` attribute — e.g. `£` (UTF-8 `C2 A3`) showed as `("CTRL" 194)`.

## Fix

- New `unicu::isSymbol()` — true for currency / math / modifier / other symbol categories (`u_charType`).
- `Tok::nextTok` classifies symbols as `PNPUNCT` **before** the `PNCTRL` fallback. This covers both the `tokenize` and `dicttok` passes (`dicttok` calls `nextTok`).

## Result

| Char | Before | After |
|---|---|---|
| `$` | punct | punct |
| `£` `¥` `€` | **ctrl** + `("CTRL" 194)` | **punct** ✅ |

Blast radius is minimal: ASCII symbols (`+ < = > | ~`) were already caught by `isPunct128`, so only previously-misclassified **non-ASCII** symbols move from `PNCTRL` to `PNPUNCT`.

## Testing
- `£ ¥ €` now tokenize as `punct` (no spurious `CTRL`).
- Regression: `emailaddress` still extracts email; plain ASCII (alpha/punct/num) unchanged.

## Not addressed
The legacy byte-based `cmltok` tokenizer (rarely used) is still non-Unicode-aware; fixing it means a UTF-8 rewrite — out of scope.

---

⚠️ **Merge order:** bumps `NLP_ENGINE_VERSION` → **3.7.2**, which assumes **#684 (3.7.1) merges first**. If this merges before #684, resolve the trivial `main.cpp` version-line conflict (keep 3.7.2) so master doesn't skip 3.7.1.

Fixes #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)