### PR TITLE
fix: make regexp() and regexpi() match again (3.8.0)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -260,6 +260,42 @@ jobs:
           fi
           echo "[struniquechars] unique-character extraction is UTF-8 correct"
 
+      - name: regexp/regexpi glob matching (Non-20.04)
+        if: matrix.id != 'docker-ubuntu-20.04'
+        shell: bash
+        run: |
+          set -eo pipefail
+          # regexp() and regexpi() returned false for EVERY input: the "no
+          # literal yet" marker in Regexp::init was an empty string rather
+          # than a null pointer, so every "has a literal" test read true, the
+          # literal never bound and the pattern degenerated. regexpi() also
+          # recursed into the case-SENSITIVE match(), losing case folding
+          # after the first pattern element -- hence the i-multi line.
+          FIX=.github/workflows/tests/regexp-glob
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(regexp glob): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%s\n' \
+            'star-tail:cat|' \
+            'star-head:Walking|JumPing|' \
+            'star-both:Walking|cat|' \
+            'literal:cat|' \
+            'qmark:cat|' \
+            'whole:0' \
+            'i-multi:RUNNING|' \
+            'i-head:RUNNING|Walking|JumPing|' \
+            'nomatch:0')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(regexp glob): out.txt was:"; echo "$got"
+            echo "wanted:"; echo "$want"; exit 1
+          fi
+          echo "[regexp glob] regexp/regexpi match, and regexpi folds case throughout"
+
       - name: Copy nlp.exe to nlpl.exe (Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'
         run: cp bin/nlp bin/nlpl.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -182,6 +182,41 @@ jobs:
           fi
           echo "[struniquechars] unique-character extraction is UTF-8 correct"
 
+      - name: regexp/regexpi glob matching
+        shell: bash
+        run: |
+          set -eo pipefail
+          # regexp() and regexpi() returned false for EVERY input: the "no
+          # literal yet" marker in Regexp::init was an empty string rather
+          # than a null pointer, so every "has a literal" test read true, the
+          # literal never bound and the pattern degenerated. regexpi() also
+          # recursed into the case-SENSITIVE match(), losing case folding
+          # after the first pattern element -- hence the i-multi line.
+          FIX=.github/workflows/tests/regexp-glob
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(regexp glob): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%s\n' \
+            'star-tail:cat|' \
+            'star-head:Walking|JumPing|' \
+            'star-both:Walking|cat|' \
+            'literal:cat|' \
+            'qmark:cat|' \
+            'whole:0' \
+            'i-multi:RUNNING|' \
+            'i-head:RUNNING|Walking|JumPing|' \
+            'nomatch:0')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(regexp glob): out.txt was:"; echo "$got"
+            echo "wanted:"; echo "$want"; exit 1
+          fi
+          echo "[regexp glob] regexp/regexpi match, and regexpi folds case throughout"
+
       - name: Copy nlp.exe to nlpw.exe
         run: cp bin/Release/nlp.exe bin/Release/nlpw.exe
         shell: bash

--- a/.github/workflows/tests/regexp-glob/input/text.txt
+++ b/.github/workflows/tests/regexp-glob/input/text.txt
@@ -1,0 +1,1 @@
+RUNNING Walking cat JumPing dog

--- a/.github/workflows/tests/regexp-glob/spec/analyzer.seq
+++ b/.github/workflows/tests/regexp-glob/spec/analyzer.seq
@@ -1,0 +1,11 @@
+tokenize	nil	# tokenize only -- fixture needs no dictionary
+nlp	g1	# regexp("c*")
+nlp	g2	# regexp("*ing")
+nlp	g3	# regexp("*a*")
+nlp	g4	# regexp("cat")
+nlp	g5	# regexp("?at")
+nlp	g6	# regexp("at")
+nlp	g7	# regexpi("r*ing")
+nlp	g8	# regexpi("*ING")
+nlp	g9	# regexp("zzz*")
+nlp	globout	# write the results

--- a/.github/workflows/tests/regexp-glob/spec/g1.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g1.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g1.nlp
+# SUBJ:     Trailing star.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("c*");
+@POST
+G("tail") = G("tail") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g2.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g2.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g2.nlp
+# SUBJ:     Leading star -- the case most obviously broken.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("*ing");
+@POST
+G("head") = G("head") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g3.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g3.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g3.nlp
+# SUBJ:     Star at both ends, ie a substring search.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("*a*");
+@POST
+G("both") = G("both") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g4.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g4.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g4.nlp
+# SUBJ:     Bare literal, no wildcard.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("cat");
+@POST
+G("lit") = G("lit") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g5.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g5.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g5.nlp
+# SUBJ:     Question mark matches exactly one character.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("?at");
+@POST
+G("qm") = G("qm") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g6.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g6.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g6.nlp
+# SUBJ:     A pattern must match the WHOLE token: must NOT match cat.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("at");
+@POST
+G("whole") = G("whole") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g7.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g7.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g7.nlp
+# SUBJ:     Case must fold on EVERY element, not just the first.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexpi("r*ing");
+@POST
+G("imulti") = G("imulti") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g8.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g8.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g8.nlp
+# SUBJ:     Case-insensitive leading star.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexpi("*ING");
+@POST
+G("ihead") = G("ihead") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/g9.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/g9.nlp
@@ -1,0 +1,15 @@
+###############################################
+# FILE:     g9.nlp
+# SUBJ:     Matching nothing must stay matching nothing.
+# NOTE:     One pattern per pass on purpose. Rule matching is first-match-
+#           wins at a given position, so several rules in one pass would
+#           consume each other's tokens and later patterns would never see
+#           them.
+###############################################
+
+@PRE
+<1,1> regexp("zzz*");
+@POST
+G("none") = G("none") + N("$text",1) + "|";
+@RULES
+_xNIL <- _xALPHA @@

--- a/.github/workflows/tests/regexp-glob/spec/globout.nlp
+++ b/.github/workflows/tests/regexp-glob/spec/globout.nlp
@@ -1,0 +1,34 @@
+###############################################
+# FILE:     globout.nlp
+# SUBJ:     Write what the g1..g9 passes matched.
+# NOTE:     Separate pass because a @CODE region may not follow @RULES in
+#           one pass file.
+#           A global that was never assigned prints as 0, so a pattern that
+#           matched nothing shows up as 0 rather than as an empty string.
+#           That is the point of the "whole" and "nomatch" lines.
+#           Input: RUNNING Walking cat JumPing dog
+#           Expected out.txt:
+#           star-tail:cat|
+#           star-head:Walking|JumPing|      <- case sensitive, so not RUNNING
+#           star-both:Walking|cat|
+#           literal:cat|
+#           qmark:cat|
+#           whole:0                         <- "at" must not match "cat"
+#           i-multi:RUNNING|                <- case folds on BOTH elements
+#           i-head:RUNNING|Walking|JumPing|
+#           nomatch:0
+###############################################
+
+@CODE
+
+"out.txt" << "star-tail:" << G("tail")   << "\n";
+"out.txt" << "star-head:" << G("head")   << "\n";
+"out.txt" << "star-both:" << G("both")   << "\n";
+"out.txt" << "literal:"   << G("lit")    << "\n";
+"out.txt" << "qmark:"     << G("qm")     << "\n";
+"out.txt" << "whole:"     << G("whole")  << "\n";
+"out.txt" << "i-multi:"   << G("imulti") << "\n";
+"out.txt" << "i-head:"    << G("ihead")  << "\n";
+"out.txt" << "nomatch:"   << G("none")   << "\n";
+
+@@CODE

--- a/lite/regexp.cpp
+++ b/lite/regexp.cpp
@@ -77,8 +77,11 @@ _tcscpy(xbuf_, xstr);					// Copy to buffer.
 
 // Init first element of pattern array to zeros.
 elts_ = 0;
-// elt_[0].alpha = '\0';
-elt_[0].alpha = "";	// 09/26/19 AM.
+// A NULL alpha is the "no literal seen yet" marker, and every test below
+// keys off that.  An empty string is a valid pointer, so using one made
+// every "has a literal" test read true and the literal never got bound:
+// the pattern degenerated and matched nothing at all.	// 08/03/26 DD.
+elt_[0].alpha = 0;
 elt_[0].qms = 0;
 elt_[0].stars = 0;
 
@@ -95,9 +98,10 @@ while (*x)
 			if (elt_[elts_].alpha)
 				{
 				// New elt.
+				if (elts_ + 1 >= MAX_RX)
+					return false;	// Pattern too complex.	// 08/03/26 DD.
 				++elts_;
-				// elt_[elts_].alpha = '\0';
-				elt_[elts_].alpha = "";	// 09/26/19 AM.
+				elt_[elts_].alpha = 0;	// 08/03/26 DD.
 				elt_[elts_].qms = 0;
 				elt_[elts_].stars = 1;
 				}
@@ -109,9 +113,10 @@ while (*x)
 			if (elt_[elts_].alpha)
 				{
 				// New elt.
+				if (elts_ + 1 >= MAX_RX)
+					return false;	// Pattern too complex.	// 08/03/26 DD.
 				++elts_;
-				// elt_[elts_].alpha = '\0';
-				elt_[elts_].alpha = "";	// 09/26/19 AM.
+				elt_[elts_].alpha = 0;	// 08/03/26 DD.
 				elt_[elts_].qms = 1;
 				elt_[elts_].stars = 0;
 				}
@@ -309,7 +314,10 @@ if (!wild)
 		return false;
 	// ALPHA MATCH.
 	// Set up to match the rest of the elements.
-	return match(1+count,str+xlen);
+	// Recurse into matchi, NOT match: the latter compares case-sensitively,
+	// so going through it dropped case-insensitivity for every element
+	// after the first.	// 08/03/26 DD.
+	return matchi(1+count,str+xlen);
 	}
 
 // Wild.
@@ -319,7 +327,7 @@ if (slen < xlen)
 	return false;	// String not long enough.
 if (!strcmp_ni(str,elt_[count].alpha,xlen))	// Match.
 	{
-	ok = match(1+count,str+xlen);
+	ok = matchi(1+count,str+xlen);	// 08/03/26 DD.
 	if (ok)
 		return true;
 	// Since we are a wildcard, we get to move right...
@@ -333,7 +341,7 @@ while (*++str)
 		return false;
 	if (!strcmp_ni(str,elt_[count].alpha,xlen))	// Match.
 		{
-		ok = match(1+count,str+xlen);
+		ok = matchi(1+count,str+xlen);	// 08/03/26 DD.
 		if (ok)
 			return true;
 		// Since we are a wildcard, we get to move right...


### PR DESCRIPTION
`regexp()` and `regexpi()` returned **false for every input**, so any `@PRE` using them silently never fired. Verified against `running walking cat jumping dog`: `run*`, `*ing`, `run*ing`, `?unning` and even bare `*` all matched nothing, while a control `@PRE <1,1> length(3);` correctly matched `cat|dog`.

### Three defects in `lite/regexp.cpp`

1. **The literal never bound.** `Regexp::init` used `""` — a valid pointer — rather than a null pointer as the "no literal seen yet" marker. Every `if (elt_[i].alpha)` test therefore read true, the pattern's literal never got bound, and the matcher degenerated to matching nothing. The original was `'\0'`; it was changed in 2019.

2. **`regexpi` folded case only on the first element.** `matchi()` compares with case-insensitive `strcmp_ni` but recursed into `match()`, which uses case-sensitive `_tcsncmp`. Invisible while (1) stood, because nothing matched at all.

3. **Unbounded `elt_[]` growth.** `init` grew the fixed `elt_[MAX_RX]` member array with no check, so a pattern with more than 100 wildcard-separated segments overran it and corrupted the fields after it. It now refuses such a pattern.

### Test fixture

`tests/regexp-glob` runs one pattern per pass (rule matching is first-match-wins per position, so several rules in one pass would consume each other's tokens):

| pattern | matches | proves |
|---|---|---|
| `regexp("c*")` | `cat` | trailing star |
| `regexp("*ing")` | `Walking JumPing` | leading star; case-sensitive, so not `RUNNING` |
| `regexp("*a*")` | `Walking cat` | substring search |
| `regexp("cat")` | `cat` | bare literal |
| `regexp("?at")` | `cat` | `?` is exactly one char |
| `regexp("at")` | *nothing* | patterns match the **whole** token |
| `regexpi("r*ing")` | `RUNNING` | case folds on **both** elements — fix 2 |
| `regexpi("*ING")` | `RUNNING Walking JumPing` | case-insensitive leading star |
| `regexp("zzz*")` | *nothing* | non-matches stay non-matching |

### Risk

`regexp`/`regexpi` are called by **no analyzer** in this repo or in `VisualText/analyzers`, which is how this went unnoticed. `parse-en-us`' regression tree is byte-identical after the fix.

Help pages for `regexp`/`regexpi` are updated separately in `visualtext-files`, including the previously undocumented whole-token matching rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)