### PR TITLE
fix: preserve punctuation in unquoted dict attribute values (#481)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -3822,8 +3822,22 @@ bool CG::parseDictLine(_TCHAR *buf, CONCEPT *ambigKB, const std::string &file, i
 				wasQuoted = true;
 
 			} else if (attrFlag) {
-				_tcsnccpy(val, token, lens[i]);
-				val[lens[i]] = '\0';
+				// Unquoted value. The line tokenizer splits on punctuation, so a
+				// value such as A-B-C arrives as separate tokens (A, -, B, -, C).
+				// Re-join tokens that are contiguous in the source (no whitespace
+				// gap) so hyphens/dots inside an unquoted value are preserved
+				// rather than mis-read as extra attributes. -- #481.
+				int vbeg = begins[i];
+				int vend = begins[i] + lens[i];
+				while (i + 1 < tokint && begins[i+1] == vend) {
+					i++;
+					vend = begins[i] + lens[i];
+				}
+				int vlen = vend - vbeg;
+				if (vlen >= MAXSTR)
+					vlen = MAXSTR - 1;
+				_tcsnccpy(val, &line[vbeg], vlen);
+				val[vlen] = '\0';
 				addValue = true;
 				attrFlag = false;
 


### PR DESCRIPTION
## Summary

Fixes the unquoted case of #481: an unquoted dict attribute value containing a hyphen (or dot) was silently split apart.

## Root cause

`CG::parseDictLine` tokenizes a dict line by splitting on punctuation, so
```
word code=A-B-C
```
arrived as separate tokens (`A`, `-`, `B`, `-`, `C`). The value branch consumed only the first token (`A`), then mis-read the remaining `-` and `C` as *further attributes* — producing `("code" "A") ("-" "B") ...` instead of `("code" "A-B-C")`.

## Fix

In the value branch, re-join tokens that are **contiguous in the source** (no whitespace gap) into the full value. Contained to `parseDictLine` — the shared tokenizer is untouched — and only affects unquoted values that contain internal punctuation.

## Result

| Dict entry | Before | After |
|---|---|---|
| `code=A-B-C` | `("code" "A") ("-" "B")` | `("code" "A-B-C")` ✅ |
| `plain=hello-world` | split | `("plain" "hello-world")` ✅ |
| `ver=3.14` | split | `("ver" "3.14")` ✅ |
| `q="x-y"` (quoted) | `("q" "x-y")` | `("q" "x-y")` ✅ unchanged |
| `num=42` | `("num" 42)` | `("num" 42)` ✅ still numeric |

No regression: the `emailaddress` analyzer still extracts email fields.

## Note
#481's original example used a **quoted** value (`completo="zigue-zague"`), which already works on the current engine; this fixes the **unquoted** form of the same "hyphen in attribute value" problem.

⚠️ **No version bump in this PR** — #685 (→3.7.2) is still in flight. Bump to **3.7.3** when merging this (after #685), or tell me and I'll add it.

Fixes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)