### PR TITLE
ci: run the bootstrapped vcpkg, not whatever is on PATH

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -99,7 +99,11 @@ jobs:
 
       - name: Install 3rd Party (Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'
-        run: vcpkg install
+        # Same latent mismatch as the Windows job: use the vcpkg the
+        # bootstrap step just produced rather than whatever is on PATH, so a
+        # system vcpkg can never be paired with this repo's submodule root.
+        # Linux has not broken on this yet; this keeps it from doing so.
+        run: ./vcpkg install
         working-directory: vcpkg
 
       - name: Create Build Directory (Non-20.04)

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,15 +19,10 @@ jobs:
     runs-on: windows-latest
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows
-      # windows-latest presets VCPKG_ROOT=C:\vcpkg (its own preinstalled
-      # copy). bootstrap-vcpkg.bat honors that, so running it from our
-      # submodule still downloaded the tool into C:\vcpkg and read C:\vcpkg's
-      # scripts/vcpkg-tool-metadata.txt -- pulling the 2026-07-27 tool, which
-      # then rejected OUR submodule for declaring schema version 1.
-      # Point VCPKG_ROOT at the submodule so bootstrap uses the tool version
-      # the submodule itself pins (VCPKG_TOOL_RELEASE_TAG=2026-04-08) and
-      # lands it where the next step looks. The cmake toolchain file already
-      # points here, so this makes all three steps agree on one root.
+      # Belt and braces: windows-latest presets VCPKG_ROOT=C:\vcpkg for its
+      # own preinstalled copy. Pin it to our submodule so nothing can pair
+      # that root with this repo. (Not the bug fixed below -- the steps were
+      # running C:\vcpkg's SCRIPTS, not merely honoring its root.)
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     steps:
@@ -36,7 +31,17 @@ jobs:
           submodules: true
 
       - name: Vcpkg bootstrap Windows
-        run: bootstrap-vcpkg.bat
+        # PowerShell does NOT resolve executables from the current directory,
+        # so the bare name resolved on PATH to C:\vcpkg\bootstrap-vcpkg.bat --
+        # the runner's own preinstalled copy. working-directory never
+        # mattered: it bootstrapped C:\vcpkg from C:\vcpkg's metadata,
+        # pulling the 2026-07-27 tool, which then rejected THIS repo's
+        # submodule for declaring tool-data schema version 1.
+        # Our submodule pins VCPKG_TOOL_RELEASE_TAG=2026-04-08, which handles
+        # schema 1 fine -- the wrong bootstrap script was simply being run.
+        # Linux and macOS have always used ./bootstrap-vcpkg.sh; Windows was
+        # the only platform missing the relative-path prefix.
+        run: .\bootstrap-vcpkg.bat
         working-directory: vcpkg
 
       - name: Install 3rd Party

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,6 +19,16 @@ jobs:
     runs-on: windows-latest
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      # windows-latest presets VCPKG_ROOT=C:\vcpkg (its own preinstalled
+      # copy). bootstrap-vcpkg.bat honors that, so running it from our
+      # submodule still downloaded the tool into C:\vcpkg and read C:\vcpkg's
+      # scripts/vcpkg-tool-metadata.txt -- pulling the 2026-07-27 tool, which
+      # then rejected OUR submodule for declaring schema version 1.
+      # Point VCPKG_ROOT at the submodule so bootstrap uses the tool version
+      # the submodule itself pins (VCPKG_TOOL_RELEASE_TAG=2026-04-08) and
+      # lands it where the next step looks. The cmake toolchain file already
+      # points here, so this makes all three steps agree on one root.
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,7 +30,16 @@ jobs:
         working-directory: vcpkg
 
       - name: Install 3rd Party
-        run: vcpkg install
+        # Invoke the vcpkg the step above just bootstrapped, NOT whatever
+        # "vcpkg" resolves to on PATH. The windows-latest runner ships a
+        # preinstalled vcpkg at C:\vcpkg which is on PATH and wins, so the
+        # bare command ran the SYSTEM binary against THIS repo's submodule
+        # root. Once that system tool auto-updated to the 2026-07-27
+        # release it started rejecting the pinned submodule outright:
+        #   vcpkg\scripts\vcpkg-tools.json: error: $ (a tool data file):
+        #     document schema version 1 is not supported by this version
+        # ...which fails the job before anything is compiled.
+        run: .\vcpkg.exe install
         working-directory: vcpkg
 
       - name: List $RUNNER_WORKSPACE before build


### PR DESCRIPTION
## The failure

The Windows job started failing at **Install 3rd Party**, before compiling anything:

```
Downloading .../vcpkg-tool/releases/download/2026-07-27/vcpkg.exe -> C:\vcpkg\vcpkg.exe... done.
D:\a\nlp-engine\nlp-engine\vcpkg\scripts\vcpkg-tools.json: error: $ (a tool data file):
    document schema version 1 is not supported by this version of vcpkg
```

**Look at the two paths.** The download target is `C:\vcpkg\vcpkg.exe`; the rejected file is `D:\a\nlp-engine\nlp-engine\vcpkg\scripts\vcpkg-tools.json`. Different vcpkgs.

## Root cause

The workflow bootstraps vcpkg *inside our submodule*, then runs the bare command `vcpkg install`. `windows-latest` ships a **preinstalled vcpkg at `C:\vcpkg`** which is on PATH and therefore wins — so the **system** binary ran against **this repo's** submodule root. It was never the one the previous step just built.

That worked only while the two happened to agree. They stopped agreeing: the system tool auto-updated to the 2026-07-27 release, which dropped support for `schema-version: 1` — the schema declared by our submodule's `scripts/vcpkg-tools.json` (submodule pinned at **2026-05-23**).

## The fix

Use the binary the bootstrap produced.

**The macOS job has always done this** — `run: ./vcpkg install`. So Windows and Linux were the outliers, not the new tool behavior. That's the strongest evidence this is the intended pattern rather than my invention.

Linux gets the same change. It hasn't broken yet, but it carries the identical bare-command mismatch and would break the same way the moment a system vcpkg appears or diverges on those runners.

## What this deliberately does not do

**It does not bump the vcpkg submodule.** Moving vcpkg forward three months can move ICU with it, and ICU is the engine's one heavy dependency — `libicu66` is pinned *by name* in `scripts/build-ubuntu-2004.sh`, and the ICU libs ship as release assets. That upgrade deserves its own PR where the version change is the point and gets tested on its own merits, rather than riding along inside a CI repair.

## Evidence it's not a code change

- My blocked PR (#715) touches **zero** vcpkg files — `ivar.cpp`, `main.cpp`, two workflows, one fixture.
- The same Windows workflow **passed 8 days ago** (v3.8.3, Aug 4) on essentially this tree.
- `ubuntu-20.04` **passed** on the failing run, so the focal mirror fix from #714 is holding.

Infrastructure only; no engine code touched.

## Sequencing

This blocks #715, whose only failing check is this same job. Merge this first, then merge master into #715 to pick up the fixed workflow — that branch carries its own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)