### PR TITLE
fix: string-layer cleanups -- O(n^3) struniquechars, dead alloc guard, double hashing (3.7.16)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -235,6 +235,31 @@ jobs:
           grep -qF '("note" "lone * and / here")' "$TREE" || { echo "FAIL(data block comments): dict string lost its * or /"; exit 1; }
           echo "[block comments] /* */ is skipped in .seq, .kb, .dict and .kbb"
 
+      - name: struniquechars regression (Non-20.04)
+        if: matrix.id != 'docker-ubuntu-20.04'
+        shell: bash
+        run: |
+          set -eo pipefail
+          # str_unique_chars() used to rebuild an icu::StringPiece over its
+          # OUTPUT buffer, call u_strlen() on it and re-decode it with
+          # U8_NEXT -- once per input character. This pins the observable
+          # behavior of struniquechars(), including multi-byte UTF-8, so the
+          # rewrite (and any future one) cannot drift.
+          FIX=.github/workflows/tests/struniquechars
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(struniquechars): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%b' 'abc|abc|a|abcdefg|helo wrd|3|ab\xc3\xa9\xc3\xbc|\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(struniquechars): out.txt was '$got' (wanted '$want')"; exit 1
+          fi
+          echo "[struniquechars] unique-character extraction is UTF-8 correct"
+
       - name: Copy nlp.exe to nlpl.exe (Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'
         run: cp bin/nlp bin/nlpl.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -158,6 +158,30 @@ jobs:
           grep -qF '("note" "lone * and / here")' "$TREE" || { echo "FAIL(data block comments): dict string lost its * or /"; exit 1; }
           echo "[block comments] /* */ is skipped in .seq, .kb, .dict and .kbb"
 
+      - name: struniquechars regression
+        shell: bash
+        run: |
+          set -eo pipefail
+          # str_unique_chars() used to rebuild an icu::StringPiece over its
+          # OUTPUT buffer, call u_strlen() on it and re-decode it with
+          # U8_NEXT -- once per input character. This pins the observable
+          # behavior of struniquechars(), including multi-byte UTF-8, so the
+          # rewrite (and any future one) cannot drift.
+          FIX=.github/workflows/tests/struniquechars
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(struniquechars): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%b' 'abc|abc|a|abcdefg|helo wrd|3|ab\xc3\xa9\xc3\xbc|\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(struniquechars): out.txt was '$got' (wanted '$want')"; exit 1
+          fi
+          echo "[struniquechars] unique-character extraction is UTF-8 correct"
+
       - name: Copy nlp.exe to nlpw.exe
         run: cp bin/Release/nlp.exe bin/Release/nlpw.exe
         shell: bash

--- a/.github/workflows/tests/struniquechars/input/text.txt
+++ b/.github/workflows/tests/struniquechars/input/text.txt
@@ -1,0 +1,1 @@
+placeholder text

--- a/.github/workflows/tests/struniquechars/spec/analyzer.seq
+++ b/.github/workflows/tests/struniquechars/spec/analyzer.seq
@@ -1,0 +1,2 @@
+tokenize	nil	# tokenize only -- fixture needs no dictionary
+nlp	unichars

--- a/.github/workflows/tests/struniquechars/spec/unichars.nlp
+++ b/.github/workflows/tests/struniquechars/spec/unichars.nlp
@@ -1,0 +1,28 @@
+###############################################
+# FILE:     unichars.nlp
+# SUBJ:     Regression for struniquechars().
+# NOTE:     str_unique_chars() used to rebuild an icu::StringPiece over the
+#           output buffer, call u_strlen() on it and re-decode it with
+#           U8_NEXT once per INPUT character -- turning an O(n^2) job into
+#           roughly O(n^3).  This pins the observable behavior, including
+#           multi-byte UTF-8 characters, so the rewrite cannot drift.
+#           Expected out.txt:
+#           abc|abc|a|abcdefg|helo wrd|3|ab<U+00E9><U+00FC>|<CJK 3 chars>
+###############################################
+
+@CODE
+
+"out.txt" << struniquechars("abc") << "|";
+"out.txt" << struniquechars("aaabbbccc") << "|";
+"out.txt" << struniquechars("aaaaaa") << "|";
+"out.txt" << struniquechars("abcdefg") << "|";
+"out.txt" << struniquechars("hello world") << "|";
+"out.txt" << struniquechars("333") << "|";
+
+# Multi-byte UTF-8: accented Latin, repeated. Bytes must not be split.
+"out.txt" << struniquechars("aabbééüü") << "|";
+
+# CJK, each character 3 bytes, with repeats.
+"out.txt" << struniquechars("日日本本語語") << "\n";
+
+@@CODE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,18 @@ set(CMAKE_CXX_STANDARD 17)
 include(CTest)
 enable_testing()
 
+# Default to an optimized build for single-config generators (Makefiles,
+# Ninja). Without this, a plain `cmake -B build -S .` on Linux/macOS leaves
+# CMAKE_BUILD_TYPE empty, which means NO optimization flags at all -- local
+# developer builds ran unoptimized while CI (which passes
+# -DCMAKE_BUILD_TYPE=Release explicitly) did not. Multi-config generators
+# such as Visual Studio ignore this and pick the config at build time.
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _isMultiConfig AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+    message(STATUS "CMAKE_BUILD_TYPE not set; defaulting to Release")
+endif()
+
 find_package(ICU REQUIRED COMPONENTS i18n uc data io)
 find_library(DL_LIBRARY dl)  # Ensure dl library is found
 

--- a/lite/chars.cpp
+++ b/lite/chars.cpp
@@ -10,6 +10,7 @@ All rights reserved.
 *******************************************************************************/
 
 #include "StdAfx.h"
+#include <new>			// std::nothrow	// 08/03/26 AM.
 #include "machine.h"	// 10/25/06 AM.
 #include "u_out.h"		// 01/19/06 AM.
 #include "lite/global.h"
@@ -61,7 +62,10 @@ Chars::~Chars()
 _TCHAR *Chars::create(long size)
 {
 _TCHAR *tmp;
-if (!(tmp = new _TCHAR[size]))
+// Plain new THROWS on failure and never returns null, so the guard below
+// was unreachable and the diagnostic could never fire.  Use the nothrow
+// form so the existing error path actually works.	// 08/03/26 AM.
+if (!(tmp = new (std::nothrow) _TCHAR[size]))
 	{
 	std::_t_strstream gerrStr;
 	gerrStr << _T("[Couldn't allocate a char array.]") << std::ends;

--- a/lite/htab.cpp
+++ b/lite/htab.cpp
@@ -23,6 +23,7 @@ All rights reserved.
 #include "io.h"
 #include "lite/iarg.h"	// 05/14/03 AM.
 #include "str.h"
+#include "chars.h"	// 08/03/26 AM.
 #include "node.h"	// 07/07/03 AM.
 #include "tree.h"	// 07/07/03 AM.
 #include "nlppp.h"	// 07/07/03 AM.
@@ -409,9 +410,14 @@ if (empty(str))
 	return 0;
 	}
 
-// Convert to lower case.
-str_to_lower(str, lcbuf);
-return hfind(lcbuf);
+// Convert to lower case.  Overlong strings go to the heap rather than
+// overrunning the shared static buffer.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, lcbuf, MAXSTR, /*UP*/ alloced);
+Selt<Sym> *selt = hfind(lc);
+if (alloced)
+	Chars::destroy(lc);
+return selt;
 }
 
 
@@ -466,17 +472,45 @@ return 0;						// Not found in list.
 * FN:		HGET
 * CR:		11/18/98 AM.
 * SUBJ:	Find string in hash table, else add it.
-* OPT:	Unoptimized.  The two calls do redundant work.
+* NOTE:	08/03/26 AM. Was hfind() then hadd(), which hashed the string
+*			twice and walked to the bucket twice.  Hash once and reuse the
+*			bucket for both the search and the insert.  Behavior is
+*			unchanged, including the empty-string diagnostic and the
+*			crash guard on a sym with no string.
 *
 ********************************************/
 
 Selt<Sym> *Htab::hget(_TCHAR *str)
 {
-// The calls check for empty string.
+if (empty(str))
+	{
+	std::_t_strstream gerrStr;
+	gerrStr << _T("[hget: Given null string.]") << std::ends;
+	errOut(&gerrStr,false);
+	return 0;
+	}
+
+long val = hash(str);
+Slist<Sym> *list = &(parr_[val]);		// Hash array loc for string.
+
+// Search the chain.
 Selt<Sym> *ptr;
-if ((ptr = hfind(str)))
-	return ptr;
-return hadd(str);
+for (ptr = list->getFirst(); ptr; ptr = ptr->Right())
+	{
+	if (!_tcscmp(str, ptr->getData()->getStr()))
+		return ptr;				// Found it in chain.
+	}
+
+// Not present -- add it, reusing the bucket we already located.
+Sym *sym = new Sym(str, stab_);
+if (empty(sym->getStr()))							// CRASH GUARD.
+	{
+	delete sym;
+	return 0;
+	}
+Selt<Sym> *selt = new Selt<Sym>(sym);
+list->push(selt);				// Place at FRONT of hash chain.
+return selt;
 }
 
 
@@ -556,15 +590,20 @@ sym = selt->getData();
 if (sym->getLcsym())			// Already has a lowercase version.
 	return sym;
 
-// Install lowercase variant.
-str_to_lower(str, buf);
-if (!_tcscmp(str, buf))		// String is already lowercase.
+// Install lowercase variant.  Overlong strings go to the heap.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, buf, MAXSTR, /*UP*/ alloced);
+if (!_tcscmp(str, lc))		// String is already lowercase.
 	{
 	sym->setLcsym(sym);		// Make it point to itself!
+	if (alloced)
+		Chars::destroy(lc);
 	return sym;
 	}
 
-lcsym = hsym(buf);			// Get or make lowercase sym.
+lcsym = hsym(lc);			// Get or make lowercase sym.
+if (alloced)
+	Chars::destroy(lc);
 lcsym->setLcsym(lcsym);		// Lc points to itself (whether set or not).
 sym->setLcsym(lcsym);		// Non-lc points to its lc variant.
 return sym;
@@ -597,16 +636,21 @@ if ((lcsym = sym->getLcsym()))			// Already has a lowercase version.
 
 str = sym->getStr();			// Get terminated string.
 
-// Install lowercase variant.
-str_to_lower(str, buf);
-if (!_tcscmp(str, buf))		// String is already lowercase.
+// Install lowercase variant.  Overlong strings go to the heap.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, buf, MAXSTR, /*UP*/ alloced);
+if (!_tcscmp(str, lc))		// String is already lowercase.
 	{
 	sym->setLcsym(sym);		// Make it point to itself!
 	lcstr = str;	// 08/01/11 AM.
+	if (alloced)
+		Chars::destroy(lc);
 	return sym;
 	}
 
-lcsym = hsym(buf);			// Get or make lowercase sym.
+lcsym = hsym(lc);			// Get or make lowercase sym.
+if (alloced)
+	Chars::destroy(lc);
 lcsym->setLcsym(lcsym);		// Lc points to itself (whether set or not).
 sym->setLcsym(lcsym);		// Non-lc points to its lc variant.
 lcstr = lcsym->getStr();	// 08/01/11 AM.

--- a/lite/str.cpp
+++ b/lite/str.cpp
@@ -793,6 +793,68 @@ return buf;
 
 
 /********************************************
+* FN:		STR_TO_LOWER_SAFE
+* CR:		08/03/26 AM.
+* SUBJ:	Lowercase into a caller buffer, or onto the heap if it will not fit.
+* RET:	Pointer to the lowercased string.  UP alloced - true if the result
+*			is a fresh heap allocation the CALLER MUST FREE with
+*			Chars::destroy; false if the result is 'buf'.
+* NOTE:	DEFENSE IN DEPTH, not a fix for a known live bug.
+*			str_to_lower(str,buf) cannot know how big buf is, and several
+*			callers (tHtab::hfind_lc, Htab::hsym_kb, hadd_lc, hget_lc) hand
+*			it a fixed MAXSTR buffer.  Today nothing overruns them: the
+*			tokenizer clamps token length to MAXSTR-1 before a node name is
+*			ever interned (see the 08/06/06 "Intern Token: Too long --
+*			truncating" guards in dicttok.cpp and cmltok.cpp), and a
+*			2000-character single token was verified to arrive as a
+*			511-character node name.  But that safety lives in a different
+*			subsystem, and a future caller reaching these hash entry points
+*			with a longer string has no local guard to stop it.  Bound the
+*			write where the write happens.
+*			Truncating instead would be wrong here: these buffers feed hash
+*			lookups, and a truncated key can collide with a real entry.  So
+*			fall back to the heap and keep the result exact.
+*			Case mapping can also LENGTHEN a UTF-8 string (eg Turkish
+*			dotless i), so a plain strlen check against the buffer size is
+*			not sufficient on its own -- leave room for expansion when the
+*			input is not pure ASCII.
+********************************************/
+
+_TCHAR *str_to_lower_safe(
+	_TCHAR *str,			// String to lowercase.
+	_TCHAR *buf,			// Caller's buffer, used when the result fits.
+	long bufsize,			// Capacity of buf, in _TCHARs, including terminator.
+	/*UP*/
+	bool &alloced			// True if a heap buffer was returned instead.
+	)
+{
+alloced = false;
+if (!str)
+	{
+	if (buf && bufsize > 0)
+		*buf = '\0';
+	return buf;
+	}
+
+long len = (long) _tcsclen(str);
+
+// Pure ASCII cannot change length; anything else may expand.
+long need = ascii_only(str) ? (len + 1) : ((3 * len) + 4);
+
+if (buf && need <= bufsize)
+	{
+	str_to_lower(str, buf);
+	return buf;
+	}
+
+_TCHAR *big = Chars::create(need);
+str_to_lower(str, big);
+alloced = true;
+return big;
+}
+
+
+/********************************************
 * FN:		STR_TO_UPPER
 * CR:		11/04/99 AM.
 * SUBJ:	Convert a string to uppercase
@@ -1891,50 +1953,43 @@ if (!str || !*str)
 icu::StringPiece sp(str);
 const char *spd = sp.data();
 int32_t length = sp.length();
-int32_t unilen = u_strlen(str);
+int32_t unilen = (int32_t) u_strlen(str);
+
+// OPT: 08/03/26 AM. The old inner loop rebuilt an icu::StringPiece over the
+// output buffer, called u_strlen() on it (itself a full codepoint walk) and
+// then re-decoded it with U8_NEXT -- once per input character.  That turned
+// an inherently O(n^2) job into roughly O(n^3).  Track the codepoints seen
+// so far in a flat array and scan that instead.  A string cannot have more
+// unique codepoints than it has codepoints, so one allocation suffices.
+UChar32 *seen = new UChar32[(unilen > 0) ? unilen : 1];
+int32_t nseen = 0;
 
 UChar32 c = 1;
 int32_t s = 0;
-int32_t start = 0;
-int32_t i = 0;
 int32_t len = 0;
-int32_t strStart = 0;
-bool found = false;
 
-while (c && i<unilen) {
-	start = s;
+while (c && s < length) {
+	int32_t start = s;
 	U8_NEXT(spd, s, length, c);
 
-	found = false;
-	if (len) {
-		UChar32 cb = 1;
-		int32_t sb = 0;
-		icu::StringPiece spb(buf);
-		const char *spdb = spb.data();
-		int32_t lengthb = spb.length();
-		int32_t unilenb = u_strlen(buf);
-
-		for (int j=0; j<unilenb; j++) {
-			U8_NEXT(spdb, sb, lengthb, cb);
-			if (cb == c) {
-				found = true;
-				break;
-			}
-		}		
+	bool found = false;
+	for (int32_t j = 0; j < nseen; j++) {
+		if (seen[j] == c) {
+			found = true;
+			break;
+		}
 	}
 
 	if (!found) {
-		int32_t letlen = s-start;
-
-		for (int k=0; k<letlen; k++) {
-			buf[len++] = str[strStart++];
-		}
-		buf[len] = '\0';
+		if (nseen < unilen)
+			seen[nseen++] = c;
+		// Copy this character's bytes through verbatim.
+		for (int32_t k = start; k < s; k++)
+			buf[len++] = str[k];
 	}
-	strStart = s;
-	i++;
 }
 buf[len] = '\0';
+delete [] seen;
 return true;
 }
 

--- a/lite/str.h
+++ b/lite/str.h
@@ -39,6 +39,8 @@ _TCHAR *str_to_lower(_TCHAR *str, _TCHAR *buf);
 _TCHAR *str_to_lower(_TCHAR *str);                   // 12/15/14 AM.
 _TCHAR *str_to_upper(_TCHAR *str, _TCHAR *buf);							// 11/04/99 AM.
 _TCHAR *str_to_upper(_TCHAR *str);                   // 12/15/14 AM.
+_TCHAR *str_to_lower_safe(_TCHAR *str, _TCHAR *buf,				// 08/03/26 AM.
+			long bufsize, /*UP*/ bool &alloced);
 bool zap_final_white(_TCHAR *str);										// 02/12/99 AM.
 
 bool str_equal(_TCHAR *str1, _TCHAR *str2);							// 06/07/99 AM.

--- a/lite/thtab.h
+++ b/lite/thtab.h
@@ -27,6 +27,7 @@ All rights reserved.
 #include "lite/global.h"
 //#include "inline.h"		// 05/19/99 AM.
 #include "str.h"
+#include "chars.h"	// 08/03/26 AM.
 #include "slist.h"
 #include "selt.h"
 #ifdef LINUX
@@ -511,9 +512,14 @@ if (!str || !*str)
 	return 0;
 	}
 
-// Convert to lower case.
-str_to_lower(str, lc_buf);
-return hfind(lc_buf);
+// Convert to lower case.  Overlong strings go to the heap rather than
+// overrunning the shared static buffer.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, lc_buf, MAXSTR, /*UP*/ alloced);
+Selt<tSym<TYPE> > *selt = hfind(lc);
+if (alloced)
+	Chars::destroy(lc);
+return selt;
 }
 
 /********************************************
@@ -543,10 +549,13 @@ if (!str || !*str)
 	return 0;
 	}
 
-// Convert to lower case.
-str_to_lower(str, lc_buf);
+// Convert to lower case.  Overlong strings go to the heap.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, lc_buf, MAXSTR, /*UP*/ alloced);
 Selt<tSym<TYPE> > *selt;
-selt = hfind(lc_buf);
+selt = hfind(lc);
+if (alloced)
+	Chars::destroy(lc);
 if (!selt)
 	return 0;
 dat = selt->getData()->getPtr();
@@ -570,19 +579,22 @@ if (!str || !*str)
 	}
 long val;
 
-// Convert to lower case.
-str_to_lower(str, lc_buf);
+// Convert to lower case.  Overlong strings go to the heap.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, lc_buf, MAXSTR, /*UP*/ alloced);
 
-val = hash(lc_buf);
+val = hash(lc);
 Slist<tSym<TYPE> > *list;
 list = &(parr_[val]);			// Hash array location for string.	// 12/12/98 AM
 //list = &(arr_[val]);			// Hash array location for string.	// 12/12/98 AM
 
 tSym<TYPE>  *sym;
-sym = new tSym<TYPE> (lc_buf, stab_);	// Create sym for string.
+sym = new tSym<TYPE> (lc, stab_);	// Create sym for string.
 Selt<tSym<TYPE> > *selt;
 selt = new Selt<tSym<TYPE> >(sym);	// Create hash table entry for string.
 
+if (alloced)
+	Chars::destroy(lc);
 list->push(selt);			// Place at FRONT of hash chain.
 return selt;
 }
@@ -599,14 +611,17 @@ return selt;
 template<class TYPE>
 Selt<tSym<TYPE> > *tHtab<TYPE>::hget_lc(_TCHAR *str)
 {
-// Convert to lower case.
-str_to_lower(str, lc_buf);
+// Convert to lower case.  Overlong strings go to the heap.	// 08/03/26 AM.
+bool alloced;
+_TCHAR *lc = str_to_lower_safe(str, lc_buf, MAXSTR, /*UP*/ alloced);
 
 // The calls check for empty string.
 Selt<tSym<TYPE> > *ptr;
-if ((ptr = hfind(lc_buf)))
-	return ptr;
-return hadd(lc_buf);
+if (!(ptr = hfind(lc)))
+	ptr = hadd(lc);
+if (alloced)
+	Chars::destroy(lc);
+return ptr;
 }
 
 /********************************************
@@ -660,18 +675,43 @@ return 0;						// Not found in list.
 * FN:		HGET
 * CR:		11/18/98 AM.
 * SUBJ:	Find string in hash table, else add it.
-* OPT:	Unoptimized.  The two calls do redundant work.
+* NOTE:	08/03/26 AM. Was hfind() then hadd(), hashing the string twice.
+*			Hash once and reuse the bucket for search and insert.
 *
 ********************************************/
 
 template<class TYPE>
 Selt<tSym<TYPE> > *tHtab<TYPE>::hget(_TCHAR *str)
 {
-// The calls check for empty string.
+if (!str || !*str)
+	{
+	std::_t_strstream gerrStr;
+	gerrStr << _T("[hget: Given null string.]") << std::ends;
+	errOut(&gerrStr,false);
+	return 0;
+	}
+
+long val = hash(str);
+Slist<tSym<TYPE> > *list = &(parr_[val]);
+
+// Search the chain.
 Selt<tSym<TYPE> > *ptr;
-if ((ptr = hfind(str)) != NULL)
-	return ptr;
-return hadd(str);
+for (ptr = list->getFirst(); ptr; ptr = ptr->Right())
+	{
+	if (!_tcscmp(str, ptr->getData()->getStr()))
+		return ptr;				// Found it in chain.
+	}
+
+// Not present -- add it, reusing the bucket we already located.
+tSym<TYPE> *sym = new tSym<TYPE> (str, stab_);
+if (empty(sym->getStr()))							// CRASH GUARD.
+	{
+	delete sym;
+	return 0;
+	}
+Selt<tSym<TYPE> > *selt = new Selt<tSym<TYPE> >(sym);
+list->push(selt);				// Place at FRONT of hash chain.
+return selt;
 }
 
 /*******************************************/

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.15"
+#define NLP_ENGINE_VERSION "3.7.16"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Follow-up to #701. Four defects and one hardening change in the engine's string/hash layer, found while auditing the C++ for performance opportunities.

**None of this is a demonstrated speedup.** As with #701, these are correctness and waste fixes. See "On the perf framing" at the bottom.

## The four defects

### 1. `str_unique_chars` was effectively O(n³) — `lite/str.cpp`

The inner loop rebuilt an `icu::StringPiece` over its **output** buffer, called `u_strlen()` on it (itself a full codepoint walk), and re-decoded it with `U8_NEXT` — **once per input character**:

```cpp
if (len) {
    icu::StringPiece spb(buf);        // rebuilt every iteration
    int32_t unilenb = u_strlen(buf);  // full walk, every iteration
    for (int j=0; j<unilenb; j++) { U8_NEXT(spdb, sb, lengthb, cb); ... }
}
```

An inherently O(n²) job made roughly O(n³). Now tracks codepoints seen so far in a flat array with a single allocation.

### 2. `Chars::create`'s allocation guard was unreachable — `lite/chars.cpp`

```cpp
if (!(tmp = new _TCHAR[size]))   // plain new THROWS; never returns null
```

The guard could never fire and its "[Couldn't allocate a char array.]" diagnostic was dead. Switched to the `nothrow` form so the existing error path actually works.

### 3. `Htab::hget` / `tHtab::hget` hashed every string twice — `lite/htab.cpp`, `lite/thtab.h`

`hfind()` then `hadd()` — hashing the string and walking to the bucket twice on every insert. Now hashed once, with the bucket reused for search and insert. Both functions carried an `OPT: Unoptimized. The two calls do redundant work.` comment asking for precisely this. Behavior preserved, including the empty-string diagnostic and the crash guard on a sym with no string.

### 4. Local builds were unoptimized — `CMakeLists.txt`

No default `CMAKE_BUILD_TYPE`, so a plain `cmake -B build -S .` on Linux/macOS built with **no optimization flags at all**. CI was never affected — all three workflows pass `-DCMAKE_BUILD_TYPE=Release` explicitly — so this only ever hit local developer builds. Multi-config generators (Visual Studio) are left alone via `GENERATOR_IS_MULTI_CONFIG`.

## The hardening — and a correction

`tHtab::hfind_lc`, `Htab::hsym_kb`, `hadd_lc` and `hget_lc` lowercase into a fixed `MAXSTR` buffer with no length check.

**I initially reported this as a reachable buffer overflow. It is not, and I was wrong.** The tokenizer already clamps token length before interning:

```cpp
// If token too long, truncate.	// FIX.	// 08/06/06 AM.
if (len >= MAXSTR)
    ... "[Intern Token: Too long -- truncating.]" ...
    len = MAXSTR - 1;
```

`dicttok.cpp:719`, mirrored in `cmltok.cpp:1592`. Verified empirically: **unmodified master** fed a 2000-character single token runs clean, exit 0, and produces a node name of exactly **511** characters.

Keeping the change anyway as defense in depth — that safety currently lives in a different subsystem, and a future caller reaching these hash entry points has no local guard — but it is hardening, not a bug fix, and the in-code comment says so explicitly. Overlong strings fall back to the heap rather than truncating, since a truncated key can collide with a real hash entry. The helper also accounts for case mapping *lengthening* UTF-8 (e.g. Turkish dotless i), which a plain `strlen`-vs-capacity check would miss.

## New regression fixture

`.github/workflows/tests/struniquechars` pins `struniquechars()` behavior — repeats, all-same, no-repeats, spaces, digits, accented Latin (`aabbééüü` → `abéü`) and CJK (`日日本本語語` → `日本語`) — so this rewrite and any future one cannot drift. Wired into the Windows and Linux workflows alongside the existing fixtures.

## Verification

- All **5 existing CI fixtures** pass locally (parse-en-us, fulldict-hang #669, fnname-digits #698, block-comments, block-comments-data)
- **English parse tree byte-identical** to the stored baseline
- **New struniquechars fixture** passes, including multi-byte UTF-8
- **2000-char single token** exercises the heap fallback cleanly

## On the perf framing

#701 taught the lesson this PR is written around: I fixed what looked like the hottest path in the engine, and it bought nothing measurable. So nothing here is claimed as an optimization. `str_unique_chars` going from O(n³) to O(n²) is real algorithmic work, but `struniquechars()` is not on any hot path I know of — it is fixed because it is wrong, not because it is slow.

Whatever actually dominates pass time is still unidentified and wants a profiler. Also worth noting from the #701 measurements: ~4-5s of every run is fixed overhead independent of input size (analyzer load + dict read), which likely dwarfs everything in the matching loop for anyone processing many small documents.

## Deliberately not done

From the same audit, considered and rejected pending a profile:

- **`Chars::create` arena allocator** — an architectural change to lifetime management in a codebase with manual `new`/`delete` throughout. Realistic outcome is a use-after-free the regression suite doesn't catch, for zero measured benefit.
- **`readConvert` block read** — `inFile.get()` reads from `ifstream`'s internal buffer, so it is a function call per byte, not a syscall per byte; single-digit milliseconds for a 100KB file. Not worth rewriting a fiddly CR/LF + line-folding + BOM + EOF state machine.
- **`Ivar` builtin cascade** — ~16 sequential `strcmp_i`, but #701 made those cheap. Marginal.

Still open and genuinely worth doing, but deserving their own PR since they touch the match dispatcher: `Pat::resetRules`' per-node allocate-and-de-accent, and the 12-deep `_tcscmp` cascade in `Pat::modeMatch` with `_xWILD` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)