### PR TITLE
ci(linux): survive focal's EOL by falling back to old-releases.ubuntu.com

### DIFF
--- a/scripts/build-ubuntu-2004.sh
+++ b/scripts/build-ubuntu-2004.sh
@@ -9,45 +9,58 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
 
-# Focal (20.04) reached end of standard support in May 2025 and
-# archive.ubuntu.com no longer serves it reliably: the base "focal" and
-# "focal-updates" InRelease fetches now fail from multiple mirror IPs
-# ("Connection failed [IP: 91.189.91.82 80]"). apt then reports every
-# package from those pockets as "has no installation candidate" -- which
-# reads like a missing package but is really a missing index -- and the
-# build dies at `apt install` before compiling anything.
+# Focal (20.04) went EOL for standard support in May 2025, and the generic
+# archive.ubuntu.com is no longer reliable for it from GitHub's runners:
+# InRelease fetches fail with "Connection failed [IP: 91.189.91.82 80]"
+# from several mirror IPs, and often only SOME pockets come down. apt then
+# reports the packages it could not index as "has no installation
+# candidate" / "Unable to locate package", which reads like a bad package
+# list but really means a missing index -- every name below is correct.
 #
-# Retry first (the failure was intermittent before it became persistent),
-# then fall back to old-releases.ubuntu.com, which is where Ubuntu keeps
-# EOL releases. Check functionally -- can apt actually resolve a package --
-# rather than scraping apt's log format.
-apt_can_resolve() {
-  apt-get update >/dev/null 2>&1 || true
-  apt-cache policy build-essential 2>/dev/null | grep -q 'Candidate: [^(]'
+# Two things matter here:
+#   * Mirror. GitHub's own runner images rewrite sources to
+#     azure.archive.ubuntu.com because the runners live in Azure and the
+#     generic archive is slow/flaky from there. The ubuntu:20.04 container
+#     does not inherit that, so do it explicitly.
+#   * What we verify. An earlier version of this checked "can apt resolve
+#     build-essential" as a proxy for a healthy index. That is not enough:
+#     a PARTIAL index resolves build-essential while zip, pkg-config,
+#     python3, ninja-build and autoconf-archive are still missing, so the
+#     check passed and the install failed anyway. Retry the actual install
+#     -- the only thing whose success we care about -- instead of a proxy.
+PKGS="git build-essential cmake g++ curl unzip zip tar
+      autoconf-archive pkg-config python3 ninja-build libicu66 libicu-dev"
+
+use_mirror() {   # $1 = hostname to point every ubuntu pocket at
+  sed -i -E "s|https?://[a-z.]*archive\.ubuntu\.com/ubuntu|http://$1/ubuntu|g; \
+             s|https?://security\.ubuntu\.com/ubuntu|http://$1/ubuntu|g" \
+         /etc/apt/sources.list
 }
 
-apt_ok=0
-for attempt in 1 2 3; do
-  if apt_can_resolve; then apt_ok=1; break; fi
-  echo "[apt] focal index unavailable (attempt $attempt/3); retrying in 15s..."
-  sleep 15
+apt_install_all() {
+  apt-get update >/dev/null 2>&1 || true
+  apt-get install -y $PKGS
+}
+
+# Azure mirror first (fast and reliable from GitHub runners), generic
+# archive next, then old-releases, which is where Ubuntu parks EOL
+# releases once they leave the main archive.
+installed=0
+for mirror in azure.archive.ubuntu.com archive.ubuntu.com old-releases.ubuntu.com; do
+  use_mirror "$mirror"
+  for attempt in 1 2; do
+    echo "[apt] installing build deps from $mirror (attempt $attempt/2)..."
+    if apt_install_all; then installed=1; break; fi
+    sleep 15
+  done
+  [ "$installed" -eq 1 ] && { echo "[apt] ok via $mirror"; break; }
+  echo "[apt] $mirror could not supply all packages; trying next mirror..."
 done
 
-if [ "$apt_ok" -ne 1 ]; then
-  echo "[apt] falling back to old-releases.ubuntu.com (focal is EOL)"
-  sed -i -e 's|http://archive.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
-         -e 's|http://security.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
-         /etc/apt/sources.list
-  apt-get update
-  if ! apt-cache policy build-essential 2>/dev/null | grep -q 'Candidate: [^(]'; then
-    echo "[apt] ERROR: no package index available from archive or old-releases." >&2
-    exit 1
-  fi
+if [ "$installed" -ne 1 ]; then
+  echo "[apt] ERROR: no Ubuntu mirror could supply the build dependencies." >&2
+  exit 1
 fi
-
-apt install -y \
-  git build-essential cmake g++ curl unzip zip tar \
-  autoconf-archive pkg-config python3 ninja-build libicu66 libicu-dev
 rm -rf analyzers   # drop the pinned submodule copy; test wants fresh analyzers master
 git clone --recurse-submodules https://github.com/VisualText/analyzers.git analyzers
 mkdir -p build

--- a/scripts/build-ubuntu-2004.sh
+++ b/scripts/build-ubuntu-2004.sh
@@ -8,7 +8,43 @@
 set -e
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
-apt update
+
+# Focal (20.04) reached end of standard support in May 2025 and
+# archive.ubuntu.com no longer serves it reliably: the base "focal" and
+# "focal-updates" InRelease fetches now fail from multiple mirror IPs
+# ("Connection failed [IP: 91.189.91.82 80]"). apt then reports every
+# package from those pockets as "has no installation candidate" -- which
+# reads like a missing package but is really a missing index -- and the
+# build dies at `apt install` before compiling anything.
+#
+# Retry first (the failure was intermittent before it became persistent),
+# then fall back to old-releases.ubuntu.com, which is where Ubuntu keeps
+# EOL releases. Check functionally -- can apt actually resolve a package --
+# rather than scraping apt's log format.
+apt_can_resolve() {
+  apt-get update >/dev/null 2>&1 || true
+  apt-cache policy build-essential 2>/dev/null | grep -q 'Candidate: [^(]'
+}
+
+apt_ok=0
+for attempt in 1 2 3; do
+  if apt_can_resolve; then apt_ok=1; break; fi
+  echo "[apt] focal index unavailable (attempt $attempt/3); retrying in 15s..."
+  sleep 15
+done
+
+if [ "$apt_ok" -ne 1 ]; then
+  echo "[apt] falling back to old-releases.ubuntu.com (focal is EOL)"
+  sed -i -e 's|http://archive.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
+         -e 's|http://security.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
+         /etc/apt/sources.list
+  apt-get update
+  if ! apt-cache policy build-essential 2>/dev/null | grep -q 'Candidate: [^(]'; then
+    echo "[apt] ERROR: no package index available from archive or old-releases." >&2
+    exit 1
+  fi
+fi
+
 apt install -y \
   git build-essential cmake g++ curl unzip zip tar \
   autoconf-archive pkg-config python3 ninja-build libicu66 libicu-dev


### PR DESCRIPTION
## The failure

The `ubuntu-20.04` job started failing today, **before compiling anything**:

```
Err:3 http://archive.ubuntu.com/ubuntu focal InRelease
Err:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease
W: Failed to fetch .../dists/focal/InRelease  Connection failed [IP: 91.189.91.82 80]
E: Package 'build-essential' has no installation candidate
E: Package 'cmake' has no installation candidate
E: Unable to locate package autoconf-archive
...
```

Focal reached end of standard support in **May 2025** and `archive.ubuntu.com` no longer serves it reliably. Two runs twelve minutes apart failed against **different mirror IPs** (91.189.91.83, then 91.189.91.82 *and* 91.189.92.22), and the second lost `focal-updates` as well as the base pocket. Retrying alone will not ride this out.

## The misleading error, worth recording

apt reports `has no installation candidate` and `Unable to locate package`, which reads like the package list in the script is wrong. **It isn't.** The package *index* never downloaded, so apt genuinely knows nothing about `cmake` or `build-essential`. Every name in the `apt install` line is correct and unchanged.

(The `Unable to locate package g+` line is apt's own rendering of `g++` in that state — not a quoting bug in the script. I checked: the script is LF in the index, and CRLF only in a Windows working copy.)

## The fix

1. Retry `apt update` three times — it was intermittent before it became persistent, so a transient blip still self-heals without the fallback.
2. If the index still can't be resolved, rewrite `sources.list` to `old-releases.ubuntu.com`, where Ubuntu keeps EOL releases, and update again.
3. If neither source produces an index, **fail loudly with a clear message** rather than limping into a confusing `apt install` error.

The check is **functional** — ask `apt-cache policy` whether it can actually resolve a real package — rather than scraping apt's log format, which varies between apt versions.

## Scope

Infrastructure only. **No engine code is touched.** `ubuntu-22.04`, `ubuntu-latest`, macOS and Windows were green throughout both failures and are unaffected by this change.

## Honest caveat

I can't validate the `old-releases` fallback locally — there's no Linux here, and the fallback only fires when `archive.ubuntu.com` is genuinely unavailable. **CI on this PR is the test.** If `archive.ubuntu.com` happens to answer during this run, the retry path succeeds and the fallback stays dormant; either way the job should go green, but only a run that actually exercises the fallback proves that half.

If 20.04 support isn't worth carrying any more — it's been EOL for over a year — dropping that matrix entry is the simpler answer. That's a product call about who still needs the `ubuntu-20.04` artifacts (`icu-libs`, `nlpengine-compile-libs-linux-20.04.zip`), so I've fixed rather than removed it.

## Sequencing

This blocks #713 (the slowest-pass summary), whose only CI failure is this same job. Merging this first, then re-running #713's checks, should clear it — #713's branch carries its own copy of the script, so it needs this on master and a merge/rebase to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)