### PR TITLE
feat: let a user function shadow a builtin of the same name (3.8.0)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -322,6 +322,35 @@ jobs:
           fi
           echo "[signed str] negative numbers render as negative"
 
+      - name: User functions shadow builtins (Non-20.04)
+        if: matrix.id != 'docker-ubuntu-20.04'
+        shell: bash
+        run: |
+          set -eo pipefail
+          # Defining a function whose name is also a builtin used to be a hard
+          # error, so adding any builtin broke every analyzer that had already
+          # defined that name -- which is what happened to arrayreverse and
+          # push, hand-written in visualText/spec/UtilFuncs.nlp long before
+          # they became builtins. The user definition now wins, with a warning.
+          FIX=.github/workflows/tests/shadowing
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(shadowing): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%s\n' 'shadowed:USER-WON' 'unshadowed:HELLO' 'stilldispatches:5')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(shadowing): out.txt was:"; echo "$got"
+            echo "wanted:"; echo "$want"; exit 1
+          fi
+          if ! grep -q "shadows built-in" "$FIX/logs/make_ana.log"; then
+            echo "FAIL(shadowing): no warning was logged"; exit 1
+          fi
+          echo "[shadowing] a user function overrides a builtin of the same name"
+
       - name: Copy nlp.exe to nlpl.exe (Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'
         run: cp bin/nlp bin/nlpl.exe

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -273,6 +273,7 @@ jobs:
           # after the first pattern element -- hence the i-multi line.
           FIX=.github/workflows/tests/regexp-glob
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          mkdir -p "$FIX/logs"
           ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
           if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
           OUT="$FIX/input/text.txt_log/out.txt"
@@ -308,6 +309,7 @@ jobs:
           # compiled-analyzer path (Arun::str) and in the code generator.
           FIX=.github/workflows/tests/signed-str
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          mkdir -p "$FIX/logs"
           ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
           if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
           OUT="$FIX/input/text.txt_log/out.txt"
@@ -334,6 +336,7 @@ jobs:
           # they became builtins. The user definition now wins, with a warning.
           FIX=.github/workflows/tests/shadowing
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          mkdir -p "$FIX/logs"
           ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
           if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
           OUT="$FIX/input/text.txt_log/out.txt"
@@ -346,8 +349,11 @@ jobs:
             echo "FAIL(shadowing): out.txt was:"; echo "$got"
             echo "wanted:"; echo "$want"; exit 1
           fi
+          # make_analyzer only writes make_ana.log when logs/ already exists,
+          # which is why the step recreates it above. Without that, Linux left
+          # no log to grep while Windows created the directory on the way.
           if ! grep -q "shadows built-in" "$FIX/logs/make_ana.log"; then
-            echo "FAIL(shadowing): no warning was logged"; exit 1
+            echo "FAIL(shadowing): the shadowing warning was never emitted"; exit 1
           fi
           echo "[shadowing] a user function overrides a builtin of the same name"
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -194,6 +194,7 @@ jobs:
           # after the first pattern element -- hence the i-multi line.
           FIX=.github/workflows/tests/regexp-glob
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          mkdir -p "$FIX/logs"
           ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
           if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
           OUT="$FIX/input/text.txt_log/out.txt"
@@ -228,6 +229,7 @@ jobs:
           # compiled-analyzer path (Arun::str) and in the code generator.
           FIX=.github/workflows/tests/signed-str
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          mkdir -p "$FIX/logs"
           ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
           if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
           OUT="$FIX/input/text.txt_log/out.txt"
@@ -253,6 +255,7 @@ jobs:
           # they became builtins. The user definition now wins, with a warning.
           FIX=.github/workflows/tests/shadowing
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          mkdir -p "$FIX/logs"
           ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
           if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
           OUT="$FIX/input/text.txt_log/out.txt"
@@ -265,8 +268,11 @@ jobs:
             echo "FAIL(shadowing): out.txt was:"; echo "$got"
             echo "wanted:"; echo "$want"; exit 1
           fi
+          # make_analyzer only writes make_ana.log when logs/ already exists,
+          # which is why the step recreates it above. Without that, Linux left
+          # no log to grep while Windows created the directory on the way.
           if ! grep -q "shadows built-in" "$FIX/logs/make_ana.log"; then
-            echo "FAIL(shadowing): no warning was logged"; exit 1
+            echo "FAIL(shadowing): the shadowing warning was never emitted"; exit 1
           fi
           echo "[shadowing] a user function overrides a builtin of the same name"
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -242,6 +242,34 @@ jobs:
           fi
           echo "[signed str] negative numbers render as negative"
 
+      - name: User functions shadow builtins
+        shell: bash
+        run: |
+          set -eo pipefail
+          # Defining a function whose name is also a builtin used to be a hard
+          # error, so adding any builtin broke every analyzer that had already
+          # defined that name -- which is what happened to arrayreverse and
+          # push, hand-written in visualText/spec/UtilFuncs.nlp long before
+          # they became builtins. The user definition now wins, with a warning.
+          FIX=.github/workflows/tests/shadowing
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
+          ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          if [ -f "$FIX/logs/make_ana.log" ]; then cat "$FIX/logs/make_ana.log"; fi
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(shadowing): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          want=$(printf '%s\n' 'shadowed:USER-WON' 'unshadowed:HELLO' 'stilldispatches:5')
+          if [ "$got" != "$want" ]; then
+            echo "FAIL(shadowing): out.txt was:"; echo "$got"
+            echo "wanted:"; echo "$want"; exit 1
+          fi
+          if ! grep -q "shadows built-in" "$FIX/logs/make_ana.log"; then
+            echo "FAIL(shadowing): no warning was logged"; exit 1
+          fi
+          echo "[shadowing] a user function overrides a builtin of the same name"
+
       - name: Copy nlp.exe to nlpw.exe
         run: cp bin/Release/nlp.exe bin/Release/nlpw.exe
         shell: bash

--- a/.github/workflows/tests/shadowing/input/text.txt
+++ b/.github/workflows/tests/shadowing/input/text.txt
@@ -1,0 +1,1 @@
+irrelevant

--- a/.github/workflows/tests/shadowing/spec/analyzer.seq
+++ b/.github/workflows/tests/shadowing/spec/analyzer.seq
@@ -1,0 +1,2 @@
+tokenize	nil	# tokenize only -- fixture needs no dictionary
+nlp	shadow	# a user function must shadow a builtin of the same name

--- a/.github/workflows/tests/shadowing/spec/shadow.nlp
+++ b/.github/workflows/tests/shadowing/spec/shadow.nlp
@@ -1,0 +1,38 @@
+###############################################
+# FILE:     shadow.nlp
+# SUBJ:     A user function must shadow a builtin of the same name.
+# NOTE:     Defining a function whose name is also a builtin used to be a
+#           hard error, so adding any builtin broke every analyzer that had
+#           already defined that name -- which is exactly what happened to
+#           arrayreverse and push, hand-written in visualText/spec/
+#           UtilFuncs.nlp long before they became builtins.
+#           Now the user's definition wins and a warning is logged.
+#           Fn::fnCall must therefore search the analyzer's own functions
+#           BEFORE the builtin table.
+#           Only long-standing builtins are used here, so the fixture stands
+#           on its own without any newly added function.
+#           Expected out.txt:
+#           shadowed:USER-WON
+#           unshadowed:HELLO
+#           stilldispatches:5
+###############################################
+
+@DECL
+
+# Deliberately collide with the strtolower builtin.
+strtolower(L("str")) {
+	return "USER-WON";
+}
+
+@@DECL
+
+@CODE
+
+# The user definition must win over the builtin.
+"out.txt" << "shadowed:" << strtolower("ABC") << "\n";
+
+# Builtins that are NOT shadowed must still dispatch normally.
+"out.txt" << "unshadowed:" << strtoupper("hello") << "\n";
+"out.txt" << "stilldispatches:" << str(strlength("hello")) << "\n";
+
+@@CODE

--- a/lite/fn.cpp
+++ b/lite/fn.cpp
@@ -158,30 +158,33 @@ if (ifunc)	// Optimized check.
 	}
 else																				// 12/26/01 AM.
 	{
-	// LOOK UP FUNCTION ID IN BUILTINS HASH TABLE.					// 12/21/01 AM.
 	Ana *ana = parse->getAna();											// 12/21/01 AM.
 	NLP *nlp = ana->getNLP();												// 12/21/01 AM.
 	VTRun *vtrun = nlp->getVTRun();	// [DEGLOB]	// 10/15/20 AM.
+
+	// LOOK IT UP IN USER-DEFINED NLP++ FUNCTIONS FIRST.
+	// A user's own definition SHADOWS a builtin of the same name, so that
+	// adding a builtin can never change what an existing analyzer does.
+	// Ifunc::load warns about the shadowing at analyzer build time.
+	// This used to search the builtins first, which meant a user function
+	// could never win -- and the builtin table was only reachable at all
+	// because defining such a name was a hard error.	// 08/03/26 DD.
+	void *htab = ana->getHtfunc();										// 12/21/01 AM.
+	Ifunc *ifunc = Ifunc::htLookup(func,htab);						// 12/21/01 AM.
+	if (ifunc && ifunc->getBody())
+		{
+//		action->setFunc(ifunc);								// BAD.	// 12/27/01 AM.
+		return ifunc->eval(args,nlppp,sem);								// 12/21/01 AM.
+		}
+
+	// LOOK UP FUNCTION ID IN BUILTINS HASH TABLE.					// 12/21/01 AM.
 //	void *htab = nlp->getHtfunc();										// 12/21/01 AM.
 //	void *htab = VTRun_Ptr->htfunc_;				// 08/28/02 AM.
-	void *htab = vtrun->htfunc_;	// [DEGLOB]	// 10/15/20 AM.
-	Ifunc *ifunc = Ifunc::htLookup(func,htab);						// 12/27/01 AM.
-	if (ifunc)																	// 12/26/01 AM.
+	htab = vtrun->htfunc_;	// [DEGLOB]	// 10/15/20 AM.
+	if ((ifunc = Ifunc::htLookup(func,htab)) != 0)					// 12/27/01 AM.
 		{
 		fnid = ifunc->getId();												// 12/26/01 AM.
 //		action->setFunc(ifunc);									// BAD	// 12/27/01 AM.
-		}
-
-	// LOOK IT UP IN USER-DEFINED NLP++ FUNCTIONS.					// 12/21/01 AM.
-	// If found, EXECUTE user-define function.						// 12/21/01 AM.
-	else																			// 12/26/01 AM.
-		{
-		htab = ana->getHtfunc();											// 12/21/01 AM.
-		if ((ifunc = Ifunc::htLookup(func,htab)))						// 12/21/01 AM.
-			{
-//			action->setFunc(ifunc);								// BAD.	// 12/27/01 AM.
-			return ifunc->eval(args,nlppp,sem);							// 12/21/01 AM.
-			}
 		}
 	}
 

--- a/lite/ifunc.cpp
+++ b/lite/ifunc.cpp
@@ -450,15 +450,21 @@ for (delt = list->getFirst(); delt; delt = delt->Right())
 	line = deffunc->line_;													// 12/21/01 AM.
 	pass = deffunc->pass_;													// 12/21/01 AM.
 
-	// Check that function name is not already in builtin table.
+	// Warn if the function name is also a builtin.
+	// This used to be a hard error, which meant that adding a builtin broke
+	// every existing analyzer that had defined a function of that name --
+	// eg arrayreverse and push, both hand-written in
+	// visualText/spec/UtilFuncs.nlp long before they became builtins.
+	// The user's definition now SHADOWS the builtin (see Fn::fnCall, which
+	// searches the analyzer's own functions first), so old analyzers keep
+	// their own behavior and no future builtin can break them.	// 08/03/26 DD.
 	if (htbuilt->hfind(name))
 		{
 		std::_t_strstream gerrStr;
-		gerrStr << _T("[Can't use built-in NLP++ function name='")
-				<< name << _T("']") << std::ends;
-		errOut(&gerrStr,false,currseqpass,line);
-		ok = false;
-		continue;
+		gerrStr << _T("[Warning: user function shadows built-in NLP++ function name='")
+				<< name << _T("'. The user function will be used.]") << std::ends;
+		errOut(&gerrStr,true,currseqpass,line);
+		// Fall through and load it: shadowing is allowed.
 		}
 
 	// Check that function name is not already in user-defined table.


### PR DESCRIPTION
> **Stacked on #705.** Base retargets to `master` as the stack merges. Only the last commit belongs to this PR.
>
> **This is a prerequisite for the string/array builtins PR** — without it, adding `arrayreverse` and `push` stops `parse-en-us` from building at all.

Defining a function in a `@DECL` region whose name was also a builtin was a **hard error**. That meant adding any new builtin broke every existing analyzer that happened to have defined a function of that name.

Not hypothetical: `visualText/spec/UtilFuncs.nlp` and `parse-en-us/spec/funs.nlp` have both had hand-written `arrayreverse()` and `push()` for years.

The user's definition now wins, the analyzer builds, and a warning is logged:

```
[Warning: user function shadows built-in NLP++ function name='push'. The user function will be used.]
```

### Two changes were needed, not one

Downgrading the error in `Ifunc::load` **on its own would have been worse than the error**. `Fn::fnCall` searched the builtin table first and consulted the analyzer's own functions only in the `else` branch, so the builtin would have silently replaced the user's function — a shadowed definition with different semantics would be quietly ignored rather than reported.

- `lite/ifunc.cpp` — hard error → warning; load the definition anyway.
- `lite/fn.cpp` — `fnCall` now searches the analyzer's own functions **first**.

### Why this matters beyond the immediate need

Adding a builtin can no longer change what an existing analyzer does. That makes the language safe to extend — which is the whole point, given two of the eight functions in the follow-up PR collide with names already in shipped library code.

### Verification

- `tests/shadowing` — a user `strtolower` returning `USER-WON` wins; unshadowed builtins (`strtoupper`, `strlength`) still dispatch; the warning is asserted to appear in the build log. The fixture deliberately uses only long-standing builtins so it stands alone.
- `parse-en-us` builds with a **byte-identical** parse tree.
- All 12 bundled analyzers with input files build and run.

Documented on the `@DECL` help page in `visualtext-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)