### PR TITLE
fix: lazy-load *full.kbb under its own top concept and consult every kbb (3.7.6)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -4397,11 +4397,35 @@ bool CG::openFullKBB(const std::string &file)
 		return false;
 	}
 
-	// The kbb's top concept ("dictionary"). Lazily-loaded words hang off this,
-	// matching the output pass's getconcept(findroot(),"dictionary").
-	f.root = getConcept(findRoot(), _T("dictionary"));
+	// The kbb's top concept. Read it from the file (the first non-comment line
+	// at indent 0) rather than assuming "dictionary": an isolated kbb such as
+	// "en-roots-full.kbb" has its own top concept ("roots"), and its words must
+	// hang off that so the analyzer can find it (getconcept(findroot(),"roots")).
+	// This also creates that concept up front, before any word is looked up.
+	_TCHAR rootName[MAXMSG];
+	rootName[0] = '\0';
+	f.stream.clear();
+	f.stream.seekg(0);
+	{
+		_TCHAR line[MAXMSG];
+		while (f.stream.getline(line, MAXMSG)) {
+			chompCRLF(line);
+			if (line[0] == '#' || line[0] == '\0' || line[0] == ' ')
+				continue;					// comment, blank, or indented line
+			int i = 0;
+			while (line[i] && line[i] != ':') {
+				rootName[i] = line[i];
+				i++;
+			}
+			rootName[i] = '\0';
+			break;
+		}
+	}
+	f.root = getConcept(findRoot(), (rootName[0] ? rootName : _T("dictionary")));
 
-	std::_t_cerr << _T("[Lazy-loading words from ") << file << _T("]") << std::endl;
+	std::_t_cerr << _T("[Lazy-loading words from ") << file
+				 << _T(" under \"") << (rootName[0] ? rootName : _T("dictionary"))
+				 << _T("\"]") << std::endl;
 	return true;
 }
 
@@ -4459,15 +4483,21 @@ CONCEPT *CG::findFullWord(_TCHAR *str)
 	return word;
 }
 
-// Look up str across every open *full.kbb, returning the first match.
+// Look up str in every open *full.kbb. Each kbb is an independent knowledge
+// source with its own top concept (eg "dictionary" for en-full.kbb, "roots"
+// for en-roots-full.kbb), so we build the word under each one that has it --
+// not just the first -- and return the first match to the caller (the token's
+// primary word concept). Lookups are cached after the first hit, so this whole
+// scan runs at most once per distinct word.
 CONCEPT *CG::findFullKBBWord(_TCHAR *str)
 {
+	CONCEPT *first = 0;
 	for (FullFile &f : fullKBBs_) {
 		CONCEPT *word = searchKBBFile(f, str);
-		if (word)
-			return word;
+		if (word && !first)
+			first = word;
 	}
-	return 0;
+	return first;
 }
 
 // Binary-search one open *full.kbb for str. If found, build that word's block

--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -4421,11 +4421,12 @@ bool CG::openFullKBB(const std::string &file)
 			break;
 		}
 	}
-	f.root = getConcept(findRoot(), (rootName[0] ? rootName : _T("dictionary")));
+	if (!rootName[0])
+		strcpy(rootName, _T("dictionary"));	// no top concept found; fall back
+	f.root = getConcept(findRoot(), rootName);
 
 	std::_t_cerr << _T("[Lazy-loading words from ") << file
-				 << _T(" under \"") << (rootName[0] ? rootName : _T("dictionary"))
-				 << _T("\"]") << std::endl;
+				 << _T(" under \"") << rootName << _T("\"]") << std::endl;
 	return true;
 }
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.6"
+#define NLP_ENGINE_VERSION "3.7.7"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem
A lazily-loaded `*full.kbb` **without** a paired `*full.dict` was always hung under a hardcoded `dictionary` root, and per-word lookups stopped at the first `*full.kbb` that matched.

So an isolated kbb such as `en-roots-full.kbb` (whose top concept is `roots`):
- never created its `roots` concept — words went under `dictionary` instead, and
- was never consulted for words that also live in `en-full.kbb` (lookup short-circuited).

The result: `roots` stayed empty and `findconcept(findroot(),"roots")` failed in downstream passes (reported against `textgen/analyzers/TextGen`, `spec/output.nlp:17`).

## Fix
- **`openFullKBB`** — read the actual top concept (first non-comment indent-0 line) from the kbb and hang looked-up words under it, instead of hardcoding `"dictionary"` (falls back to `"dictionary"` when none is found).
- **`findFullKBBWord`** — treat each `*full.kbb` as an independent knowledge source: build the word under *every* kbb that contains it, and return the first match as the token's primary word concept. Cached after the first hit, so the scan runs at most once per distinct word.

## Verification
Against `TextGen`:
- `en-full.kbb` loads under `dictionary`, `en-roots-full.kbb` loads under `roots` (was `dictionary`).
- `output.nlp:17` `findconcept(findroot(),"roots")` no longer errors.
- Generated `roots.kbb` is populated with words found in the text and their morphology, e.g. `group → grouped/grouper/grouping/groups`.
- Regression: `emailaddress` analyzer still extracts (`_EMAILZONE` unchanged).

Bumps `NLP_ENGINE_VERSION` to 3.7.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)