### PR TITLE
fix: stop leaking an ICU Collator per call; ASCII fast paths in hot string fns (3.7.15)

### DIFF
--- a/include/Api/lite/inline.h
+++ b/include/Api/lite/inline.h
@@ -39,12 +39,62 @@ return (!empty(str)
 
 
 /********************************************
+* FN:		ASCII_LOWER
+* CR:		08/03/26 AM.
+* SUBJ:	Locale-independent lowercase for a 7-bit char.
+* NOTE:	Helper for the ASCII fast paths below.  Deliberately NOT
+*			locale-aware: it is only ever applied to bytes < 0x80.
+********************************************/
+
+inline unsigned char ascii_lower(unsigned char ch)
+{
+return (ch >= 'A' && ch <= 'Z') ? (unsigned char)(ch + ('a' - 'A')) : ch;
+}
+
+inline unsigned char ascii_upper(unsigned char ch)
+{
+return (ch >= 'a' && ch <= 'z') ? (unsigned char)(ch - ('a' - 'A')) : ch;
+}
+
+
+/********************************************
+* FN:		ASCII_ONLY
+* CR:		08/03/26 AM.
+* SUBJ:	True if the string is entirely 7-bit.
+* NOTE:	Helper for the ASCII fast paths.  One cheap pass lets callers skip
+*			the ICU round trip entirely for the common case.
+********************************************/
+
+inline bool ascii_only(const _TCHAR *str)
+{
+const unsigned char *p = (const unsigned char *) str;
+while (*p)
+	{
+	if (*p & 0x80)
+		return false;
+	++p;
+	}
+return true;
+}
+
+
+/********************************************
 * FN:		STRCMP_I
 * CR:		09/26/01 AM.
 * SUBJ:	String compare, case insensitive.
 * RET:	0 if equal, +1 or -1 according to lex order.
 * NOTE:	No error checking, for max speed.
 *			Assumes string has at least a null char.
+* OPT:	08/03/26 AM. ASCII fast path.  This is the innermost function of
+*			the rule matcher (see Pat::literalMatch), and building two ICU
+*			UnicodeStrings per comparison -- transcoding UTF-8 to UTF-16 both
+*			ways -- dominated the cost of a pass.  Compare bytewise while both
+*			strings stay 7-bit and only fall through to ICU when a byte >= 0x80
+*			actually shows up.
+*			The fast path is exact, not an approximation: u_strcasecmp with
+*			U_COMPARE_IGNORE_CASE does Unicode *case folding*, which is
+*			locale-independent and which maps A-Z to a-z and nothing else
+*			within the 7-bit range.
 ********************************************/
 
 inline int strcmp_i(
@@ -52,6 +102,34 @@ inline int strcmp_i(
 	const _TCHAR *str2
 	)
 {
+// icu::StringPiece treats a null pointer as the empty string; preserve that
+// rather than dereferencing it below.
+if (!str1)
+	str1 = _T("");
+if (!str2)
+	str2 = _T("");
+
+const unsigned char *p1 = (const unsigned char *) str1;
+const unsigned char *p2 = (const unsigned char *) str2;
+for (;;)
+	{
+	unsigned char c1 = *p1;
+	unsigned char c2 = *p2;
+	if ((c1 | c2) & 0x80)
+		break;					// Non-ASCII in play.  Hand off to ICU.
+	if (c1 != c2)
+		{
+		c1 = ascii_lower(c1);
+		c2 = ascii_lower(c2);
+		if (c1 != c2)
+			return (c1 < c2) ? -1 : 1;
+		}
+	else if (!c1)
+		return 0;				// Both ended together.  Equal.
+	++p1;
+	++p2;
+	}
+
 icu::UnicodeString ustr1 = icu::UnicodeString::fromUTF8(icu::StringPiece(str1 ));
 const UChar *strBuff1 = reinterpret_cast<const UChar *>(ustr1.getTerminatedBuffer());
 icu::UnicodeString ustr2 = icu::UnicodeString::fromUTF8(icu::StringPiece(str2));

--- a/lite/str.cpp
+++ b/lite/str.cpp
@@ -722,6 +722,25 @@ return false;
 
 _TCHAR *str_to_lower(_TCHAR *str, _TCHAR *buf)
 {
+// OPT: ASCII fast path.	// 08/03/26 AM.
+// tHtab::hfind_lc calls this for every node at every match position, and
+// the ICU round trip below (UTF-8 -> UTF-16 -> toLower -> std::string ->
+// strcpy) was showing up as pure overhead on plain English text.
+// NOTE: the fast path folds A-Z only, independent of locale.  ICU's
+// toLower() honors the default locale, which differs from this for exactly
+// one case: under a Turkish/Azeri locale 'I' lowercases to dotless U+0131.
+// Lowercased forms are used here as dictionary/hash keys, where
+// locale-dependent folding would be a bug rather than a feature.
+if (str && ascii_only(str))
+	{
+	const unsigned char *p = (const unsigned char *) str;
+	_TCHAR *out = buf;
+	while (*p)
+		*out++ = (_TCHAR) ascii_lower(*p++);
+	*out = '\0';
+	return buf;
+	}
+
 icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
 ustr.toLower();
 std::string converted;
@@ -744,6 +763,18 @@ _TCHAR *str_to_lower(_TCHAR *str)
 {
 if (empty(str))
 	return 0;
+
+// OPT: ASCII fast path.  See str_to_lower(str,buf) above.	// 08/03/26 AM.
+if (ascii_only(str))
+	{
+	unsigned char *p = (unsigned char *) str;
+	while (*p)
+		{
+		*p = ascii_lower(*p);
+		++p;
+		}
+	return str;
+	}
 
 icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
 ustr.toLower();
@@ -771,6 +802,17 @@ return buf;
 
 _TCHAR *str_to_upper(_TCHAR *str, _TCHAR *buf)
 {
+// OPT: ASCII fast path.  See str_to_lower above for the locale note.	// 08/03/26 AM.
+if (str && ascii_only(str))
+	{
+	const unsigned char *p = (const unsigned char *) str;
+	_TCHAR *out = buf;
+	while (*p)
+		*out++ = (_TCHAR) ascii_upper(*p++);
+	*out = '\0';
+	return buf;
+	}
+
 icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
 ustr.toUpper();
 std::string converted;
@@ -792,6 +834,18 @@ _TCHAR *str_to_upper(_TCHAR *str)
 {
 if (empty(str))
 	return 0;
+
+// OPT: ASCII fast path.  See str_to_lower above for the locale note.	// 08/03/26 AM.
+if (ascii_only(str))
+	{
+	unsigned char *p = (unsigned char *) str;
+	while (*p)
+		{
+		*p = ascii_upper(*p);
+		++p;
+		}
+	return str;
+	}
 
 icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
 ustr.toUpper();
@@ -1055,6 +1109,27 @@ return false;
 * NOTE:	Case insensitive.  For use by compiled runtime match fns, etc.
 ********************************************/
 
+// OPT: the collator used to be built -- and leaked -- on every call.	// 08/03/26 AM.
+// Collator::createInstance loads locale data; doing that per call was both
+// expensive and an unbounded leak.  Build it once and keep it.  ICU collators
+// are documented thread-safe for const operations such as compare().
+static icu::Collator *nocase_collator()
+{
+static icu::Collator *collator = 0;
+if (!collator)
+	{
+	UErrorCode success = U_ZERO_ERROR;
+	collator = icu::Collator::createInstance("UTF-8", success);
+	if (U_FAILURE(success) || !collator)
+		{
+		collator = 0;
+		return 0;
+		}
+	collator->setStrength(icu::Collator::PRIMARY);  // This is for case insensitive
+	}
+return collator;
+}
+
 bool find_str_nocase(
 	_TCHAR *str,				// String to find.
 	const _TCHAR **arr			// Array to look in.
@@ -1063,13 +1138,11 @@ bool find_str_nocase(
 if (!str || !*str || !arr || !*arr)
 	return false;
 
-icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
-const UChar *strBuf = reinterpret_cast<const UChar *>(ustr.getTerminatedBuffer());
-icu::UCharCharacterIterator iter(strBuf, unicu::strLen(strBuf));
+icu::Collator *collator = nocase_collator();
+if (!collator)								// Collator unavailable.
+	return false;
 
-UErrorCode success = U_ZERO_ERROR;
-icu::Collator *collator = icu::Collator::createInstance("UTF-8", success);
-collator->setStrength(icu::Collator::PRIMARY);  // This is for case insensitive
+icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
 
 while (*arr)
 	{

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.14"
+#define NLP_ENGINE_VERSION "3.7.15"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## What

Three related changes to the engine's string layer, found while auditing the C++ for performance opportunities.

**1. `find_str_nocase` leaked an `icu::Collator` on every call** (`lite/str.cpp`)

```cpp
icu::Collator *collator = icu::Collator::createInstance("UTF-8", success);
collator->setStrength(icu::Collator::PRIMARY);
```

Constructed per call, never deleted. `createInstance` loads locale data, so this was expensive as well as leaky, and the `U_FAILURE` case would have crashed on the next line. Now built once behind a `nocase_collator()` accessor with a null guard. Comparison semantics are unchanged — still a full ICU collator at PRIMARY strength.

**2. ASCII fast paths in `strcmp_i`** (`include/Api/lite/inline.h`) **and `str_to_lower`/`str_to_upper`** (`lite/str.cpp`)

Each was doing a full ICU UTF-8 → UTF-16 round trip for what is, on ordinary text, a plain ASCII operation. `strcmp_i` is the body of `Pat::literalMatch` — the innermost function of the rule matcher — and has 420+ call sites across the engine. `str_to_lower` feeds `tHtab::hfind_lc`, which `Pat::resetRules` calls for every node at every match position.

All four now compare/convert bytewise while the input stays 7-bit, and fall through to the **original ICU code, unmodified, on the original pointers** the moment a byte >= 0x80 appears.

**3. Version bump** to 3.7.15.

## Why this is safe for Unicode

UTF-8 guarantees every byte of a multi-byte sequence has the high bit set, so the byte-level "is this ASCII" gate is exactly equivalent to a codepoint-level one — no non-ASCII character can slip through. And within the 7-bit range, `u_strcasecmp` with `U_COMPARE_IGNORE_CASE` performs Unicode *case folding*, which is locale-independent and maps A–Z to a–z and nothing else.

`strcmp_i` additionally now treats a null pointer as the empty string, matching what `icu::StringPiece` already did — previously the new fast path would have dereferenced it.

## Verification

- **All 5 CI regression fixtures pass** locally: parse-en-us, fulldict-hang (#669), fnname-digits (#698), block-comments, block-comments-data
- **English parse tree byte-identical** to `.github/workflows/tests/parse-en-us/final.tree`
- **Differential test** comparing old vs new implementations directly over a 43-string corpus — accented Latin (`café`, `Zürich`, `Straße`), Greek, Cyrillic, CJK, 4-byte emoji, strings with the non-ASCII byte late, Turkish dotted/dotless İ/ı:

```
strcmp_i    : 1849 pairs checked, 0 mismatches
str_to_lower:   43 strings checked, 0 mismatches
str_to_upper:   43 strings checked, 0 mismatches
ALL AGREE
```

- **End-to-end on accented UTF-8 input**: every accented word survives the pipeline intact and is matched by rules (not passed through as an unknown token)

## What this is NOT

**This is not a demonstrated speedup**, despite being motivated by a perf audit.

An initial A/B suggested ~1.4x, but it was measured non-interleaved with a rebuild between the two groups on a desktop sitting at ~80% CPU. Re-run with both binaries built and alternated A,B,A,B in a single loop, it collapsed to ~5% with 2 of 5 pairs favoring the baseline — noise.

| pair | baseline | optimized | delta |
|---|---|---|---|
| 1 | 44.81 | 37.14 | −7.67 |
| 2 | 41.94 | 42.01 | +0.07 |
| 3 | 45.04 | 47.16 | +2.12 |
| 4 | 39.49 | 37.55 | −1.94 |
| 5 | 45.93 | 43.10 | −2.83 |

So: merge this as a **correctness and waste fix** (the leak is unambiguous), not as an optimization. Whatever dominates pass time lives somewhere else and wants an actual profiler.

## Known behavior difference (one, documented in-code)

The ASCII path in `str_to_lower`/`str_to_upper` folds A–Z locale-independently, whereas ICU's `toLower()` honors the *default locale*. These differ in exactly one case: under a Turkish or Azeri locale, `I` lowercases to dotless `ı` (U+0131). Since these lowercased forms are used as dictionary and hash-table keys, locale-independence is arguably the correct behavior — but flagging it explicitly. `strcmp_i` has no such caveat (case folding is already locale-independent).

## Follow-ups not in this PR

From the same audit, unverified by profiling:

- `Pat::resetRules` allocates a `Slist` + `Chars::create` + full `Xml::de_accent` + compare + free **per node per match position**, purely to ask "does this string have accents" — answerable with a high-bit scan
- `Pat::modeMatch`/`modeMatch1`: linear cascade of up to 12 `_tcscmp` to identify `_x*` elements, with the very common `_xWILD` last; should be an enum resolved once when the `Ielt` is built
- `Ivar` builtin resolution: ~16 sequential `strcmp_i` for `$text`, `$length`, etc.
- `readConvert` reads input files one byte at a time via `inFile.get()`
- ~4–5s of every run is fixed per-pass overhead independent of input size — significant for anyone processing many small files

🤖 Generated with [Claude Code](https://claude.com/claude-code)