### PR TITLE
feat: load per-run json/kbb data pairs in compiled-KB analyzers (3.7.12)

### DIFF
--- a/cs/libconsh/cg.cpp
+++ b/cs/libconsh/cg.cpp
@@ -618,6 +618,11 @@ if (hkbdll_)
 	// compiled KB, so open them explicitly here or lazy lookup never runs
 	// in a compiled analyzer.									// 07/13/26 DD.
 	openFullFiles();
+	// Likewise, per-run data dropped in as a "<stem>.json"/"<stem>.kbb" pair
+	// (e.g. data.json converted to data.kbb) is not part of the compiled KB;
+	// load such pairs into the live KB so a compiled analyzer still sees
+	// run-time data.											// 07/14/26 DD.
+	loadJsonPairedKBBs();
 	return true;		// This is just info, ok.						// 06/29/00 AM.
 	}
 
@@ -3597,6 +3602,36 @@ void CG::openFullFiles() {
 		if (!openFullDict(ptr->string()))
 			std::_t_cerr << _T("[Error: ") << ptr->string()
 				<< _T(" is not byte-sorted (LC_ALL=C); cannot lazy-load. Skipping.]") << std::endl;
+	}
+}
+
+// Load per-run incoming data into a compiled-KB analyzer. The static KB is
+// baked into kb.dll, so readKB() returns early (above) and never runs the
+// normal readKBBs load -- but data supplied at run time (e.g. a caller drops
+// "data.json" into kb/user and a json2kbb pass converts it to "data.kbb") is
+// NOT part of the compiled KB and must still reach the live KB. The signal is
+// the pair: a "<stem>.kbb" that has a matching "<stem>.json" sibling is loaded
+// normally here. Anything without a ".json" mate is assumed already compiled
+// in (so it is skipped, not double-loaded); a "*full" file is skipped too
+// (those are lazy-opened by openFullFiles(), never read whole). Generic: works
+// for any XXX.json/XXX.kbb pair, not just "data".					// 07/14/26 DD.
+void CG::loadJsonPairedKBBs() {
+	std::error_code ec;
+	if (!std::filesystem::is_directory(kbdir_, ec))
+		return;
+
+	std::vector<std::filesystem::path> files;
+	std::vector<std::filesystem::path>::iterator ptr;
+
+	read_files(kbdir_, _T("(.*\\.kbb)$"), files);
+	for (ptr = files.begin(); ptr < files.end(); ptr++) {
+		std::string stem = removeExtension(ptr->filename().string());
+		if (stemEndsWithFull(stem))
+			continue;						// lazy full file: opened by openFullFiles(), never loaded whole
+		std::filesystem::path jsonpath = ptr->parent_path() / (stem + ".json");
+		if (!std::filesystem::exists(jsonpath, ec))
+			continue;						// no ".json" mate: part of the compiled KB, do not re-load
+		readKBB(ptr->string());				// incoming run-time data: load into the live KB
 	}
 }
 

--- a/include/Api/consh/cg.h
+++ b/include/Api/consh/cg.h
@@ -237,6 +237,13 @@ public:
 	// (implicitly, via readDicts/readKBBs) and from the compiled-KB path, where
 	// readKB() otherwise returns early and would leave the full files unopened.
 	void openFullFiles();
+	// In a compiled-KB analyzer, load any "<stem>.kbb" that has a matching
+	// "<stem>.json" sibling in kb/user into the live KB. Such a pair is per-run
+	// incoming data (a caller-supplied "<stem>.json" converted to "<stem>.kbb"
+	// by a json2kbb pass), NOT part of the baked compiled KB -- and the
+	// early-returning compiled-KB path skips the normal readKBBs load, so it
+	// must load these explicitly. A "*full" file is never loaded whole here.
+	void loadJsonPairedKBBs();
 	// Parse a single line of a "*.kbb" file (indented "dictionary" format) into
 	// the KB. cons/index carry the indentation state between calls; root is the
 	// parent for top-level (indent 0) concepts.							// 06/10/26.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.11"
+#define NLP_ENGINE_VERSION "3.7.12"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Problem

A compiled analyzer bakes its static KB into `kb.dll`, so `readKB()` returns early on the `hkbdll_` branch and never runs the normal `readKBBs` load. That means **per-run data supplied at run time** — e.g. a caller drops `data.json` into `kb/user` and a `json2kbb` pass converts it to `data.kbb` — **never reaches the live KB**, so `getconcept("data")` comes back empty (or serves a value baked in at compile time). A fully-compiled, source-hidden analyzer therefore can't take per-render data.

## Fix

Add `CG::loadJsonPairedKBBs()`, called on the `hkbdll_` branch right after `openFullFiles()`. It scans `kb/user` and, for every `<stem>.kbb` that has a matching `<stem>.json` sibling (and is not a `*full` file), loads it into the live KB via `readKBB()`.

The `.json` mate is the signal that the `.kbb` is **incoming run-time data** rather than part of the compiled KB. A `.kbb` **without** a `.json` mate is assumed already compiled into `kb.dll` and is skipped, so nothing is double-loaded. It's fully generic — works for any `XXX.json`/`XXX.kbb` pair, not just `data`.

## Safety

No interference with the lazy full files: `openFullDict`/`openFullKBB` keep each file in its own `fullDicts_`/`fullKBBs_` stream, whereas `readKBB` only closes `allDictStream_` (the consolidated `all.dict` stream, which is unused in the compiled path).

## Usage note

To make the runtime pair the sole data source, compile the analyzer **data-less** (no `data.json`/`data.kbb` present at compile time), so `kb.dll` holds the static KB (`varysets`/`banned`/…) but no `data` concept.

## Test

Compile an analyzer data-less → deploy (`TextGen.dll` + lazy `*full` files, no source) → in a fresh engine, drop `data.json` with `Filing fee: 715` and render, then `999` and render → **outputs must differ** (`$715.00` then `$999.00`). Without this change both render the baked/empty value.

Files: `cs/libconsh/cg.cpp` (function + call site), `include/Api/consh/cg.h` (decl), `nlp/main.cpp` (version → 3.7.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)