### PR TITLE
feat: rank the slowest analyzer passes at end of run (3.8.3)

### DIFF
--- a/include/Api/lite/parse.h
+++ b/include/Api/lite/parse.h
@@ -24,6 +24,10 @@ All rights reserved.
 typedef void TREE;	// 07/07/03 AM.
 typedef void LTREE;	// 07/07/03 AM.
 
+// Capacity of the per-pass timing table.  An analyzer.seq with more passes
+// than this still runs; the passes beyond it just miss the ranked summary.
+#define PASSTIMES_MAX 1024		// 08/04/26 AM.
+
 //#include "global.h"				// 05/19/99 AM.
 //#include "ana.h"
 //#include "lite/dlist.h"			// 07/07/03 AM.
@@ -612,6 +616,17 @@ private:
 	// Support API for stepping through a parse.						// 07/23/01 AM.
 	long currpass_;	// Current pass number.			// RENAMED.	// 08/22/02 AM.
 	Delt<Seqn> *seq_;	// Current pass.									// 07/23/01 AM.
+
+	// Per-pass time accumulation, for the ranked summary that finExecute
+	// prints.  The engine already logged one "[Pass N time: ...]" line per
+	// pass execution, but in pass order and buried in dbg.log, so nobody
+	// could see WHICH pass dominated without post-processing the log.
+	// Indexed by pass number; a pass that runs many times (eg a rec pass)
+	// accumulates.	// 08/04/26 AM.
+	double passsecs_[PASSTIMES_MAX];		// Total seconds, per pass number.
+	long passruns_[PASSTIMES_MAX];		// Times that pass executed.
+	_TCHAR *passnames_[PASSTIMES_MAX];	// Points into the Seqn; stable.
+	long passmax_;								// Highest pass number recorded.
 
 	// Debugging info about input file.									// 08/23/02 AM.
 	long inputpass_;	// If INTERNING, pass number of infile.	// 08/23/02 AM.

--- a/lite/parse.cpp
+++ b/lite/parse.cpp
@@ -87,6 +87,15 @@ intern_ = true;																// 05/26/01 AM.
 currpass_ = 0;			// 07/24/01 AM.
 rulepass_ = 0;			// 02/03/05 AM.
 inputpass_ = 0;		// 08/23/02 AM.
+
+// Per-pass timing table for the ranked summary.	// 08/04/26 AM.
+passmax_ = 0;
+for (long pi = 0; pi < PASSTIMES_MAX; ++pi)
+	{
+	passsecs_[pi]  = 0.0;
+	passruns_[pi]  = 0;
+	passnames_[pi] = 0;
+	}
 seq_ = 0;				// 07/24/01 AM.
 line_	= 0;				// 08/24/02 AM.
 inputline_ = 0;		// 08/24/02 AM.
@@ -573,6 +582,74 @@ void Parse::finExecute(
 if (eana_->getFlogfinal())									// 10/13/99 AM.
 	finalTree();												// 10/11/99 AM.
 
+// RANKED SLOWEST-PASS SUMMARY.	// 08/04/26 AM.
+// The per-pass "[Pass N time: ...]" lines above are emitted in pass order
+// and land in dbg.log, so on a 137-pass analyzer you cannot see which pass
+// actually costs you anything without post-processing the log.  Rank them.
+if (eana_->getFtimepass() && passmax_ > 0)
+	{
+	double gtot = 0.0;
+	long pi;
+	for (pi = 1; pi <= passmax_; ++pi)
+		gtot += passsecs_[pi];
+
+	if (gtot > 0.0)
+		{
+		{
+		std::_t_strstream gerrStr;
+		gerrStr << _T("[Slowest passes (total ") << gtot << _T(" sec in ")
+				  << passmax_ << _T(" passes):]") << std::ends;
+		nlp_->logOut(&gerrStr,false);
+		}
+
+		// Report the top ten by simple selection; passmax_ is small and this
+		// runs once per input, so an in-place sort of the table is not worth
+		// the extra state.
+		bool taken[PASSTIMES_MAX];
+		for (pi = 0; pi < PASSTIMES_MAX; ++pi)
+			taken[pi] = false;
+
+		long shown;
+		for (shown = 0; shown < 10; ++shown)
+			{
+			long best = 0;
+			for (pi = 1; pi <= passmax_; ++pi)
+				{
+				if (taken[pi] || passsecs_[pi] <= 0.0)
+					continue;
+				if (!best || passsecs_[pi] > passsecs_[best])
+					best = pi;
+				}
+			if (!best)
+				break;				// Ran out of passes with measurable time.
+			taken[best] = true;
+
+			std::_t_strstream gerrStr;
+			gerrStr << _T("[  ") << passsecs_[best] << _T(" sec  ")
+					  << (long)((passsecs_[best] * 100.0 / gtot) + 0.5) << _T("%  pass ")
+					  << best;
+			if (passruns_[best] > 1)
+				gerrStr << _T(" x") << passruns_[best];
+			gerrStr << _T("  ")
+					  << (passnames_[best] ? passnames_[best] : _T("?"))
+					  << _T("]") << std::ends;
+			nlp_->logOut(&gerrStr,false);
+			}
+
+		// These numbers include whatever the pass wrote.  Under -DEV that is
+		// a full parse-tree dump per pass, which on a 9K input was measured
+		// at 137 files / 44MB and roughly 3.6x total runtime -- so -DEV
+		// timings say little about how fast the matching itself is.
+		if (eana_->getFlogfiles())
+			{
+			std::_t_strstream gerrStr;
+			gerrStr << _T("[  NOTE: -DEV dumps a parse tree per pass; these times include that I/O.]")
+					  << std::ends;
+			nlp_->logOut(&gerrStr,false);
+			}
+		}
+	}
+
 if (eana_->getFtimesum())									// 10/13/99 AM.
 	{
 	double tot;
@@ -811,6 +888,19 @@ if (flogfiles)																	// 03/08/00 AM.
 if (ftimepass)																	// 10/13/99 AM.
 	{
 	clock_t e_time = clock();												// 12/28/98 AM.
+
+	// Accumulate for the ranked summary in finExecute.	// 08/04/26 AM.
+	// A rec pass runs many times per input, so this sums rather than
+	// overwrites.  pretname points into the Seqn, which outlives the parse.
+	if (num > 0 && num < PASSTIMES_MAX)
+		{
+		passsecs_[num] += (double)(e_time - s_time)/CLOCKS_PER_SEC;
+		++passruns_[num];
+		if (!passnames_[num])
+			passnames_[num] = pretname;
+		if (num > passmax_)
+			passmax_ = num;
+		}
 
 // DEBUGGING memleak // 06/19/05 AM.
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.2"
+#define NLP_ENGINE_VERSION "3.8.3"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## The problem

The engine has timed every pass since 1999 — `finPass` emits `[Pass N time: X sec  name]` whenever `ftimepass` is on. But the lines come out **in pass order** and land in `dbg.log`, so on a 136-pass analyzer you cannot see which pass actually costs you anything without post-processing the log by hand.

Nobody does that. In practice the data was already there and effectively invisible.

## The change

Accumulate the existing per-pass measurements and print a ranked top-ten at end of run, alongside the existing total-time summary:

```
[Slowest passes (total 3.632 sec in 136 passes):]
[  1.11 sec  31%  pass 135  buff_out]
[  0.919 sec  25%  pass 75  pos50]
[  0.757 sec  21%  pass 132  ne_out]
[  0.223 sec  6%  pass 127  pos_out_noscore]
[  0.142 sec  4%  pass 136  displayKB]
...
```

Times accumulate **per pass number**, so a pass that runs repeatedly reports its total with an `xN` run count rather than only its last execution.

**No new flag.** This rides on the `ftimepass_` config that `conf_REG` and `conf_DEV` already enable, so it shows up in normal and `-DEV` runs and stays silent in the quiet configurations (`conf_ZILCH`, `conf_RUG`, `conf_RFA`, `conf_INTERN`).

## The `-DEV` warning

Under `-DEV` the report appends:

```
[  NOTE: -DEV dumps a parse tree per pass; these times include that I/O.]
```

That is not a nicety. Profiling for this PR measured `-DEV` writing **137 `.tree` files totalling 44 MB for a 9 KB input**, costing **~3.6x total runtime** (29.6s vs 8.2s, interleaved, non-overlapping ranges). So `-DEV` per-pass times say very little about how fast the matching itself is. Without `-DEV` the numbers are clean.

This matters beyond cosmetics: the entire v3.7.15/16/17 perf audit was benchmarked with `-DEV`, which is why optimizing the innermost string compare in the match loop produced no measurable win — roughly three quarters of every measurement was tree-dump I/O. The warning exists so the next person doesn't repeat that.

## What the report immediately shows

On `parse-en-us` with a 9 KB input, without `-DEV`: **`buff_out` + `pos50` + `ne_out` are 77% of analysis time**, and two of those three are output-generation passes. That is the kind of thing this report is for, and it was not visible before.

Also worth knowing, from the same profiling: **~5.4s of every run is fixed cost** (analyzer load — parsing ~165 rule files through the self-hosted RFB grammar, plus dict read), against ~2.2s of actual analysis for 9 KB of text. For any multi-document workload the fixed load cost dominates everything in this report.

## Verification

All **13 regression fixtures** pass:

parse-en-us (byte-identical tree), fulldict-hang, fnname-digits, block-comments, block-comments-data, struniquechars, file-regex, json-builtins, regexp-glob, shadowing, signed-str, str-array, python-pass

## Cost

Three fixed-size arrays on `Parse` (`PASSTIMES_MAX` = 1024): ~20 KB per `Parse` object, one per input file. An `analyzer.seq` with more than 1024 passes still runs; the passes beyond the limit simply miss the ranked summary. Selection is a plain top-N scan over `passmax_` entries, run once per input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)