### PR TITLE
feat: support python passes in compiled analyzers (3.7.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@ The NLP engine is the engine that runs text analyzers writtein in [NLP++](http:/
 1. Calling the nlp.exe command line executable (this is what the VSCode NLP++ Language Extension does)
 1. Calling from within C++ or another language that can call c++ functions
 
+## What's New in Version 3
+
+Version 3 is the release line in which NLP++ became **compilable, cloud-buildable, and installable from package managers**, while hardening the engine across all supported platforms. NLP++ is *glass-box*, **deterministic** NLP — the same input always produces the same output from rules you can read — and Version 3 makes that engine faster, easier to build, and easier to adopt.
+
+### Compiled analyzers (NLP++ → C++ → native library)
+- **One-click compilation.** Compiling an analyzer and its knowledge base to a native shared library (`.dll` / `.so` / `.dylib`) was always technically possible but effectively expert-only. Version 3 turns it into a one-click action (in the VS Code extension) with no C++ knowledge required. Use `-COMPILE` to generate the C++, then `-COMPILED` to run the compiled analyzer.
+- **Granular compile targets.** `-COMPILE` (analyzer + KB), `-COMPILEKB` (KB only), and `-COMPILEANA` (rules only) so you can recompile just what changed.
+- **Compiled Python passes.** A `python` pass anywhere in `analyzer.seq` (including before the tokenizer, e.g. to build a KB/dictionary from JSON) is now emitted into the compiled analyzer and runs from the native library — previously these only worked interpreted.
+- **Cross-platform generated code.** The generated C++ compiles and links on Windows, Linux, and macOS; compiled-run dispatch works uniformly across all three.
+
+### Cloud compile
+- A **cloud-compile service** builds the native libraries for Windows, Linux, and macOS on hosted runners, so users don't need a local C++ toolchain. Available from the VS Code extension and the language bindings.
+
+### Lazy dictionaries & knowledge bases (large lexicons)
+- **`*-full.dict` / `*-full.kbb` files load lazily** — the engine binary-searches the sorted file on disk one word at a time instead of loading the whole lexicon into memory, dramatically cutting memory and startup cost. Multiple lazy files can be open at once.
+- Lazy files are **never compiled into the library** — they stay as data files and are stream-searched at runtime, so they work identically in interpreted and compiled analyzers. This lets you ship a compiled analyzer whose only visible data is the `*-full` lexicon.
+- New `loadkbb` and `loaddict` NLP++ functions.
+
+### Native language bindings
+- **Node.js** — `npm install nlpplus` embeds the engine directly (new in Version 3).
+- **Python** — `pip install NLPPlus` native bindings gained the compile / cloud-compile APIs (`compile()`, `cloud_compile()`).
+
+### NLP++ language & robustness
+- `_xVAR("attribute")` match-list special for attribute access in rules.
+- Digits allowed in underscore-prefixed token names (e.g. `_token2`).
+- A long list of compiled-mode correctness fixes (output flushing, null-guards, evaluation-order) and cross-platform build fixes.
+
+For a fuller narrative of the Version 3 work across all the VisualText repos, see the overview in `docs/version-3/VERSION-3-OVERVIEW.md`.
+
 # Command Line
 
 You can get help on nlp.exe:

--- a/docs/version-3/VERSION-3-OVERVIEW.md
+++ b/docs/version-3/VERSION-3-OVERVIEW.md
@@ -1,0 +1,145 @@
+# VisualText NLP Engine — Version 3 Overview
+
+*An org-wide summary of the Version 3 work across the [VisualText](https://github.com/VisualText) repositories, with emphasis on the changes developed in collaboration with Claude (Anthropic's Claude Code / Claude Opus 4.x).*
+
+**Snapshot date:** June 2026 · **Engine line:** v3.x (latest release **v3.4.0**, 2026-06-12)
+
+---
+
+## What "Version 3" means
+
+Version 3 is the release line in which the **NLP++ engine became compilable, cloud-buildable, and installable from npm**, while hardening the engine across its already-supported platforms. The headline shifts are:
+
+1. **One-click compiled analyzers.** Compiling NLP++ analyzers and knowledge bases to native C++ shared libraries (`.dll` / `.so` / `.dylib`) was *always* technically possible — but it was hidden, brittle, and effectively reachable only by someone with deep C++ build expertise. Version 3 turns it into a **one-click process available to any user**, with no C++ knowledge required.
+2. **Cloud compile.** A **cloud-compile service** builds those native libraries for Windows, Linux, and macOS on GitHub-hosted runners, so users don't need a local C++ toolchain.
+3. **A new Node.js package.** Version 3 introduces first-class **Node.js bindings** (`npm install nlpplus`) that embed the engine directly — alongside the pre-existing Python package, which gained the new compile/cloud-compile APIs.
+4. **Numerous cross-platform fixes.** The engine has run on Windows, Linux, and macOS for years; v3 fixed a long list of platform-specific problems surfaced by compiled mode and the cloud-build pipeline.
+5. **Cross-repo release automation.** A connected "percolation" system propagates releases automatically across the engine, analyzers, dictionaries, language parsers, and the platform-distribution repos.
+
+A large share of this work was developed with **Claude** as a pair-programming collaborator — visible in the commit history through `Co-Authored-By: Claude` trailers and the systematic `NLP-ENGINE-###` / conventional-commit message style introduced in the v3 era.
+
+> **Why it matters.** NLP++ is *glass-box* (explainable, rule-based) NLP — and, crucially, **deterministic**: the same input always produces the same output, with rules you can read. That makes it suitable for **critical-path systems where statistical/probabilistic models cannot be trusted**. Version 3 makes that deterministic engine faster (compiled), easier to build (one-click and in the cloud), and easier to adopt (now installable from npm as well as pip). Notably, an LLM (Claude) is being used as a *development* collaborator to help build a deterministic NLP system — the LLM helps create the tools; the runtime stays transparent and reproducible.
+
+---
+
+## The core engine — `nlp-engine`
+
+**Repo:** [VisualText/nlp-engine](https://github.com/VisualText/nlp-engine) · the C++ NLP++ engine.
+**Version journey (Claude era):** v3.1.17 → v3.1.40 → v3.2.0 → v3.2.1 → **v3.4.0**.
+**Claude involvement:** Heavy — ~50+ Claude-co-authored commits drove the v3.1.x–v3.4.0 stabilization.
+
+### 1. Compiled-analyzer mode (NLP++ → C++ → native library)
+The engine code-generates C++ from NLP++ rule files and compiles it. v3 hardened this path:
+- Added dozens of **`RFASem` overloads** for NLP++ builtins (e.g. `attrtype`, `pnremoveval`, `pnvartype`) and **`Arun::assign` / `iassign` / `vargt` / `varlt`** overloads so generated code type-checks correctly.
+- **Provenance comments** (`/* nlp-source */`) emitted during `-COMPILE` so generated C++ can be traced back to its NLP++ origin — and the parser/error pipeline learned to handle those inline comments.
+- Fixed compiled-mode correctness bugs: SaveKB writes now flush (compiled-mode output files were silently empty), null-`cgerr` guards (fixed a compiled-mode SEGV), and function-call args hoisted into temps to fix unspecified C++ evaluation order.
+
+### 2. Cross-platform fixes (the generated code, not the engine itself)
+The engine has run on Windows, Linux, and macOS for years. What was *new* in v3 — compiled mode and the cloud-build pipeline — surfaced a string of platform-specific problems in the **generated C++** and its build, which v3 fixed:
+- Gated Windows-only headers behind `#ifndef LINUX`; emitted **forward-slash include paths** and `prim/libprim.h` so generated `St*.cpp` compiles on cloud Linux.
+- **Fixed compiled-RUN dispatch on Linux/macOS** to match Windows (previously Linux loaded `run.so` then immediately fell back to interpreted).
+- Used the correct **`.so` / `.dylib`** extensions for compiled analyzers and KBs; implemented `make_dir` / `rm_dir` via `std::filesystem`.
+- macOS-specific fixes (e.g. casting string emits to `_TCHAR*` to dodge a `<<` bool-overload bug; dropping a `-std=c++11` override so `std::filesystem` works).
+
+### 3. Robustness & safety
+- Bounded `_stprintf` writes into `MAXPATH` buffers.
+- Made `NLP_ENGINE::close()` **idempotent** (and fixed a Windows tempdir-cleanup `PermissionError` downstream).
+- Fixed segfaults in NLP-source-file emission and codegen edge cases.
+
+### 4. NLP++ language features (the "lite" runtime)
+- `_xVAR("attribute")` match-list special for attribute access in rules.
+- **Lazy dictionary loading** — `*-full` dictionaries load one word at a time (and multiple lazy dictionaries can be open at once), dramatically cutting memory/startup cost for large lexicons.
+- Allow **digits in underscore-prefixed token names** (e.g. `_token2`).
+- New `loadkbb` and `loaddict` NLP++ functions.
+
+---
+
+## The VS Code extension — `vscode-nlp` ("VisualText")
+
+**Repo:** [VisualText/vscode-nlp](https://github.com/VisualText/vscode-nlp) · the VS Code language extension for NLP++ (this is the "VisualText" IDE experience).
+**Version:** **v3.1.24** (the extension's own v3 line).
+**Claude involvement:** Major — ~20+ commits driving the entire 3.1.x line.
+
+- **Cloud compile in the editor.** Added a cloud-compile path that submits analyzers to the compile service, verifies the engine release exists before submitting, shows quiet progress with an elapsed-time counter and a 30-minute poll, and stages the resulting `.so`/`.dylib` into `bin/` on Linux/macOS.
+- **Markdown help system.** Replaced browser/HTML help with in-editor **markdown previews** (Functions, Variables, Index).
+- **Packaging hygiene.** `.vscodeignore` excludes `.vscode/`, `.claude/`, and logs from the packaged `.vsix`.
+
+---
+
+## Native language bindings
+
+### Node.js — `npm-package-nlpengine` (`nlpplus`) — **NEW in v3**
+**Repo:** [VisualText/npm-package-nlpengine](https://github.com/VisualText/npm-package-nlpengine) · **v1.0.5** · Node native addon (node-addon-api).
+Version 3's brand-new package — it brings the engine to the JavaScript/Node ecosystem for the first time.
+- **Scaffolded from scratch with Claude**; Windows build bundles ICU runtime DLLs so the addon is self-contained.
+- Tests isolated per-process to survive the engine's process-global teardown.
+- `cloudCompile` multipart upload; publish switched to **npm trusted publishing (OIDC)**.
+
+### Python — `py-package-nlpengine` (`NLPPlus`) — pre-existing, enhanced in v3
+**Repo:** [VisualText/py-package-nlpengine](https://github.com/VisualText/py-package-nlpengine) · **v2.0.9** · pip-installable native bindings (no subprocess).
+The Python package predates v3; in this cycle it gained the new compile workflow.
+- Native C++ bindings (pybind / scikit-build-core), embeds the **nlp-engine v3.x** submodule.
+- **New compile-mode and cloud-compile APIs** (`compile()`, `cloud_compile()`).
+- `Engine.close()` + context-manager support; Python **3.13 wheels**; manual bump-and-publish-to-PyPI workflow.
+
+### Lighter-weight wrappers
+- **`ts-nlp-engine`** — a single TypeScript class that shells out to `nlp.exe`; gained compile-mode support. Positioned as the simple option, pointing production users to native `NLPPlus`.
+- **`python`** — example scripts / `NLPEngine` class (**v2.0.1**); gained compile-mode support + docs.
+
+---
+
+## The cloud-compile backend — `nlp-compile-service` ⭐
+
+**Repo:** [VisualText/nlp-compile-service](https://github.com/VisualText/nlp-compile-service) · the backend behind `cloud_compile()` / `cloudCompile`.
+**Claude involvement:** Overwhelming — the repo is almost entirely Claude-authored.
+
+- A **Cloudflare Worker dispatcher** (TypeScript, KV-backed) plus a **GitHub Actions runner workflow** that compiles NLP++ analyzers into native shared libraries on Windows / Linux / macOS runners.
+- The hard part — **cross-platform native linking** — was solved here: defining `LINUX` for non-Windows CMake builds, wrapping ICU static libs in `--whole-archive` (fixing an `icu::ByteSink` undefined-symbol error), and `--start-group` for engine static libs on Linux. This sequence brought Linux/macOS compiled-mode online.
+- Runner workflow modernized: rolling `-latest` runner labels, normalized `engineVersion` tags, no hardcoded VS 2019 paths.
+
+---
+
+## Analyzers, parsers & dictionaries
+
+| Repo | Purpose | Latest | Claude role |
+|------|---------|--------|-------------|
+| [package-analyzers](https://github.com/VisualText/package-analyzers) | Shared analyzers (email, telephone, links, address) embedded by the Python/Node packages | **v1.0.0** | **Zone-based re-architecture** of all four analyzers (line-based → whole-text/zone-based so they work on real HTML/Markdown pages); international telephone support |
+| [parse-en-us](https://github.com/VisualText/parse-en-us) | Full English (US) NLP++ parser | v1.1.2 | Cross-repo release-percolation plumbing |
+| [analyzer-templates](https://github.com/VisualText/analyzer-templates) | Starter templates consumed by the VS Code extension | v1.0.11 | Percolation wiring + dispatch scaffolding |
+| [analyzers](https://github.com/VisualText/analyzers) | Umbrella collection of NLP++ analyzers | v1.9.5 | Percolation automation |
+| [dehilster-analyzers](https://github.com/VisualText/dehilster-analyzers) | Personal analyzer/dictionary collection | v0.26.0 | Claude-built **English Phrase analyzer** |
+| [visualtext-files](https://github.com/VisualText/visualtext-files) | Shared dictionaries, KBs, help docs | v2.2.2 | Root-lemma English dictionary + `en-full.kbb` KB; markdown help conversion |
+
+---
+
+## Platform distribution repos
+
+**Repos:** [nlp-engine-linux](https://github.com/VisualText/nlp-engine-linux), [nlp-engine-mac](https://github.com/VisualText/nlp-engine-mac), [nlp-engine-windows](https://github.com/VisualText/nlp-engine-windows) · ready-to-run, prebuilt distributions of the engine for each OS. **All currently ship engine v3.4.0**, in lockstep.
+
+- **Automated mirroring.** Each repo auto-updates via `repository_dispatch` when the upstream engine cuts a release — downloads per-OS release ZIPs, swaps binaries, commits, and tags to match upstream.
+- **Claude fixes:**
+  - A **release-automation race** where `git rm` ran *after* extraction, silently dropping a just-extracted directory (the v3.1.53/54 `compile-libs/` vs `ubuntu-*/` "flip-flop"). Diagnosed and fixed in linux + mac, aligned to the windows reference ordering.
+  - **Full-analyzer compile scripts** rewritten from KB-only to building the *full* analyzer (`run/` + `kb/`) into native `.so` / `.dylib` / `.dll`, with per-platform linker specifics (GNU `--whole-archive` vs macOS `-force_load`; VS detection + ICU import-lib generation on Windows).
+  - A real macOS engine bug: `make_analyzer` wrote `run/<pass>.cpp` without creating `run/` first, silently producing an **empty run tree** on macOS — fixed with directory pre-creation plus a loud guard.
+
+---
+
+## Cross-cutting theme: release percolation
+
+Claude built a connected **cross-repo dispatch / auto-tag / release-listener system**. A release in one repo (e.g. `parse-en-us`) percolates downstream — to `analyzer-templates`, `package-analyzers`, `analyzers`, the Python/Node packages (via a shared `package-analyzers` submodule + auto-publish-on-bump), and the platform distribution repos — so a single human action fans out into coordinated, version-tagged releases across the org.
+
+---
+
+## Version reference (June 2026)
+
+| Component | Version |
+|-----------|---------|
+| **nlp-engine** (core) | **v3.4.0** |
+| nlp-engine-linux / -mac / -windows | v3.4.0 (mirrors core) |
+| vscode-nlp (VisualText extension) | v3.1.24 |
+| py-package-nlpengine (`NLPPlus`) | v2.0.9 |
+| npm-package-nlpengine (`nlpplus`) | v1.0.5 |
+| package-analyzers | v1.0.0 |
+| visualtext-files | v2.2.2 |
+
+*Not every repo carries the literal number "3" — the unifying thread is the work that landed alongside the **engine v3.x** line.*

--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -196,6 +196,7 @@ public:
 	static bool cmltokenize(Parse *, int);                      // 08/18/08 AM.
 	static bool dicttok(Parse *, int);                          // 07/29/11 AM.
 	static bool dicttokz(Parse *, int);                         // 08/16/11 AM.
+	static bool python(Parse *, int, const _TCHAR *);           // 07/14/26. compiled python pass.
 	static bool lines(Parse *, int);
 	static bool patExecute(
 		Parse *,

--- a/include/Api/lite/ana.h
+++ b/include/Api/lite/ana.h
@@ -111,6 +111,7 @@ public:
 	bool genCMLTok(Seqn *pass, Gen *gen);								// 08/18/08 AM.
 	bool genDICTTok(Seqn *pass, Gen *gen);								// 07/29/11 AM.
 	bool genDICTTokz(Seqn *pass, Gen *gen);							// 08/16/11 AM.
+	bool genPython(Seqn *pass, Gen *gen);								// 07/14/26.
 	bool genLines(Seqn *pass, Gen *gen);								// 05/10/00 AM.
 
 private:

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -32,6 +32,7 @@ All rights reserved.
 #include "tok.h"
 #include "cmltok.h"					// 08/18/08 AM.
 #include "dicttok.h"					// 07/29/11 AM.
+#include "python.h"					// 07/14/26. compiled python pass.
 #include "line.h"
 
 #include "irule.h"					// 01/06/02 AM.
@@ -233,6 +234,42 @@ parse->finPass(num,flogfiles,fout,sout,
 										pretname,ftimepass,s_time);
 return true;
 }
+
+/********************************************
+* FN:		PYTHON
+* CR:		07/14/26.
+* SUBJ:	Runtime variant of the python pass (compiled analyzer).
+* NOTE:	A compiled analyzer has no Seqn at runtime, so the generated
+*			python<N> function passes the script base name as a literal.
+*			Pyalgo::run builds the same command line as the interpreted pass.
+********************************************/
+
+bool Arun::python(
+	Parse *parse,
+	int num,									// Pass number.
+	const _TCHAR *script						// Script base name (spec/<script>.py).
+	)
+{
+std::_t_ofstream *fout;				// File pass output.
+std::_t_ostream *sout;					// For restoring output stream.
+clock_t s_time;
+_TCHAR *pretname;
+_TCHAR *salgo = _T("python");
+_TCHAR *prefix = _T("ana");		// Prefix for naming files.
+bool flogfiles = parse->eana_->getFlogfiles();
+bool ftimepass = parse->eana_->getFtimepass();
+
+parse->iniPass(num,prefix,flogfiles,ftimepass,true,0,salgo,
+			/*DU*/fout,sout,s_time,pretname);
+
+if (!Pyalgo::run(parse, script))
+	return false;
+
+parse->finPass(num,flogfiles,fout,sout,
+										pretname,ftimepass,s_time);
+return true;
+}
+
 /********************************************
 * FN:		LINES
 * CR:		05/11/00 AM.

--- a/lite/ana.cpp
+++ b/lite/ana.cpp
@@ -696,6 +696,8 @@ else if (!strcmp_i(s_algo, _T("python")))			// Python pass (any position).
 	// May be placed anywhere, including before the tokenizer; the pre/post phase
 	// is detected automatically in Pyalgo::Execute.
 	algo = new Pyalgo();
+	if (gen)		// Gen'ing code for analyzer: emit the python<N> wrapper so
+		genPython(pass, gen);	// run_analyzer's python<N>(parse) call resolves.	// 07/14/26.
 	}
 else if (	!strcmp_i(s_algo, _T("stub"))			// 06/23/99 AM.
 		  )
@@ -1101,6 +1103,43 @@ Gen::nl(fcode);
 Gen::nl(fcode);
 // Return false if fatal error on tokenization.
 *fcode << _T("if (!Arun::dicttokz(parse,") << id << _T(")) return false;");
+Gen::nl(fcode);
+*fcode << _T("return true;");
+Gen::nl(fcode);
+*fcode << _T("}");
+Gen::nl(fcode);
+return true;
+}
+
+/********************************************
+* FN:		GENPYTHON
+* CR:		07/14/26.
+* SUBJ:	Gen code for a python pass (compiled analyzer).
+* NOTE:	run_analyzer emits a python<N>(parse) call for every python pass;
+*			this writes the matching python<N> body, which runs the script by
+*			its base name via Arun::python. The name is baked in as a literal
+*			because a compiled analyzer has no sequence/Seqn at runtime.
+********************************************/
+
+bool Ana::genPython(Seqn *pass, Gen *gen)
+{
+std::_t_ofstream *fcode = gen->getFcode();
+std::_t_ofstream *fhead = gen->getFhead();
+long id = pass->getPassnum();
+_TCHAR *script = pass->getRulesfilename();		// The spec/<script>.py base name.
+
+// Write out prototype.
+*fhead << _T("bool python") << id << _T("(Parse *);");
+Gen::nl(fhead);
+
+// Write out function.
+Gen::nl(fcode);
+*fcode << _T("bool python") << id << _T("(Parse *parse)");
+Gen::nl(fcode);
+*fcode << _T("{");
+Gen::nl(fcode);
+*fcode << _T("if (!Arun::python(parse,") << id << _T(",_T(\"")
+		<< (script ? script : _T("")) << _T("\"))) return false;");
 Gen::nl(fcode);
 *fcode << _T("return true;");
 Gen::nl(fcode);

--- a/lite/python.cpp
+++ b/lite/python.cpp
@@ -76,6 +76,18 @@ void Pyalgo::setup(_TCHAR * /*s_data*/)
 bool Pyalgo::Execute(Parse *parse, Seqn *seqn)
 {
 _TCHAR *script = seqn ? seqn->getRulesfilename() : 0;
+return run(parse, script);
+}
+
+/********************************************
+* FN:		RUN
+* SUBJ:	Run the Python script for this pass by base name.
+* NOTE:	Shared by the interpreted (Execute) and compiled (generated python<N>)
+*			paths, so both build the identical command line.
+********************************************/
+
+bool Pyalgo::run(Parse *parse, const _TCHAR *script)
+{
 if (!script || !*script)
 	{
 	if (parse->Verbose())

--- a/lite/python.h
+++ b/lite/python.h
@@ -34,6 +34,12 @@ public:
 	virtual Algo &dup();
 	virtual void setup(_TCHAR *s_data);
 	virtual bool Execute(Parse *, Seqn *);
+
+	// Run the Python script named by its base name (spec/<script>.py). Shared by
+	// the interpreted pass (Execute reads the name from the Seqn) and the compiled
+	// pass (the generated python<N> function passes the name as a literal, since a
+	// compiled analyzer has no Seqn at runtime).					// 07/14/26.
+	static bool run(Parse *, const _TCHAR *script);
 };
 
 #endif

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.9"
+#define NLP_ENGINE_VERSION "3.7.10"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem

Compiling any analyzer that contains a `python` pass failed to link — exactly the error reported against the **TextGen** analyzer (pass 1 = `python json2kbb`):

```
analyzer.cpp(12,105): error C3861: 'python1': identifier not found
```

The code generator was only half-wired for python passes:
- `Seqn::gen` (the `run_analyzer` body) emitted a call `python<N>(parse);` via its generic `else` branch.
- `internPass` had explicit codegen cases for `tokenize`/`dicttokz`/`lines`/`nlp`/`rec`, but the `python` case created a `Pyalgo` for the interpreted path and generated **no function body**.

So `run_analyzer` called `python<N>` with nothing defining it → unresolved identifier at compile time.

## Fix

- **`Ana::genPython`** emits the `python<N>` function body, baking the script base name in as a string literal (a compiled analyzer has no `Seqn` at runtime), wired into the `python` case of `internPass` alongside the other pass generators.
- **`Arun::python(Parse*, int, const _TCHAR*)`** is the runtime entry the generated code calls; it runs the script via `Pyalgo::run` with the usual `iniPass`/`finPass` logging + timing.
- **`Pyalgo::Execute`** refactored to share **`Pyalgo::run(parse, script)`** with the compiled path, so interpreted and compiled build the identical `python "<appdir>/spec/<script>.py" …` command line.

## Verification (end-to-end)

Built `nlp.exe` with the change, then generated + compiled an analyzer with a pre-tokenizer `python <script>` pass:

- `run/analyzer.cpp` now **defines** `python1`: `bool python1(Parse *parse){ if (!Arun::python(parse,1,_T("myscript"))) return false; return true; }`
- The generated analyzer library **links cleanly — no C3861, no unresolved symbols**.
- Running it with `-COMPILED` shows `[Loaded compiled analyzer]` + `[Loaded compiled KB library]` and the python pass **executes** with the correct args and `pre` phase (`[myscript.py ran] [... 'pre']`).

## Notes

- A python pass still shells out to `<appdir>/spec/<script>.py` at runtime, so the `.py` script must ship with a compiled analyzer (it can't be compiled into the library).
- Bumps engine to **3.7.10**.
- Also refreshes the main README with a **"What's New in Version 3"** section (compiled analyzers incl. python passes, cloud compile, lazy dictionaries, npm/pip bindings) and adds `docs/version-3/VERSION-3-OVERVIEW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)