### PR TITLE
fix: preserve all attributes on inline KBB sense lines (3.7.8)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -4043,6 +4043,24 @@ void CG::parseKBBLine(_TCHAR *buf, std::vector<CONCEPT *> &cons, int32_t &index,
 			if (c == '#') {
 				break;
 			}
+			// A space ends an unquoted attribute value in the inline KBB form
+			// "attr=val attr=val ..." (eg "m01: pos=verb vform=past tense=past").
+			// Without this, each space just reset start and every value but the
+			// last one (which EOL terminates) was silently dropped.
+			else if (conceptDone && attrFlag && !openDouble && !openSquare
+						&& unicu::isWhiteSpace(c)) {
+				_tcsnccpy(val, &line[start], end-start-1);
+				val[end-start-1] = '\0';
+				if (unicu::isNumeric(val)) {
+					long long vnum = 0;
+					unicu::strToLong(val, vnum);
+					addVal(con, attr, vnum);
+				} else
+					addSval(con, attr, val);
+				start = end;
+				attrFlag = false;
+				openDouble = false;
+			}
 			else if (conceptDone && !openDouble && unicu::isWhiteSpace(c)) {
 				int doNothing = 1;
 				start = end;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.7"
+#define NLP_ENGINE_VERSION "3.7.8"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem
`parseKBBLine` only committed an unquoted attribute value when it hit a comma, a quote, or end-of-line — **never a space**. So an inline sense line such as:

```
m01: pos=verb vform=past tense=past
```

lost every attribute but the last: each space just reset the scan start and silently discarded the pending value. Only `tense=past` (terminated by EOL) survived.

`en-full.kbb` was unaffected because it stores one attribute per line (each EOL-terminated). But a kbb-only source like `en-roots-full.kbb` uses the inline space-separated form, so its lazily looked-up words landed in the KB with only their final attribute — the word block was **not** an exact copy of the source.

## Fix
Make a space terminate an unquoted attribute value in `parseKBBLine`, using the same numeric-vs-string handling as the existing comma/EOL path (#439). Quoted values (`"a b"`) and bracketed concept paths are unaffected — the new branch requires `!openDouble && !openSquare`.

## Verification
Re-running the `TextGen` analyzer, the generated `roots.kbb` now reproduces every attribute from `en-roots-full.kbb`, e.g.:

```
m01:  pos=verb  vform=past  tense=past      (all three, was only tense=past)
m02:  pos=verb  vform=pastpart
```

The word blocks are now a verbatim copy of the source kbb (the remaining inline-vs-one-per-line layout is purely `SaveKB`'s dump format, not data loss).

Bumps `NLP_ENGINE_VERSION` to 3.7.8. Follows #691 (v3.7.7), which is what introduced kbb-only lazy loading.

## Note
This change was briefly committed directly to `master` (`da2f6b1`/`df7ed4e`) due to a shared-working-directory mixup; those commits have been reverted from `master` and re-applied here so the fix goes through review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)