### PR TITLE
fix: read numeric KBB attribute values as numbers, not strings (#439) + 3.7.4

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -4100,7 +4100,16 @@ void CG::parseKBBLine(_TCHAR *buf, std::vector<CONCEPT *> &cons, int32_t &index,
 				_tcsnccpy(val, &line[start],end-start);
 				int adjust = length && c != ']' && c != '"' && c != ',' ? 0 : 1;
 				val[end-start-adjust] = '\0';
-				addSval(con,attr,val);
+				// An unquoted numeric value is stored as a number; a quoted value
+				// (openDouble) is always a string. This is what lets a KBB round-
+				// trip num/float vs string, instead of everything being a string.
+				// -- #439.
+				if (!openDouble && unicu::isNumeric(val)) {
+					long long vnum = 0;
+					unicu::strToLong(val,vnum);
+					addVal(con,attr,vnum);
+				} else
+					addSval(con,attr,val);
 				start = end;
 				if (end >= length) {
 					conceptDone = false;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.3"
+#define NLP_ENGINE_VERSION "3.7.4"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

Fixes the engine (read) half of #439: `.kbb` attribute values that are numeric were being stored as **strings**.

## Root cause

`CG::parseKBBLine` stored every attribute value via `addSval` (string). But num/float values are serialized **unquoted** in a KBB, so on read they came back as the string `"42"` rather than the number `42` — the KBB round-trip flattened all types to strings.

## Fix (read side)

An unquoted value that is numeric is now stored via `addVal` (number); a double-quoted value (`openDouble`) is always kept as a string. So:

| KBB value | Stored as |
|---|---|
| `count=42` (unquoted, numeric) | **number** ✅ (was string) |
| `price=3` | **number** ✅ |
| `color=red` (unquoted, non-numeric) | string |
| `label="12345"` (quoted) | string ✅ (quoted stays string) |

Verified by loading a KBB and checking `attrtype()`/`getnumval()`. No regression: `emailaddress` and `telephone` (real `.kbb` country lists) still load and extract.

## The other half lives in the analyzers repo

The **write** side is NLP++ code — `SaveKB` in the `KBFuncs.nlp` library (package-analyzers), not the engine. It already writes num/float unquoted, but string values go through `QuoteIfNeeded`, which only quotes on space/punct — so a numeric-looking **string** like `12345` is written unquoted and would now read back as a number. For full round-trip fidelity, `SaveKB` should quote string values always. That's a separate change in the analyzers repo (I can take it next).

Per the maintainer decision on this issue, unquoted-numeric → number everywhere; existing KBs get the corrected typing (regenerate any that relied on the old string storage).

Bumps `NLP_ENGINE_VERSION` → **3.7.4**.

Fixes #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)