### PR TITLE
chore: bump NLP_ENGINE_VERSION to 3.8.1

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.0"
+#define NLP_ENGINE_VERSION "3.8.1"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Bumps `NLP_ENGINE_VERSION` from `3.8.0` to `3.8.1`, so the constant matches the `v3.8.1` tag.

Patch release for #710: a python pass shelled out to the literal command `python` — absent on macOS 12.3+ and most Linux distributions — and reported failure only when `system()` returned a negative value, which never happens for command-not-found. A failing pass was therefore completely silent; for `json2kbb` that meant no `.kbb` was built and the analyzer ran against an empty knowledge base with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)