### PR TITLE
fix: render negative numbers as negative in str() (3.8.0)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -296,6 +296,32 @@ jobs:
           fi
           echo "[regexp glob] regexp/regexpi match, and regexpi folds case throughout"
 
+      - name: Signed numbers in str() (Non-20.04)
+        if: matrix.id != 'docker-ubuntu-20.04'
+        shell: bash
+        run: |
+          set -eo pipefail
+          # str() converted a signed long long with the UNSIGNED "%llu", so
+          # every negative printed as roughly 1.8e19 -- str(-1) gave
+          # "18446744073709551615" -- which also made the documented -1
+          # return of filesize() unreadable. The same fault was in the
+          # compiled-analyzer path (Arun::str) and in the code generator.
+          FIX=.github/workflows/tests/signed-str
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(signed str): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%s\n' 'expr:-1' 'big:-12345' 'filesize:-1' 'pos:42' 'zero:0')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(signed str): out.txt was:"; echo "$got"
+            echo "wanted:"; echo "$want"; exit 1
+          fi
+          echo "[signed str] negative numbers render as negative"
+
       - name: Copy nlp.exe to nlpl.exe (Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'
         run: cp bin/nlp bin/nlpl.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -217,6 +217,31 @@ jobs:
           fi
           echo "[regexp glob] regexp/regexpi match, and regexpi folds case throughout"
 
+      - name: Signed numbers in str()
+        shell: bash
+        run: |
+          set -eo pipefail
+          # str() converted a signed long long with the UNSIGNED "%llu", so
+          # every negative printed as roughly 1.8e19 -- str(-1) gave
+          # "18446744073709551615" -- which also made the documented -1
+          # return of filesize() unreadable. The same fault was in the
+          # compiled-analyzer path (Arun::str) and in the code generator.
+          FIX=.github/workflows/tests/signed-str
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(signed str): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%s\n' 'expr:-1' 'big:-12345' 'filesize:-1' 'pos:42' 'zero:0')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(signed str): out.txt was:"; echo "$got"
+            echo "wanted:"; echo "$want"; exit 1
+          fi
+          echo "[signed str] negative numbers render as negative"
+
       - name: Copy nlp.exe to nlpw.exe
         run: cp bin/Release/nlp.exe bin/Release/nlpw.exe
         shell: bash

--- a/.github/workflows/tests/signed-str/input/text.txt
+++ b/.github/workflows/tests/signed-str/input/text.txt
@@ -1,0 +1,1 @@
+The fixture only does arithmetic, not text.

--- a/.github/workflows/tests/signed-str/spec/analyzer.seq
+++ b/.github/workflows/tests/signed-str/spec/analyzer.seq
@@ -1,0 +1,2 @@
+tokenize	nil	# tokenize only -- fixture needs no dictionary
+nlp	signed	# str() must render negative numbers as negative

--- a/.github/workflows/tests/signed-str/spec/signed.nlp
+++ b/.github/workflows/tests/signed-str/spec/signed.nlp
@@ -1,0 +1,30 @@
+###############################################
+# FILE:     signed.nlp
+# SUBJ:     str() must render a negative number as negative.
+# NOTE:     str() converted a signed long long with the UNSIGNED "%llu", so
+#           every negative value printed as roughly 1.8e19: str(-1) gave
+#           "18446744073709551615". That also made the documented -1 return
+#           of filesize() unreadable, and the same fault sat in the
+#           compiled-analyzer path (Arun::str) and in the code generator
+#           (Ivar), so compiled analyzers emitted wrong numeric literals.
+#           Expected out.txt:
+#           expr:-1
+#           big:-12345
+#           filesize:-1
+#           pos:42
+#           zero:0
+###############################################
+
+@CODE
+
+L("neg")  = 0 - 1;
+L("big")  = 0 - 12345;
+L("size") = filesize("no/such/file/anywhere.txt");
+
+"out.txt" << "expr:"     << str(L("neg"))  << "\n";
+"out.txt" << "big:"      << str(L("big"))  << "\n";
+"out.txt" << "filesize:" << str(L("size")) << "\n";
+"out.txt" << "pos:"      << str(42)        << "\n";
+"out.txt" << "zero:"     << str(0)         << "\n";
+
+@@CODE

--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -6897,8 +6897,12 @@ switch (typ)																	// 05/29/02 AM.
 	case IANUM:																	// 05/29/02 AM.
 		{
 		// Convert num, then intern string.
+		// %lld, not %llu: num is SIGNED, so an unsigned conversion printed
+		// every negative value as ~1.8e19.  str(-1) gave
+		// "18446744073709551615", which also made the documented -1 return
+		// of filesize unreadable.	// 08/03/26 DD.
 		_TCHAR buf[MAXSTR+1];
-		_stprintf(buf, _T("%llu"), num);
+		_stprintf(buf, _T("%lld"), num);
 		parse->internStr(buf, /*UP*/ str);
 		}
 		break;

--- a/lite/fnrun.cpp
+++ b/lite/fnrun.cpp
@@ -7828,8 +7828,10 @@ _TCHAR *Arun::str(
 _TCHAR *st=0;
 
 // Convert num, then intern string.
+// %lld, not %llu: num is SIGNED. This is the compiled-analyzer twin of
+// Fn::fnStr, so it has to render negatives the same way.	// 08/03/26 DD.
 _TCHAR buf[MAXSTR+1];
-_stprintf(buf, _T("%llu"), num);
+_stprintf(buf, _T("%lld"), num);
 Parse *parse = nlppp->getParse();
 parse->internStr(buf, /*UP*/ st);
 return st;

--- a/lite/ivar.cpp
+++ b/lite/ivar.cpp
@@ -1923,7 +1923,9 @@ _TCHAR *name = getName();
 long long num = getNum();
 _TCHAR s_num[64];																// 05/04/01 AM.
 if (num)																			// 05/04/01 AM.
-	_stprintf(s_num, _T("%llu"), num);											// 05/04/01 AM.
+	// %lld, not %llu: num is SIGNED, and this literal is emitted straight
+	// into generated C++, so a negative index compiled to ~1.8e19.	// 08/03/26 DD.
+	_stprintf(s_num, _T("%lld"), num);											// 08/03/26 DD.
 else																				// 05/04/01 AM.
 	_stprintf(s_num, _T("0LL"));												// 05/04/01 AM.
 *fcode << _T("Arun::");

--- a/lite/var.cpp
+++ b/lite/var.cpp
@@ -1853,7 +1853,8 @@ switch (arg->getType())														// 11/03/99 AM.
 		num = arg->getNum();													// 11/03/99 AM.
 		// Convert to string.
 		// _stprintf(buf, _T("%d"), num);	// 11/03/99 AM.
-		_stprintf(buf, _T("%llu"), num);	// 11/03/99 AM.	// 09/26/19 AM.
+		// %lld, not %llu: num is SIGNED.	// 08/03/26 DD.
+		_stprintf(buf, _T("%lld"), num);	// 11/03/99 AM.	// 08/03/26 DD.
 		break;
 	case IAFLOAT:																// 08/17/01 AM.
 		_stprintf(buf, _T("%f"), arg->getFloat());							// 08/17/01 AM.


### PR DESCRIPTION
> **Stacked on #704.** Base is `fix/regexp-glob-matcher`; it will retarget to `master` once that merges. Only the second commit belongs to this PR.

`str()` converted a **signed** `long long` with the **unsigned** `%llu`, so every negative value printed as roughly 1.8e19. Plain NLP++ arithmetic was enough to hit it:

```
L("n") = 0 - 1;
"out.txt" << str(L("n"));      # 18446744073709551615
```

It also made the documented `-1` return of [`filesize()`](https://github.com/VisualText/nlp-engine) unreadable, and any other function reporting "not found" as `-1`.

### Four sites, all converting a signed value

| file | what |
|---|---|
| `lite/fn.cpp` | `Fn::fnStr` — the interpreted `str()` builtin |
| `lite/fnrun.cpp` | `Arun::str` — the **compiled** analyzer's `str()` |
| `lite/var.cpp` | variable value → string |
| `lite/ivar.cpp` | **code generation** for a numeric literal |

The last one emitted the wrong constant straight into generated C++, so a compiled analyzer did not merely *print* a negative number wrongly — it *compiled* the wrong number. The `fn.cpp`/`fnrun.cpp` pair had to move together to keep interpreted and compiled analyzers aligned, which the docs call out as a standing concern.

Two of the four carried a `09/26/19` date, suggesting a single sweep that changed these from `%d`/`%ld` to `%llu` when the values widened to `long long`.

### Test fixture

`tests/signed-str` asserts `expr:-1`, `big:-12345`, `filesize:-1`, `pos:42`, `zero:0` — covering negatives from arithmetic, from a builtin's error return, and confirming positives and zero are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)