### PR TITLE
fix: defer user-KB load until first tokenizer pass so pre-tokenizer passes run first

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -85,6 +85,7 @@ nlp_PUNCT =
 0;
 
 dirty_ = false;																// 05/12/00 AM.
+userkbLoaded_ = false;														// 07/11/26 DD.
 // Must run on Linux too: hkbdll_ was previously only zeroed under
 // #ifndef LINUX, leaving it uninitialized on Linux. readKB() treats a
 // nonzero hkbdll_ as "compiled KB loaded" and skips reading the dict
@@ -376,6 +377,7 @@ if (cg)
 
 _TCHAR	*CG::getAppdir()	{return appdir_;}
 bool	 CG::getDirty()	{return dirty_;}								// 05/12/00 AM.
+bool	 CG::getUserkbLoaded()	{return userkbLoaded_;}				// 07/11/26 DD.
 AKBM	*CG::getKBM()		{return kbm_;}									// 06/11/02 AM.
 ALIST *CG::getALIST()	{return alist_;}								// 08/14/02 AM.
 #ifndef LINUX
@@ -388,6 +390,7 @@ HINSTANCE CG::getHkbdll()	{return hkbdll_;}
 ********************************************/
 void	CG::setAppdir(_TCHAR *x)	{_tcscpy(appdir_, x);	}
 void	CG::setDirty(bool x)		{dirty_ = x;			}				// 05/12/00 AM.
+void	CG::setUserkbLoaded(bool x)	{userkbLoaded_ = x;	}				// 07/11/26 DD.
 void	CG::setKBM(AKBM *x)		{kbm_	= x;				}				// 06/11/02 AM.
 void	CG::setALIST(ALIST *x)	{alist_ = x;			}
 #ifndef LINUX

--- a/include/Api/consh/cg.h
+++ b/include/Api/consh/cg.h
@@ -106,6 +106,10 @@ public:
 	// Modify
 	void setAppdir(_TCHAR *);
 	void setDirty(bool);														// 05/12/00 AM.
+	// Has the user KB (kb/user) been read into memory yet?  Loading is deferred
+	// for interpreted runs so pre-tokenizer passes run first.			// 07/11/26 DD.
+	bool getUserkbLoaded();
+	void setUserkbLoaded(bool);
 	void setKBM(AKBM*);														// 06/11/02 AM.
 	void setALIST(ALIST*);													// 08/14/02 AM.
 //#ifndef LINUX
@@ -668,6 +672,7 @@ private:
 	std::string missingLogDir_;			// Where to write missing-words.log (else kbdir_).
 
 	bool dirty_;					// KB dirty flag.						// 05/12/00 AM.
+	bool userkbLoaded_;			// True once the user KB has been read in.	// 07/11/26 DD.
 
 	// For diverting the libconsh error output.						// 09/16/99 AM.
 	std::_t_ostream *serr_;															// 09/16/99 AM.

--- a/include/Api/lite/vtrun.h
+++ b/include/Api/lite/vtrun.h
@@ -86,7 +86,8 @@ public:
 	CG *makeCG(         // 07/18/03 AM.
 		_TCHAR *appdir,    // Folder housing the kb folder.
 		bool compiled,   // If loading the compiled kb.
-		NLP *nlp         // Associated analyzer, if any.
+		NLP *nlp,        // Associated analyzer, if any.
+		bool deferUserKB = false  // Create the CG but do NOT read kb/user yet.	// 07/11/26 DD.
 		);
 
 	// API: Delete a knowledge base.

--- a/lite/nlp_engine.cpp
+++ b/lite/nlp_engine.cpp
@@ -279,11 +279,19 @@ int NLP_ENGINE::init(
         // SET UP THE KNOWLEDGE BASE
         /////////////////////////////////////////////////
 
+        // Interpreted run: defer reading kb/user until Parse::execute reaches
+        // the first tokenizer/grammar pass, so any pre-tokenizer pass (eg a
+        // python pass that generates kbb/dict files) runs first and the load
+        // then sees what it produced. Compile modes and compiled-analyzer runs
+        // still load eagerly here (they don't go through Parse::execute).	// 07/11/26 DD.
+        bool deferUserKB = !m_compile && !m_compileKB && !m_compileAna && !m_compiled;
+
          clock_t kb_s_time = clock();                                  // KB read timing.
          m_cg = m_vtrun->makeCG(                                        // 07/21/03 AM.
                 m_anadir,
                 true,      // LOAD COMPILED KB IF POSSIBLE.
-                m_nlp);      // Associated analyzer object.              // 07/21/03 AM.
+                m_nlp,       // Associated analyzer object.              // 07/21/03 AM.
+                deferUserKB);                                           // 07/11/26 DD.
 
 
         if (!m_cg)                                                       // 07/21/03 AM.
@@ -297,7 +305,8 @@ int NLP_ENGINE::init(
         }
 
         double kb_tot = (double)(clock() - kb_s_time) / CLOCKS_PER_SEC;
-        std::_t_cerr << _T("[Loaded knowledge base: ") << kb_tot << _T(" sec]") << std::endl;             // 02/19/19 AM.
+        if (!deferUserKB)                                                // 07/11/26 DD.
+            std::_t_cerr << _T("[Loaded knowledge base: ") << kb_tot << _T(" sec]") << std::endl;             // 02/19/19 AM.
 
         // Compile the KB if requested. Analyzer-only compile skips this.
         if (m_compile || m_compileKB)

--- a/lite/parse.cpp
+++ b/lite/parse.cpp
@@ -45,6 +45,8 @@ All rights reserved.
 #include "ana.h"
 #include "seqn.h"				// 02/26/01 AM.
 #include "Eana.h"				// 02/26/01 AM.
+#include "consh/libconsh.h"	// CG (deferred user-KB load).	// 07/11/26 DD.
+#include "consh/cg.h"
 //#include "iarg.h"				// 05/23/01 AM.
 #include "parse.h"
 #include "lite/nlp.h"		// FOR DEBUGGING!!!	// 10/10/99 AM.
@@ -438,6 +440,23 @@ return true;
 * SUBJ:	Perform the analysis of the current text.
 ********************************************/
 
+// Does this pass consume the user KB (tokenizer or grammar pass)?  The user KB
+// is read into memory just before the first such pass, so any pre-tokenizer
+// pass (eg a python pass that generates kbb/dict files) runs first.	// 07/11/26 DD.
+static bool kbConsumerAlgo(_TCHAR *salgo)
+{
+if (!salgo || !*salgo)
+	return false;
+return !strcmp_i(salgo, _T("dicttok"))
+	 || !strcmp_i(salgo, _T("dicttokz"))
+	 || !strcmp_i(salgo, _T("cmltok"))
+	 || !strcmp_i(salgo, _T("chartok"))
+	 || !strcmp_i(salgo, _T("tok"))
+	 || !strcmp_i(salgo, _T("nlp"))
+	 || !strcmp_i(salgo, _T("rec"))
+	 || !strcmp_i(salgo, _T("pat"));
+}
+
 void Parse::execute()
 {
 Delt<Seqn> *seq;
@@ -481,10 +500,22 @@ if (!ana)	// 05/05/09 AM.
 	return;	// 05/05/09 AM.
 	}
 
+// KB whose kb/user read was deferred (interpreted run): load it just before
+// the first pass that consumes it, so pre-tokenizer passes run first.	// 07/11/26 DD.
+CG *cg = ana->getCG();
+
 // Cosmetic rewrite as for loop.											// 11/10/99 AM.
 for (seq = ana->getSeq(); seq; seq = seq->Right())
 	{
 	++rulepass_;																// 02/03/05 AM.
+
+	if (cg && !cg->getUserkbLoaded()										// 07/11/26 DD.
+		 && kbConsumerAlgo(seq->getData()->getAlgoname()))
+		{
+		cg->readKB(_T("user"));
+		cg->setUserkbLoaded(true);
+		}
+
 	if (!stepExecute(seq, ++currpass_))		// 05/15/99 AM.		// 08/22/02 AM.
 		return;																	// 05/15/99 AM.
 

--- a/lite/vtrun.cpp
+++ b/lite/vtrun.cpp
@@ -515,7 +515,8 @@ return 0;
 CG *VTRun::makeCG(
 	_TCHAR *appdir,	// Directory housing kb folder.
 	bool compiled,	// If loading compiled kb.
-	NLP *nlp			// Associated analyzer if any.
+	NLP *nlp,			// Associated analyzer if any.
+	bool deferUserKB	// Create the CG but do NOT read kb/user yet.	// 07/11/26 DD.
 	)
 {
 if (!appdir || !*appdir)
@@ -536,20 +537,28 @@ if (!cg)
    return 0;
    }
 
+// Defer the kb/user read for interpreted runs: Parse::execute reads it just
+// before the first tokenizer/grammar pass, so pre-tokenizer passes (eg a
+// python pass that GENERATES kbb/dict files) run first and the normal load
+// then picks up whatever they produced.							// 07/11/26 DD.
+if (!deferUserKB)
+   {
 //return cg;	///// TESTING!!!!!!!!!!!!  // 07/28/03 AM.
 #ifdef QDBM_
 if (!cg->getLoaded())		// QDBM ...	// 03/04/07 AM.
 #endif
-if (!cg->readKB(_T("user")))	// 09/23/20 AM.
-   {
-   std::_t_cerr << _T("[Couldn't read knowledge base.]") << std::endl;
+   if (!cg->readKB(_T("user")))	// 09/23/20 AM.
+      {
+      std::_t_cerr << _T("[Couldn't read knowledge base.]") << std::endl;
 //   if (cg) delete cg;	// 07/18/03 AM.
-	CG::deleteCG(cg);
-   return 0;
-   }
+	   CG::deleteCG(cg);
+      return 0;
+      }
+   cg->setUserkbLoaded(true);								// 07/11/26 DD.
 #ifdef QDBM_
-cg->setLoaded(true);	// 03/04/07 AM.
+   cg->setLoaded(true);	// 03/04/07 AM.
 #endif
+   }
 
 if (nlp)
 	nlp->setCG(cg);      // Give analyzer the CG REFERENCE.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.5"
+#define NLP_ENGINE_VERSION "3.7.6"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem

For interpreted runs the engine reads `kb/user` **once at init** (`NLP_ENGINE::init` → `makeCG` → `readKB("user")`), *before* any analyzer pass executes. A pre-tokenizer pass that **generates** knowledge-base files — e.g. a `python` pass that builds `<name>.kbb` from `<name>.json` in `kb/user` — therefore ran *after* the KB was already loaded. Its output was only picked up on the **next** run, never the run that produced it (generate on run 1, only visible on run 2).

## Fix

Make the general principle hold: **any pass before the tokenizer runs before the KB/dict files are loaded.** The `kb/user` read is moved out of init and into `Parse::execute`, firing **once**, just before the first pass that actually consumes the KB (a tokenizer or grammar pass). Pre-tokenizer passes run first, and the normal load then sees whatever they produced.

The mechanism is generic — the `python` pass is **unchanged** and knows nothing about KBBs. It works for any pre-tokenizer pass that generates dict/kbb files (or does anything else).

### Changes
- **`CG`** (`cg.h`/`cg.cpp`): add `userkbLoaded_` flag (+ `getUserkbLoaded`/`setUserkbLoaded`) so the load happens exactly once, including across multi-file / re-entrant runs.
- **`VTRun::makeCG`**: add `deferUserKB` param to create the CG without reading `kb/user`.
- **`NLP_ENGINE::init`**: defer only for interpreted runs; compile modes (`-COMPILE`/`-COMPILEKB`/`-COMPILEANA`) and compiled-analyzer runs (`-COMPILED`, which bypass `Parse::execute`) still load eagerly.
- **`Parse::execute`**: `readKB("user")` once, before the first `tok`/`dicttok`/`dicttokz`/`cmltok`/`chartok`/`nlp`/`rec`/`pat` pass.

## Verification
- A single clean run of an analyzer whose pre-tokenizer `python` pass generates `data.kbb` now loads that data **in the same run** (previously required two runs).
- Dictionary lookups still work: the token tree after `dicttokz` shows POS tags (noun/verb/adj/det/prep), confirming `en-full` dict + `word.kb`/`attr.kb` are loaded *before* the tokenizer — just deferred past the python pass.
- Run 2 (kbb already present) still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)