### PR TITLE
feat: open lazy *full.dict/*full.kbb in compiled-KB analyzers

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -611,6 +611,13 @@ if (!kbm_ || !ast_ || !aptr_ || !asym_ || !acon_)	// 07/29/03 AM.
 if (hkbdll_)
 	{
 	*cgerr << _T("[Using compiled kb. readKB ignored.]") << std::endl;	// 06/29/00 AM.
+	// The compiled kb.dll holds the hierarchy/dict/kbb concepts, but a
+	// "*full.dict"/"*full.kbb" is never compiled in -- it stays a sorted file
+	// on disk that we binary-search per unknown word. readKB normally opens
+	// those via readDicts/readKBBs below, but that code is skipped for a
+	// compiled KB, so open them explicitly here or lazy lookup never runs
+	// in a compiled analyzer.									// 07/13/26 DD.
+	openFullFiles();
 	return true;		// This is just info, ok.						// 06/29/00 AM.
 	}
 
@@ -3551,6 +3558,46 @@ std::string CG::removeExtension(const std::string& filename) {
     if (lastDot == std::string::npos)
         return filename;
     return filename.substr(0, lastDot);
+}
+
+// Scan the kb dir for lazy "*full.dict"/"*full.kbb" files and open them for
+// on-disk stream lookup (openFullDict/openFullKBB) without loading them into
+// the KB. Used by the compiled-KB path, where readKB() returns early before it
+// would otherwise open them via readDicts/readKBBs.
+//
+// Note: we glob "*.dict"/"*.kbb" directly rather than reusing openDict()/
+// openKBB(), which short-circuit to a consolidated all.dict/all.kbb and would
+// not surface the separate full files. Each hit is filtered through
+// stemEndsWithFull so the same "-full"/"_full" boundary rule applies.	// 07/13/26 DD.
+void CG::openFullFiles() {
+	// In a compiled analyzer the source kb/user dir may be stripped down to just
+	// the lazy "*full" blobs -- or removed entirely. read_files() opens a
+	// directory_iterator, which throws on a missing dir, so bail out quietly if
+	// there is nothing to scan.
+	std::error_code ec;
+	if (!std::filesystem::is_directory(kbdir_, ec))
+		return;
+
+	std::vector<std::filesystem::path> files;
+	std::vector<std::filesystem::path>::iterator ptr;
+
+	read_files(kbdir_, _T("(.*\\.kbb)$"), files);
+	for (ptr = files.begin(); ptr < files.end(); ptr++) {
+		if (!stemEndsWithFull(removeExtension(ptr->filename().string())))
+			continue;
+		if (!openFullKBB(ptr->string()))
+			std::_t_cerr << _T("[Error: ") << ptr->string()
+				<< _T(" is not byte-sorted (LC_ALL=C); cannot lazy-load. Skipping.]") << std::endl;
+	}
+
+	read_files(kbdir_, _T("(.*\\.dict)$"), files);
+	for (ptr = files.begin(); ptr < files.end(); ptr++) {
+		if (!stemEndsWithFull(removeExtension(ptr->filename().string())))
+			continue;
+		if (!openFullDict(ptr->string()))
+			std::_t_cerr << _T("[Error: ") << ptr->string()
+				<< _T(" is not byte-sorted (LC_ALL=C); cannot lazy-load. Skipping.]") << std::endl;
+	}
 }
 
 bool CG::openDict(std::vector<std::filesystem::path>& files) {

--- a/include/Api/consh/cg.h
+++ b/include/Api/consh/cg.h
@@ -231,6 +231,12 @@ public:
 	bool openKBB(std::vector<std::filesystem::path>& files);
 	bool readKBBs(std::vector<std::filesystem::path> files);
 	bool readKBB(std::string file);
+
+	// Open the lazy "*full.dict"/"*full.kbb" files for on-disk stream lookup
+	// WITHOUT loading them into the KB. Called both from the interpreted load
+	// (implicitly, via readDicts/readKBBs) and from the compiled-KB path, where
+	// readKB() otherwise returns early and would leave the full files unopened.
+	void openFullFiles();
 	// Parse a single line of a "*.kbb" file (indented "dictionary" format) into
 	// the KB. cons/index carry the indentation state between calls; root is the
 	// parent for top-level (indent 0) concepts.							// 06/10/26.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.8"
+#define NLP_ENGINE_VERSION "3.7.9"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem

A `*full.dict`/`*full.kbb` is never compiled into `kb.dll` — it stays a sorted file the engine binary-searches on disk per unknown word. `readKB()` opens those via `readDicts`/`readKBBs`, but returns early the moment a compiled KB (`kb.dll` → `hkbdll_`) is loaded:

```cpp
if (hkbdll_) {
    *cgerr << _T("[Using compiled kb. readKB ignored.]");
    return true;   // openDict/openKBB never ran
}
```

So in a compiled analyzer the full files were never opened and every lazy word came back unknown. This blocks shipping a fully-compiled analyzer (`run.dll` + `kb.dll`, spec and non-full sources removed) that still relies on a lazy lexicon.

## Fix

Add `CG::openFullFiles()`, which scans `kb/user` for `*full.dict`/`*full.kbb` (filtered through `stemEndsWithFull`) and opens each for on-disk stream lookup via the existing `openFullDict`/`openFullKBB`, and call it on the `hkbdll_` branch of `readKB`. Guarded with an `is_directory` check so a stripped compiled-analyzer folder without `kb/user` does not throw.

Everything downstream (`findWordConcept` → `findFullWord`) is agnostic to whether the base KB came from `kb.dll` or interpreted files.

## Verification (end-to-end)

Built `nlp.exe` with the change, generated + compiled a real `kb.dll` for the `fulldict-hang` fixture (has `zz-full.dict`), staged it into `bin/`, and ran:

- `[Loaded compiled KB library: 0.265 sec]` — compiled KB loaded, `readKB` took the early-return branch
- `[Lazy-loading words from …zz-full.dict]` — `openFullFiles()` fired on the compiled branch (impossible before this change)
- `apple/banana/cherry → ("n" 1) ("pos num" 1)` — resolved via stream lookup, identical to the interpreted baseline

`consh.lib` and `nlp.exe` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)