### PR TITLE
fix: resolve the Python interpreter and report failing python passes

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -439,6 +439,47 @@ jobs:
           fi
           echo "[str/array] strjoin, strindexof, arraysort/unique/reverse/slice, push"
 
+      - name: Python pass interpreter and error reporting (Non-20.04)
+        if: matrix.id != 'docker-ubuntu-20.04'
+        shell: bash
+        run: |
+          set -eo pipefail
+          # The python pass hardcoded the command "python". macOS 12.3+ has no
+          # /usr/bin/python and most Linux distros ship only python3, so on many
+          # machines the pass silently did nothing: system() returns the shell's
+          # exit status (127 for command-not-found), never <0, so the old rc<0
+          # test never fired. For json2kbb that meant no .kbb was built and the
+          # analyzer ran against an empty KB with no warning at all.
+          FIX=.github/workflows/tests/python-pass
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log" "$FIX/marker.txt"
+          mkdir -p "$FIX/logs"
+          ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(python pass): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          if [ "$got" != "python:PYTHON-RAN-pre" ]; then
+            echo "FAIL(python pass): the pass did not run. out.txt was '$got'"; exit 1
+          fi
+          # Now prove a missing interpreter is REPORTED rather than swallowed.
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log" "$FIX/marker.txt"
+          mkdir -p "$FIX/logs"
+          NLPPP_PYTHON=definitely-not-a-real-interpreter \
+            ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt" > pyfail.out 2>&1 || true
+          cat pyfail.out
+          got=$(tr -d '\r' < "$OUT")
+          if [ "$got" != "python:absent" ]; then
+            echo "FAIL(python pass): expected the pass to be skipped, got '$got'"; exit 1
+          fi
+          if ! grep -q "python pass FAILED" pyfail.out; then
+            echo "FAIL(python pass): a failing pass was not reported"; exit 1
+          fi
+          if ! grep -q "python pass" "$FIX/input/text.txt_log/err.log"; then
+            echo "FAIL(python pass): the failure never reached err.log"; exit 1
+          fi
+          echo "[python pass] interpreter is resolved, and failures are reported"
+
       - name: Copy nlp.exe to nlpl.exe (Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'
         run: cp bin/nlp bin/nlpl.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -356,6 +356,46 @@ jobs:
           fi
           echo "[str/array] strjoin, strindexof, arraysort/unique/reverse/slice, push"
 
+      - name: Python pass interpreter and error reporting
+        shell: bash
+        run: |
+          set -eo pipefail
+          # The python pass hardcoded the command "python". macOS 12.3+ has no
+          # /usr/bin/python and most Linux distros ship only python3, so on many
+          # machines the pass silently did nothing: system() returns the shell's
+          # exit status (127 for command-not-found), never <0, so the old rc<0
+          # test never fired. For json2kbb that meant no .kbb was built and the
+          # analyzer ran against an empty KB with no warning at all.
+          FIX=.github/workflows/tests/python-pass
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log" "$FIX/marker.txt"
+          mkdir -p "$FIX/logs"
+          ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
+          OUT="$FIX/input/text.txt_log/out.txt"
+          if [ ! -f "$OUT" ]; then
+            echo "FAIL(python pass): no out.txt -- the analyzer did not build"; exit 1
+          fi
+          got=$(tr -d '\r' < "$OUT")
+          if [ "$got" != "python:PYTHON-RAN-pre" ]; then
+            echo "FAIL(python pass): the pass did not run. out.txt was '$got'"; exit 1
+          fi
+          # Now prove a missing interpreter is REPORTED rather than swallowed.
+          rm -rf "$FIX/logs" "$FIX/input/text.txt_log" "$FIX/marker.txt"
+          mkdir -p "$FIX/logs"
+          NLPPP_PYTHON=definitely-not-a-real-interpreter \
+            ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt" > pyfail.out 2>&1 || true
+          cat pyfail.out
+          got=$(tr -d '\r' < "$OUT")
+          if [ "$got" != "python:absent" ]; then
+            echo "FAIL(python pass): expected the pass to be skipped, got '$got'"; exit 1
+          fi
+          if ! grep -q "python pass FAILED" pyfail.out; then
+            echo "FAIL(python pass): a failing pass was not reported"; exit 1
+          fi
+          if ! grep -q "python pass" "$FIX/input/text.txt_log/err.log"; then
+            echo "FAIL(python pass): the failure never reached err.log"; exit 1
+          fi
+          echo "[python pass] interpreter is resolved, and failures are reported"
+
       - name: Copy nlp.exe to nlpw.exe
         run: cp bin/Release/nlp.exe bin/Release/nlpw.exe
         shell: bash

--- a/.github/workflows/tests/python-pass/input/text.txt
+++ b/.github/workflows/tests/python-pass/input/text.txt
@@ -1,0 +1,1 @@
+irrelevant

--- a/.github/workflows/tests/python-pass/spec/analyzer.seq
+++ b/.github/workflows/tests/python-pass/spec/analyzer.seq
@@ -1,0 +1,3 @@
+python	marker	# runs BEFORE the tokenizer; writes marker.txt
+tokenize	nil	# tokenize only
+nlp	report	# report whether the python pass ran

--- a/.github/workflows/tests/python-pass/spec/marker.py
+++ b/.github/workflows/tests/python-pass/spec/marker.py
@@ -1,0 +1,14 @@
+# DESC: Test fixture. Writes marker.txt into the analyzer directory.
+#
+# The engine invokes a python pass as:
+#     <interpreter> spec/<name>.py <appdir> <inputfile> pre|post
+# so argv[1] is the analyzer directory. Writing a file there is the simplest
+# observable proof that the pass actually executed -- report.nlp reads it back
+# with readfile() and the CI step asserts on the result.
+import sys, os
+
+appdir = sys.argv[1] if len(sys.argv) > 1 else "."
+phase  = sys.argv[3] if len(sys.argv) > 3 else "?"
+
+with open(os.path.join(appdir, "marker.txt"), "w") as f:
+    f.write("PYTHON-RAN-" + phase)

--- a/.github/workflows/tests/python-pass/spec/report.nlp
+++ b/.github/workflows/tests/python-pass/spec/report.nlp
@@ -1,0 +1,27 @@
+###############################################
+# FILE:     report.nlp
+# SUBJ:     Report whether the python pass before the tokenizer ran.
+# NOTE:     The engine shells out to run a python pass. It used to hardcode
+#           the command "python", which does not exist on macOS 12.3+ or on
+#           most Linux distributions (python3 only), and it only reported a
+#           failure when system() returned <0 -- which never happens for
+#           "command not found" (the shell returns 127). So a python pass
+#           could silently do nothing and the analyzer would run on with no
+#           warning at all.
+#           Expected out.txt when the interpreter resolves:
+#           python:PYTHON-RAN-pre
+#           and when it cannot:
+#           python:absent
+###############################################
+
+@CODE
+
+L("marker") = G("$apppath") + "/marker.txt";
+
+if (fileexists(L("marker"))) {
+	"out.txt" << "python:" << strtrim(readfile(L("marker"))) << "\n";
+} else {
+	"out.txt" << "python:absent" << "\n";
+}
+
+@@CODE

--- a/lite/python.cpp
+++ b/lite/python.cpp
@@ -80,6 +80,65 @@ return run(parse, script);
 }
 
 /********************************************
+* FN:		PYTHON_CMD_UTIL
+* SUBJ:	Pick the interpreter to run Python passes with.
+* RET:	Command to invoke, or 0 if no interpreter could be found.
+* NOTE:	The pass used to hardcode "python". macOS removed /usr/bin/python in
+*			12.3, and most Linux distributions ship only python3 unless
+*			python-is-python3 is installed, so on a large share of machines that
+*			command does not exist and every Python pass quietly did nothing.
+*			Probed once and cached; the answer cannot change mid-run.
+*			NLPPP_PYTHON overrides the search, for a venv or an odd install.
+********************************************/
+
+#define PYCMD_MAX 512
+
+static const _TCHAR *python_cmd_util()
+{
+static _TCHAR chosen[PYCMD_MAX];
+static bool looked = false;
+
+if (looked)
+	return (chosen[0] ? chosen : 0);
+looked = true;
+chosen[0] = '\0';
+
+// An explicit setting wins without probing: the user knows their machine.
+_TCHAR *env = _tgetenv(_T("NLPPP_PYTHON"));
+if (env && *env)
+	{
+	_tcsncpy(chosen, env, PYCMD_MAX-1);
+	chosen[PYCMD_MAX-1] = '\0';
+	return chosen;
+	}
+
+#ifdef LINUX
+// Modern macOS and most Linux distributions provide only python3.
+static const _TCHAR *cands[] = { _T("python3"), _T("python"), 0 };
+static const _TCHAR *quiet = _T(" >/dev/null 2>&1");
+#else
+// Windows installers put "python" on PATH; "py -3" is the launcher.
+static const _TCHAR *cands[] = { _T("python"), _T("python3"), _T("py -3"), 0 };
+static const _TCHAR *quiet = _T(" >nul 2>&1");
+#endif
+
+_TCHAR probe[PYCMD_MAX];
+for (int ii = 0; cands[ii]; ++ii)
+	{
+	// "-c pass" is the cheapest thing that proves the interpreter runs.
+	_stprintf(probe, _T("%s -c \"pass\"%s"), cands[ii], quiet);
+	if (_tsystem(probe) == 0)
+		{
+		_tcscpy(chosen, cands[ii]);
+		return chosen;
+		}
+	}
+
+return 0;
+}
+
+
+/********************************************
 * FN:		RUN
 * SUBJ:	Run the Python script for this pass by base name.
 * NOTE:	Shared by the interpreted (Execute) and compiled (generated python<N>)
@@ -101,8 +160,24 @@ _TCHAR *input  = parse->getInput();
 // Detect phase: a parse tree exists only after tokenization.
 bool pre = (parse->getTree() == 0);
 
+const _TCHAR *py = python_cmd_util();
+if (!py)
+	{
+	// A missing interpreter is a setup problem, not a script bug, so say so
+	// distinctly.  This used to be invisible: the pass ran "python", the
+	// shell reported command-not-found, and nothing was printed.
+	*gout << _T("[python pass FAILED: no Python interpreter found (tried python3, python). ")
+			<< _T("Set NLPPP_PYTHON to the interpreter to use. script=")
+			<< script << _T("]") << std::endl;
+	_stprintf(Errbuf,
+		_T("[python pass '%s': no Python interpreter found. Set NLPPP_PYTHON.]"),
+		script);
+	return parse->errOut(true);
+	}
+
 _TCHAR cmd[8192];
-_stprintf(cmd, _T("python \"%s/spec/%s.py\" \"%s\" \"%s\" %s"),
+_stprintf(cmd, _T("%s \"%s/spec/%s.py\" \"%s\" \"%s\" %s"),
+			py,
 			(appdir ? appdir : _T(".")),
 			script,
 			(appdir ? appdir : _T(".")),
@@ -113,11 +188,20 @@ if (parse->Verbose())
 	*gout << _T("[python pass: ") << cmd << _T("]") << std::endl;
 
 int rc = _tsystem(cmd);
-if (rc < 0)
+if (rc != 0)
 	{
-	*gout << _T("[python pass FAILED (rc<0): ") << cmd << _T("]") << std::endl;
-	// Don't abort the whole run if a gap-filler/enricher pass fails.
-	return true;
+	// Report ANY non-zero status, not just rc<0.  system() returns the
+	// shell's exit status -- 127 for command-not-found on POSIX -- and only
+	// returns -1 when the shell itself cannot be spawned, so the old rc<0
+	// test never fired and a failing pass was completely silent.  For
+	// json2kbb that meant no .kbb was built and the analyzer ran against an
+	// empty KB with no warning.
+	*gout << _T("[python pass FAILED (exit ") << rc << _T("): ")
+			<< cmd << _T("]") << std::endl;
+	_stprintf(Errbuf, _T("[python pass '%s' failed, exit status %d.]"), script, rc);
+	// Still don't abort: a gap-filler/enricher failing should not kill the
+	// analysis.  It just must not be silent.
+	return parse->errOut(true);
 	}
 
 return true;

--- a/lite/python.cpp
+++ b/lite/python.cpp
@@ -107,7 +107,7 @@ chosen[0] = '\0';
 _TCHAR *env = _tgetenv(_T("NLPPP_PYTHON"));
 if (env && *env)
 	{
-	_tcsncpy(chosen, env, PYCMD_MAX-1);
+	_tcsnccpy(chosen, env, PYCMD_MAX-1);
 	chosen[PYCMD_MAX-1] = '\0';
 	return chosen;
 	}


### PR DESCRIPTION
A python pass shelled out to the literal command `python` and only reported a problem when `system()` returned a negative value ([lite/python.cpp:105](https://github.com/VisualText/nlp-engine/blob/master/lite/python.cpp#L105)):

```c
_stprintf(cmd, _T("python \"%s/spec/%s.py\" ..."), ...);
int rc = _tsystem(cmd);
if (rc < 0) { ...warn... }
return true;              // never aborts
```

**Both halves are wrong.**

### `python` is the wrong name on many machines

macOS removed `/usr/bin/python` in 12.3, and most Linux distributions ship only `python3` unless `python-is-python3` is installed. The **npm distribution bundles no Python at all**, so a Node user running an analyzer with a python pass has no particular reason to have one.

### The failure was invisible

`system()` returns the *shell's* exit status — 127 for command-not-found on POSIX, 1 or 9009 on Windows — and returns -1 only when the shell itself can't be spawned. So `rc < 0` never fired. Nothing printed, run continued.

For `json2kbb.py` that means **no `.kbb` is built and the analyzer runs against an empty knowledge base** — quietly wrong results, no diagnostic anywhere. Verified: with a bogus interpreter the observed status is **1**, so the old test would not have caught it.

### The fix

- Interpreter probed once and cached: `NLPPP_PYTHON` if set, else `python3` → `python` on Unix, `python` → `python3` → `py -3` on Windows.
- A missing interpreter is reported as the setup problem it is, naming the env var.
- **Any** non-zero exit is reported — to stdout *and* the analyzer's `err.log`.
- Still does **not** abort the analysis. A gap-filler/enricher failing shouldn't kill the run; it just must not be silent.

### Fixture

`tests/python-pass` runs a python pass **before the tokenizer**, and an NLP++ pass reads back the file it writes (via `readfile`, from 3.8.0) — so it asserts the pass genuinely executed rather than trusting an exit code. It then forces `NLPPP_PYTHON` to a nonexistent command and asserts the failure is reported in both places.

| | expected |
|---|---|
| interpreter resolves | `python:PYTHON-RAN-pre` |
| interpreter missing | `python:absent` + `python pass FAILED` on stdout and in `err.log` |

All other fixtures pass and the `parse-en-us` tree is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)