### PR TITLE
fix: add bool overload of Arun::ret (compiled-analyzer C2668) (3.7.11)

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -1554,6 +1554,7 @@ public:
 	static void *fnstart(Nlppp*,void*&,void*&);	// 03/11/02 AM. // 01/08/07 AM.
 
 	static RFASem *ret(Nlppp*,void*,void*,long long);						// 03/11/02 AM.
+	static RFASem *ret(Nlppp*,void*,void*,bool);					// 07/14/26. bool->0/1, avoids long long/float ambiguity.
 	static RFASem *ret(Nlppp*,void*,void*,float);					// 03/11/02 AM.
 	static RFASem *ret(Nlppp*,void*,void*,_TCHAR*);					// 03/11/02 AM.
 	static RFASem *ret(Nlppp*,void*,void*,RFASem*);					// 03/11/02 AM.

--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -13174,6 +13174,23 @@ nlppp->freeLocals((Slist<_TCHAR> *)locstrs);					// 01/08/07 AM.
 return new RFASem(num);
 }
 
+// A boolean return value (eg an NLP++ rule that returns a comparison). Without
+// this, generated code passing a bool matched both the long long and float
+// overloads ambiguously (C2668). Treat true/false as the integer 1/0.	// 07/14/26.
+RFASem *Arun::ret(
+	Nlppp *nlppp,
+	void *loc,	// List of L() local vars from calling frame.
+	void *locstrs,
+	bool b
+	)
+{
+if (nlppp->locals_)
+	Dlist<Ipair>::DeleteDlistAndData(nlppp->locals_);
+nlppp->locals_ = (Dlist<Ipair> *) loc;		// "Pop" the stack.
+nlppp->freeLocals((Slist<_TCHAR> *)locstrs);
+return new RFASem((long long) b);
+}
+
 RFASem *Arun::ret(
 	Nlppp *nlppp,
 	void *loc,	// List of L() local vars from calling frame.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.10"
+#define NLP_ENGINE_VERSION "3.7.11"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem

Compiling an analyzer whose NLP++ returns a boolean fails on the cloud/local C++ build:

```
run\pass3.cpp: error C2668: 'Arun::ret': ambiguous call to overloaded function
  could be 'RFASem *Arun::ret(Nlppp *,void *,void *,float)'
  or       'RFASem *Arun::ret(Nlppp *,void *,void *,__int64)'
  while trying to match the argument list '(Nlppp *, void *, void *, bool)'
```

The generated code emits `Arun::ret(nlppp, loc, locstrs, <bool>)`, but `ret`'s value argument only has `long long` and `float` overloads. `bool` converts to both, so the call is ambiguous.

## Fix

Add `ret(Nlppp*, void*, void*, bool)`. An exact `bool` match wins over the two conversions, resolving the ambiguity. It treats `true`/`false` as the integer `1`/`0` — the same convention the existing `bool` overloads of `assign`/`iassign`/`stmt`/`truth` already use (see NLP-ENGINE-492 for the parallel `int` disambiguator).

Scoped to `ret` — the real, common case (returning a boolean). The binary operators (`eq`, `gt`, `minus`, …) have the same latent pattern but across many positional overloads, so they're handled reactively as specific combinations surface, matching existing practice.

## Verification

- Full engine builds clean with the new overload.
- Minimal repro of the exact overload set confirms the fix: **without** the `bool` overload → `C2668` (reproduces the error); **with** it → compiles clean.

Bumps engine to **3.7.11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)