### PR TITLE
chore: bump NLP_ENGINE_VERSION to 3.8.0

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.7.17"
+#define NLP_ENGINE_VERSION "3.8.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Bumps `NLP_ENGINE_VERSION` in `nlp/main.cpp` from `3.7.17` to `3.8.0`, following #704 – #708.

A **minor** bump rather than a patch, because this release adds fourteen builtins and changes a language rule:

- **New:** `readfile`, `readlines`, `dirlist`, `rematch`, `refind`, `resubst`, `strjoin`, `strindexof`, `strlastindexof`, `arraysort`, `arrayunique`, `arrayreverse`, `arrayslice`, `push`
- **Rule change:** a user function may now shadow a builtin of the same name, so adding a builtin can no longer change what an existing analyzer does
- **Fixed:** `regexp()`/`regexpi()` matched nothing at all; `str()` printed every negative number as ~1.8e19 — in the interpreted path, the compiled path, and the code generator

The help pages in `visualtext-files` carry the same 3.8.0 label.

Verified: `nlp.exe --version` reports `3.8.0`, all nine CI fixtures pass on merged master, and the `parse-en-us` regression tree is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)