### PR TITLE
refactor: switch the match dispatcher on a tag; skip the ASCII de-accent (3.7.17)

### DIFF
--- a/lite/pat.cpp
+++ b/lite/pat.cpp
@@ -710,18 +710,28 @@ while (node)
 		Irule::mergeRules(rules, tmp);	// Merge rule lists.
 	
 	// Get deaccented version's rules.				// 01/29/05 AM.
-	// Opt: A deaccent that counted accents would be good here...
-	len = _tcsclen(nname);								// 01/29/05 AM.
-	deacc = Chars::create(len + 2);					// 01/29/05 AM.
-	Xml::de_accent(nname,/*DU*/deacc);				// 01/29/05 AM.
-	if (_tcscmp(nname,deacc))	// If accented.	// 09/20/06 AM.
+	// OPT: 08/03/26 AM. This is the answer to the old
+	// "Opt: A deaccent that counted accents would be good here..." note.
+	// Xml::de_accent copies any codepoint below 0x80 through verbatim, so
+	// for a pure-ASCII name the buffer below is always byte-identical to
+	// nname and the _tcscmp can only ever come out equal -- the allocate,
+	// transform, compare and free were pure waste.  This runs for EVERY
+	// node at EVERY match position, so it was the hottest allocation site
+	// in the matcher.  One cheap high-bit scan skips the whole thing.
+	if (!ascii_only(nname))
 		{
-		tmp = 0;								// Caution.	// 07/25/09 AM.
-		htab->hfind_lc(deacc, /*DU*/ tmp);			// 01/29/05 AM.
-		if (tmp)								// Caution.	// 07/25/09 AM.
-			Irule::mergeRules(rules, tmp);			// 01/29/05 AM.
+		len = _tcsclen(nname);							// 01/29/05 AM.
+		deacc = Chars::create(len + 2);				// 01/29/05 AM.
+		Xml::de_accent(nname,/*DU*/deacc);			// 01/29/05 AM.
+		if (_tcscmp(nname,deacc))	// If accented.	// 09/20/06 AM.
+			{
+			tmp = 0;							// Caution.	// 07/25/09 AM.
+			htab->hfind_lc(deacc, /*DU*/ tmp);		// 01/29/05 AM.
+			if (tmp)							// Caution.	// 07/25/09 AM.
+				Irule::mergeRules(rules, tmp);		// 01/29/05 AM.
+			}
+		Chars::destroy(deacc);							// 01/29/05 AM.
 		}
-	Chars::destroy(deacc);								// 01/29/05 AM.
 
 #ifdef _DEJUNK_
 	// Get dejunk version's rules.					// 09/09/11 AM.
@@ -2470,6 +2480,60 @@ return preMatch(ielt, node);	// 10/05/99 AM.				// 06/16/05 AM.
 
 
 /********************************************
+* FN:		XELTTYPE
+* CR:		08/03/26 AM.
+* SUBJ:	Resolve a special "_xNAME" rule element to an Xelt tag.
+* RET:	The tag, or XELT_NONE if the name is not a known special.
+* NOTE:	Every special is "_x" followed by an uppercase letter, so switch
+*			on that letter and compare only the handful of names that start
+*			with it.  Replaces a 12-deep if/else-if chain of _tcscmp calls
+*			in modeMatch and modeMatch1, in which _xWILD -- one of the most
+*			common elements in real grammars -- was tested last.
+********************************************/
+
+enum Xelt Pat::xeltType(_TCHAR *name)
+{
+if (!name || name[0] != '_' || name[1] != 'x')
+	return XELT_NONE;
+
+switch (name[2])
+	{
+	case 'A':
+		if (!_tcscmp(name, _T("_xALPHA")))	return XELT_ALPHA;
+		if (!_tcscmp(name, _T("_xANY")))		return XELT_ANY;
+		break;
+	case 'B':
+		if (!_tcscmp(name, _T("_xBLANK")))	return XELT_BLANK;
+		break;
+	case 'C':
+		if (!_tcscmp(name, _T("_xCAP")))		return XELT_CAP;
+		if (!_tcscmp(name, _T("_xCAPLET")))	return XELT_CAPLET;
+		if (!_tcscmp(name, _T("_xCTRL")))	return XELT_CTRL;
+		break;
+	case 'E':
+		if (!_tcscmp(name, _T("_xEMOJI")))	return XELT_EMOJI;
+		break;
+	case 'L':
+		if (!_tcscmp(name, _T("_xLET")))		return XELT_LET;
+		break;
+	case 'N':
+		if (!_tcscmp(name, _T("_xNUM")))		return XELT_NUM;
+		break;
+	case 'P':
+		if (!_tcscmp(name, _T("_xPUNCT")))	return XELT_PUNCT;
+		break;
+	case 'W':
+		if (!_tcscmp(name, _T("_xWHITE")))	return XELT_WHITE;
+		if (!_tcscmp(name, _T("_xWILD")))	return XELT_WILD;
+		break;
+	default:
+		break;
+	}
+return XELT_NONE;
+}
+
+
+/********************************************
 * FN:		MODEMATCH
 * CR:		11/03/98 AM.
 * SUBJ:	Match rule element to parse tree node, according to match mode.
@@ -2514,45 +2578,47 @@ if (*name != '_'										// 10/12/99 AM.
 	return deaccentMatch(name,pn->getName());							// 01/28/05 AM.
 	}
 
-if (!_tcscmp(name, _T("_xALPHA")))	// Alpha token.
+switch (xeltType(name))												// 08/03/26 AM.
+	{
+	case XELT_ALPHA:					// Alpha token.
 	return ((pn->getType() == PNALPHA) ? true : false);			// 07/20/04 AM.
 	// To handle retokenized alphabetics.								// 07/20/04 AM.
 	// return alphabetic(*pn->getName());									// 07/20/04 AM.
-else if (!_tcscmp(name, _T("_xNUM")))						// Numeric token.
+	case XELT_NUM:												// Numeric token.
 	return ((pn->getType() == PNNUM) ? true : false);
-else if (!_tcscmp(name, _T("_xWHITE")))						// White token.
+	case XELT_WHITE:											// White token.
 	return ((pn->getType() == PNWHITE) ? true : false);
-else if (!_tcscmp(name, _T("_xBLANK")))	// Non-newline whitespace.	// 03/22/99 AM.
+	case XELT_BLANK:			// Non-newline whitespace.	// 03/22/99 AM.
 	{
 	_TCHAR ch;
 	if ((ch = *(pn->getName())) == ' ' || ch == '\t')
 		return true;
 	return false;
 	}
-else if (!_tcscmp(name, _T("_xPUNCT")))			// Punctuation token.// 12/04/98 AM.
+	case XELT_PUNCT:								// Punctuation token.// 12/04/98 AM.
 	return ((pn->getType() == PNPUNCT) ? true : false);
-else if (!_tcscmp(name, _T("_xEMOJI")))
+	case XELT_EMOJI:
 	return ((pn->getType() == PNEMOJI) ? true : false);
-else if (!_tcscmp(name, _T("_xANY")))	// Match any node.	// 12/08/98 AM.
+	case XELT_ANY:							// Match any node.	// 12/08/98 AM.
 	return true;	// Always matches.
-else if (!_tcscmp(name, _T("_xCAP")))		// Match capitalized word. // 01/20/99 AM.
+	case XELT_CAP:								// Match capitalized word. // 01/20/99 AM.
 	return ((pn->getType() == PNALPHA)									// 07/20/04 AM.
 	// return (alphabetic(*pn->getName())									// 07/20/04 AM.
 				&& is_upper((_TUCHAR)*(pn->getName())) );		// 12/16/01 AM.
-else if (!_tcscmp(name, _T("_xCAPLET")))	// Match cap letter.	// 07/10/09 AM.
+	case XELT_CAPLET:				// Match cap letter.	// 07/10/09 AM.
 	{
 	_TCHAR *x = pn->getName();											// 07/10/09 AM.
 	return (*x && !(*(x+1)) && alphabetic(*x)						// 07/10/09 AM.
 		&& is_upper((_TUCHAR)*x));										// 07/10/09 AM.
 	}
-else if (!_tcscmp(name, _T("_xLET")))	// Match letter.			// 07/10/09 AM.
+	case XELT_LET:							// Match letter.			// 07/10/09 AM.
 	{
 	_TCHAR *x = pn->getName();											// 07/10/09 AM.
 	return (*x && !(*(x+1)) && alphabetic(*x));					// 07/10/09 AM.
 	}
-else if (!_tcscmp(name, _T("_xCTRL")))			// Control char tok.	// 07/24/00 AM.
+	case XELT_CTRL:									// Control char tok.	// 07/24/00 AM.
 	return ((pn->getType() == PNCTRL) ? true : false);
-else if (!_tcscmp(name, _T("_xWILD")))						// Restricted wildcard.
+	case XELT_WILD:												// Restricted wildcard.
 	{
 //	if (Debug())
 //		*gout << "  [Restricted wildcard.]" << std::endl;
@@ -2623,7 +2689,12 @@ else if (!_tcscmp(name, _T("_xWILD")))						// Restricted wildcard.
 	}
 
 	return false;
-	}
+	}	// End XELT_WILD.
+
+	case XELT_NONE:
+	default:
+		break;					// Unknown "_xNAME": falls through to false.
+	}	// End switch.
 //else			// LITERAL MATCH.		// OPT		// 10/12/99 AM.
 //	return literalMatch(name, pn->getName());		// 10/12/99 AM.
 return false;
@@ -2653,38 +2724,49 @@ if (!nname || !ename)
 if (!_tcsncmp(ename, _T("_xVAR("), 6))
 	return xvarMatch(ename, pn);
 
-if (!_tcscmp(ename, _T("_xALPHA")))	// Alpha token.
+switch (xeltType(ename))											// 08/03/26 AM.
+	{
+	case XELT_ALPHA:					// Alpha token.
 	return (ntype == PNALPHA) ? true : false;							// 07/20/04 AM.
 	// return (alphabetic(*nname));											// 07/20/04 AM.
-else if (!_tcscmp(ename, _T("_xNUM")))	// Numeric token.
+	case XELT_NUM:						// Numeric token.
 	return (ntype == PNNUM) ? true : false;
-else if (!_tcscmp(ename, _T("_xWHITE")))	// White token.
+	case XELT_WHITE:					// White token.
 	return (ntype == PNWHITE) ? true : false;
-else if (!_tcscmp(ename, _T("_xBLANK")))	// Non-newline whitespace.	// 03/22/99 AM.
+	case XELT_BLANK:					// Non-newline whitespace.	// 03/22/99 AM.
+	// WARN: kept verbatim, precedence bug and all.  "ch = *nname == ' '"
+	// assigns the COMPARISON result, so ch is 0 or 1 and the '\t' test can
+	// never fire -- a tab does not match _xBLANK here, though it does in
+	// Pat::modeMatch's copy of the same test.  Fixing it would change
+	// matching behavior, so it is reported separately rather than changed
+	// inside a no-behavior-change cleanup.	// 08/03/26 AM.
 	{
 	_TCHAR ch;
 	if ((ch = *nname == ' ') || ch == '\t')
 		return true;
 	return false;
 	}
-else if (!_tcscmp(ename, _T("_xPUNCT")))	// Punctuation token.
+	case XELT_PUNCT:					// Punctuation token.
 	return (ntype == PNPUNCT) ? true : false;
-else if (!_tcscmp(ename, _T("_xEMOJI")))
+	case XELT_EMOJI:
 	return (ntype == PNEMOJI) ? true : false;
-else if (!_tcscmp(ename, _T("_xANY")))				// 12/08/98 AM.
+	case XELT_ANY:									// 12/08/98 AM.
 	return true;					// User is being silly, but do it anyway.
-else if (!_tcscmp(ename, _T("_xCAP")))	// Match capitalized word. // 01/20/99 AM.
+	case XELT_CAP:						// Match capitalized word. // 01/20/99 AM.
 	return ((ntype == PNALPHA)												// 07/20/04 AM.
 	// return (alphabetic(*nname)												// 07/20/04 AM.
 			  && is_upper((_TUCHAR)*nname) );					// 12/16/10 AM.
-else if (!_tcscmp(ename, _T("_xCAPLET")))	// Match cap letter.	// 07/10/09 AM.
+	case XELT_CAPLET:					// Match cap letter.	// 07/10/09 AM.
 	return (*nname && !(*(nname+1)) && isupper((_TUCHAR)*nname)	// 07/10/09 AM.
 		&& alphabetic(*nname));												// 07/10/09 AM.
-else if (!_tcscmp(ename, _T("_xLET")))	// Match letter.			// 07/10/09 AM.
+	case XELT_LET:						// Match letter.			// 07/10/09 AM.
 	return (alphabetic(*nname) && !(*(nname+1)));					// 07/10/09 AM.
-else if (!_tcscmp(ename, _T("_xCTRL")))	// Control char token.
+	case XELT_CTRL:					// Control char token.
 	return (ntype == PNCTRL) ? true : false;
-else			// LITERAL MATCH.
+
+	case XELT_WILD:		// Not handled here; falls to literal match, as before.
+	case XELT_NONE:
+	default:			// LITERAL MATCH.
 	{
 	if (!deaccent && !dejunk)												// 01/28/05 AM.
 		return literalMatch(ename, nname);
@@ -2692,6 +2774,7 @@ else			// LITERAL MATCH.
 		return dejunkMatch(ename,nname);									// 09/09/11 AM.
 	else
 		return deaccentMatch(ename,nname);								// 01/28/05 AM.
+	}
 	}
 }
 

--- a/lite/pat.h
+++ b/lite/pat.h
@@ -43,6 +43,36 @@ class Ipre;				// 02/26/01 AM.
 class Htab;				// 02/26/01 AM.
 
 /********************************************
+* ENUM:	XELT
+* CR:		08/03/26 AM.
+* SUBJ:	The special "_xNAME" rule elements, resolved to a tag.
+* NOTE:	Pat::modeMatch and Pat::modeMatch1 used to identify these by
+*			walking a chain of up to twelve _tcscmp calls, with _xWILD --
+*			one of the most common elements in real grammars -- dead last.
+*			Pat::xeltType() dispatches on the letter after "_x" instead, so
+*			a lookup costs one switch and at most three compares, and the
+*			match functions become a switch on a tag rather than an
+*			if/else-if ladder over string literals.
+********************************************/
+
+enum Xelt
+	{
+	XELT_NONE = 0,		// Not a recognized special element.
+	XELT_ALPHA,
+	XELT_NUM,
+	XELT_WHITE,
+	XELT_BLANK,
+	XELT_PUNCT,
+	XELT_EMOJI,
+	XELT_ANY,
+	XELT_CAP,
+	XELT_CAPLET,
+	XELT_LET,
+	XELT_CTRL,
+	XELT_WILD
+	};
+
+/********************************************
 * CLASS:	PAT
 * CR:		10/18/98 AM.
 * SUBJ:	Class for the main pattern-based pass type.
@@ -299,6 +329,9 @@ public:
 		Node<Pn> *node
 		);
 
+	static enum Xelt xeltType(	// Classify a "_xNAME" element.	// 08/03/26 AM.
+		_TCHAR *name
+		);
 	static bool modeMatch(
 		Ielt *ielt,				// OPT	// 10/05/99 AM.
 		Pn *pn,					// OPT	// 10/05/99 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.16"
+#define NLP_ENGINE_VERSION "3.7.17"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Third and last PR from the engine perf audit (after #701, #702). Two changes in the rule matcher's inner loop. **Both are behavior-preserving; neither is a demonstrated speedup.**

## 1. The match dispatcher is now a switch on a tag

`Pat::modeMatch` and `Pat::modeMatch1` each identified the special `_xNAME` elements by walking a chain of up to **twelve** `_tcscmp` calls:

```cpp
if      (!_tcscmp(name, _T("_xALPHA")))  ...
else if (!_tcscmp(name, _T("_xNUM")))    ...
...  // ten more
else if (!_tcscmp(name, _T("_xWILD")))   ...   // <-- dead last
```

`_xWILD` is one of the most common elements in real grammars and sat at the end of the ladder.

Added an `Xelt` enum and `Pat::xeltType()`, which dispatches on the single letter after `_x` — so a lookup costs one switch plus at most three compares — and both match functions become a switch on a tag rather than an if/else-if ladder over string literals. **Every case body is carried over verbatim.**

One subtlety preserved: `_xWILD` was never in `modeMatch1`'s cascade, so it fell through to the literal-match `else`. The switch routes `XELT_WILD` to the same default.

## 2. `resetRules` no longer de-accents pure-ASCII names

Per node, per match position, this allocated a buffer, ran the whole node name through `Xml::de_accent`, compared the result against the original, and freed it — purely to answer "does this name have accents":

```cpp
len = _tcsclen(nname);
deacc = Chars::create(len + 2);        // heap alloc
Xml::de_accent(nname, deacc);          // full codepoint walk
if (_tcscmp(nname, deacc))             // ...just to ask "was it accented?"
    { ... }
Chars::destroy(deacc);                 // free
```

`Xml::de_accent` copies every codepoint below 0x80 through verbatim, so for a pure-ASCII name the compare **could only ever come out equal** — the whole sequence was waste. Now guarded by one high-bit scan, which is exactly equivalent by construction.

This answers the function's own standing note: `// Opt: A deaccent that counted accents would be good here...`

## Verification

- All **6 CI regression fixtures** pass
- **English parse tree byte-identical** to the stored baseline
- **Accented-input parse tree byte-identical** (12116 bytes) between this build and the pre-change build

That last one matters: the English corpus is pure ASCII, so it exercises only the side of the `resetRules` guard that now *skips* work. I built both versions and diffed a French/German/Spanish input through the full pipeline to confirm the non-ASCII path is untouched — A/B'd rather than inferred.

## Known bug deliberately left alone

`modeMatch1`'s `_xBLANK` case reads:

```cpp
if ((ch = *nname == ' ') || ch == '\t')
```

Precedence makes that assign the **comparison result**, so `ch` is 0 or 1 and the `'\t'` test can never fire. A tab does not match `_xBLANK` in a match/fail list, though it does in `Pat::modeMatch`'s copy of the same test — the two are inconsistent.

Fixing it changes matching behavior and could shift analyzer output, so it is preserved verbatim with a `WARN:` comment and reported here rather than quietly changed inside a no-behavior-change cleanup. Happy to fix it in a separate PR if you want the two paths reconciled.

## On the perf framing, once more

Same as #701 and #702: nothing here is claimed as an optimization. `resetRules` was genuinely the hottest allocation site in the matcher by inspection, and removing a per-node allocate-transform-compare is unambiguously less work — but #701 already demonstrated that my static reading of this engine's hot path does not predict wall-clock, so I am not putting a number on it.

**What is still unknown after three PRs:** what actually dominates pass time. Worth noting from the #701 measurements that ~4–5s of every run is fixed overhead independent of input size (analyzer load + dict read), which likely dwarfs the matching loop entirely for anyone processing many small documents. That is where I would point a profiler first.

## Remaining audit items, all rejected pending a profile

- **`Chars::create` arena allocator** — architectural change to lifetime management in a codebase with manual `new`/`delete` throughout; realistic outcome is a use-after-free the suite doesn't catch, for zero measured benefit
- **`readConvert` block read** — `inFile.get()` reads from `ifstream`'s internal buffer, so it's a function call per byte, not a syscall per byte; single-digit ms for a 100KB file, not worth rewriting a CR/LF + line-folding + BOM + EOF state machine
- **`Ivar` builtin cascade** — ~16 sequential `strcmp_i`, but #701 made those cheap

🤖 Generated with [Claude Code](https://claude.com/claude-code)