### PR TITLE
perf: compiled-runtime output flushing and match-table transcoding (1.5x)

### DIFF
--- a/include/Api/lite/parse.h
+++ b/include/Api/lite/parse.h
@@ -495,6 +495,7 @@ public:
 	bool deleteostr(std::_t_ostream *);											// 05/23/01 AM.
 	Delt<Iarg> *findostr(std::_t_ostream*);										// 05/23/01 AM.
 	bool deleteostrs();														// 05/24/01 AM.
+	bool flushostrs();													// Flush all open NLP++ output files.
 
 	Delt<Iarg> *newblob(long);												// 02/27/03 AM.
 	bool deleteblobs();														// 02/27/03 AM.

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -16,6 +16,7 @@ All rights reserved.
 #include <float.h>					// 08/17/01 AM.
 //#include <tchar.h>					// 09/26/01 AM.
 #include <locale.h>					// 01/06/03 AM.
+#include <stdlib.h>					// getenv, for the flush policy.
 #include "consh/libconsh.h"		// 02/14/01 AM.
 #include "consh/cg.h"				// 02/14/01 AM.
 #include "lite/global.h"			// 01/24/01 AM.
@@ -8679,6 +8680,28 @@ return sem;	// "no-op"
 * SUBJ:	NLP++ output operator, compiled runtime.
 ********************************************/
 
+
+// NLP-ENGINE-499/505 flushed on every `<<` so that print-debugging survived
+// a crash. Profiling a compiled parse-en-us run showed the cost: the analyzer
+// writes ~6 MB across 19 files, and flushing per write turned that into a
+// WriteFile plus a file-position query per token -- ~40% of total runtime.
+//
+// Durability is now provided by Parse::flushostrs(), called at the end of
+// every pass, so the output of all completed passes is on disk if the process
+// dies. Set NLP_FLUSH_EVERY_WRITE=1 to restore per-write flushing when you
+// need to bisect a crash *within* one pass.
+static void arun_flush(std::_t_ostream *ostr)
+{
+static int every = -1;
+if (every < 0)
+	{
+	const char *e = getenv("NLP_FLUSH_EVERY_WRITE");
+	every = (e && *e && *e != '0') ? 1 : 0;
+	}
+if (every)
+	ostr->flush();
+}
+
 std::_t_ostream *Arun::out(_TCHAR *fname, RFASem *sem, Nlppp *nlppp)
 {
 Ipair *pair;
@@ -8696,17 +8719,14 @@ if (!Var::filevar(fname,nlppp->getParse(),
 	delete sem;												// MEM LEAK.	// 06/12/00 AM.
 	return 0;
 	}
-// NLP-ENGINE-499: flush after each write so user-facing diagnostic output
-// (e.g. `"dbg.txt" << "marker N";` from NLP++ source) is visible in the
-// file as it's produced, not only at clean shutdown. Without flushing,
-// buffered writes are lost if the process crashes mid-pass, making it
-// impossible to bisect a SIGSEGV by sprinkling print statements in the
-// .nlp source. Performance impact is negligible for typical diagnostic
-// volumes; the streams aren't being hammered.
+// NLP-ENGINE-499: user-facing diagnostic output (e.g. `"dbg.txt" << "marker
+// N";` from NLP++ source) must survive a crash, not only a clean shutdown.
+// This used to flush on every write. It no longer does -- see arun_flush()
+// above; durability comes from the end-of-pass Parse::flushostrs().
 if (ostr)																		// 08/04/02 AM.
 	{
 	sem->out(ostr);
-	ostr->flush();
+	arun_flush(ostr);
 	}
 delete sem;				// No one using sem past this point.		// 05/27/00 AM.
 return ostr;
@@ -8730,7 +8750,7 @@ if (str && *str																// 04/30/01 AM.
 	&& ostr)																		// 08/04/02 AM.
 	{
 	*ostr << str;
-	ostr->flush();					// NLP-ENGINE-499
+	arun_flush(ostr);					// NLP-ENGINE-499
 	}
 return ostr;
 }
@@ -8752,7 +8772,7 @@ if (!Var::filevar(fname,nlppp->getParse(),
 if (ostr)								// NLP-ENGINE-499
 	{
 	*ostr << num;
-	ostr->flush();
+	arun_flush(ostr);
 	}
 return ostr;
 }
@@ -8775,7 +8795,7 @@ if (!Var::filevar(fname,nlppp->getParse(),
 if (ostr)								// NLP-ENGINE-499
 	{
 	*ostr << (flag ? 1 : 0);
-	ostr->flush();
+	arun_flush(ostr);
 	}
 return ostr;
 }
@@ -8799,7 +8819,7 @@ if (!Var::filevar(fname,nlppp->getParse(),
 if (ostr)																		// 08/04/02 AM.
 	{
 	*ostr << num;
-	ostr->flush();					// NLP-ENGINE-499
+	arun_flush(ostr);					// NLP-ENGINE-499
 	}
 return ostr;
 }
@@ -8892,7 +8912,7 @@ if (!sem)																		// 08/19/01 AM.
 if (ostr)																		// 08/04/02 AM.
 	{
 	sem->out(ostr);	// PRINT IT.										// 08/19/01 AM.
-	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (var-LHS counterpart to 499).
 	}
 
 delete ostrsem;																// 08/19/01 AM.
@@ -8976,7 +8996,7 @@ if (!str || !*str)															// 08/19/01 AM.
 if (ostr)																		// 08/04/02 AM.
 	{
 	*ostr << str;	// PRINT IT.											// 08/19/01 AM.
-	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (var-LHS counterpart to 499).
 	}
 
 delete ostrsem;																// 08/19/01 AM.
@@ -9053,7 +9073,7 @@ switch(ostrsem->getType())													// 08/07/02 AM.
 if (ostr)																		// 08/04/02 AM.
 	{
 	*ostr << num;	// PRINT IT.											// 08/19/01 AM.
-	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (var-LHS counterpart to 499).
 	}
 
 delete ostrsem;																// 08/19/01 AM.
@@ -9132,7 +9152,7 @@ switch(ostrsem->getType())
 if (ostr)
 	{
 	*ostr << (flag ? 1 : 0);	// PRINT IT.
-	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (var-LHS counterpart to 499).
 	}
 
 delete ostrsem;
@@ -9210,7 +9230,7 @@ switch(ostrsem->getType())													// 08/07/02 AM.
 if (ostr)																		// 08/04/02 AM.
 	{
 	*ostr << num;	// PRINT IT.											// 08/19/01 AM.
-	ostr->flush();			// NLP-ENGINE-505 (var-LHS counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (var-LHS counterpart to 499).
 	}
 
 delete ostrsem;																// 08/19/01 AM.
@@ -9226,7 +9246,7 @@ if (!sem)
 if (ostr)																		// 08/04/02 AM.
 	{
 	sem->out(ostr);	// PRINT IT.
-	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (chained-write counterpart to 499).
 	}
 delete sem;
 return ostr;
@@ -9238,7 +9258,7 @@ if (str && *str																// 04/30/01 AM.
 		  && ostr)																// 08/04/02 AM.
 	{
 	*ostr << str;
-	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (chained-write counterpart to 499).
 	}
 return ostr;
 }
@@ -9248,7 +9268,7 @@ std::_t_ostream *Arun::out(std::_t_ostream *ostr, long long num, Nlppp *nlppp)
 if (ostr)																		// 08/04/02 AM.
 	{
 	*ostr << num;
-	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (chained-write counterpart to 499).
 	}
 return ostr;
 }
@@ -9258,7 +9278,7 @@ std::_t_ostream *Arun::out(std::_t_ostream *ostr, bool flag, Nlppp *nlppp)		// 0
 if (ostr)
 	{
 	*ostr << (flag ? 1 : 0);
-	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (chained-write counterpart to 499).
 	}
 return ostr;
 }
@@ -9268,7 +9288,7 @@ std::_t_ostream *Arun::out(std::_t_ostream *ostr, float num, Nlppp *nlppp)		// 0
 if (ostr)																		// 08/04/02 AM.
 	{
 	*ostr << num;
-	ostr->flush();			// NLP-ENGINE-505 (chained-write counterpart to 499).
+	arun_flush(ostr);			// NLP-ENGINE-505 (chained-write counterpart to 499).
 	}
 return ostr;
 }

--- a/lite/parse.cpp
+++ b/lite/parse.cpp
@@ -883,6 +883,8 @@ sprintf_s(fname, _T("%s%c%s%s%d%s"),
 	bool ftimepass,
 	clock_t &s_time)
 {
+// Make completed passes' output durable without flushing on every write.
+flushostrs();
 if (flogfiles)																	// 03/08/00 AM.
 	resetOut(fout, sout);
 if (ftimepass)																	// 10/13/99 AM.
@@ -1368,6 +1370,38 @@ for (delt = ostrs_->getFirst(); delt; delt = delt->Right())
 		return delt;				// Found it.
 	}
 return 0;
+}
+
+
+/********************************************
+* FN:		FLUSHOSTRS
+* SUBJ:	Flush every open NLP++ output file.
+* NOTE:	Called at the end of each pass (Parse::finPass), so a crash leaves
+*			the output of all completed passes on disk. This replaces the
+*			per-write ostr->flush() that NLP-ENGINE-499/505 added in Arun::out.
+*			That flushed once per `<<`: on an analyzer writing a few MB
+*			(parse-en-us emits ~6 MB across 19 files) it cost a WriteFile plus a
+*			file-position query per token, measured at ~40% of total runtime for
+*			a compiled run. Flushing per pass is O(passes), not O(writes).
+*			Set NLP_FLUSH_EVERY_WRITE=1 to restore the old behaviour when
+*			bisecting a crash *within* a single pass.
+********************************************/
+
+bool Parse::flushostrs()
+{
+if (!ostrs_)
+	return false;
+
+Delt<Iarg> *delt;
+Iarg *arg;
+std::_t_ostream *ostr;
+for (delt = ostrs_->getFirst(); delt; delt = delt->Right())
+	{
+	arg = delt->getData();
+	if (arg && (ostr = arg->getOstream()))
+		ostr->flush();
+	}
+return true;
 }
 
 

--- a/lite/str.cpp
+++ b/lite/str.cpp
@@ -18,6 +18,8 @@ All rights reserved.
 #include "lite/global.h"
 #include "dlist.h"					// 07/07/03 AM.
 #include "lite/iarg.h"	// 05/14/03 AM.
+#include <map>
+#include <vector>
 #include "std.h"			// 07/18/00 AM.
 #include "inline.h"		// 05/19/99 AM.
 #include "chars.h"		// 07/18/00 AM.
@@ -1204,14 +1206,43 @@ icu::Collator *collator = nocase_collator();
 if (!collator)								// Collator unavailable.
 	return false;
 
+// OPT: every caller (Arun.cpp: elt->match.reg / fail.reg / except.reg, and
+// elist.reg) passes one of the static const string tables emitted into the
+// generated analyzer code, so the same array was transcoded to UTF-16 again
+// for every candidate node, for every rule element. Profiling a compiled
+// parse-en-us run put ~18% of total runtime in here, nearly all of it in
+// UnicodeString::fromUTF8 rebuilding tables that never change.
+//
+// Cache the UTF-16 form in a small direct-mapped table keyed on the array
+// address. A std::map here is NOT cheap enough -- the tree lookup showed up
+// as 13% self time on its own -- so the slot is found with a shift+mask and
+// confirmed by comparing both the array pointer and its first element.
+struct Cached
+	{
+	const _TCHAR **arr;
+	const _TCHAR *first;
+	std::vector<icu::UnicodeString> vals;
+	Cached() : arr(0), first(0) {}
+	};
+static const unsigned CACHE_SLOTS = 512;			// power of two
+static Cached cache[CACHE_SLOTS];
+
+Cached &ent = cache[((size_t)arr >> 4) & (CACHE_SLOTS - 1)];
+if (ent.arr != arr || ent.first != *arr)
+	{
+	ent.arr = arr;
+	ent.first = *arr;
+	ent.vals.clear();
+	for (const _TCHAR **p = arr; *p; ++p)
+		ent.vals.push_back(icu::UnicodeString::fromUTF8(icu::StringPiece(*p)));
+	}
+
 icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
 
-while (*arr)
+for (size_t i = 0; i < ent.vals.size(); ++i)
 	{
-	icu::UnicodeString astr = icu::UnicodeString::fromUTF8(icu::StringPiece(*arr));
-	if (collator->compare(astr,ustr) == icu::Collator::EComparisonResult::EQUAL)
+	if (collator->compare(ent.vals[i],ustr) == icu::Collator::EComparisonResult::EQUAL)
 		return true;
-	++arr;
 	}
 return false;
 }

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.4"
+#define NLP_ENGINE_VERSION "3.8.5"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## What

Two changes to the compiled-analyzer runtime, both found by profiling rather than by reading the code.

**1. `Arun::out` flushed the stream on every `<<`.** NLP-ENGINE-499/505 added that so print-debugging survives a crash, with a comment saying the cost was negligible "for typical diagnostic volumes". parse-en-us writes ~6 MB across 19 files per run (a 2.35 MB `out.xml`), one token at a time, so it became a `WriteFile` plus a file-position query per write.

Durability now comes from a new `Parse::flushostrs()` called from `Parse::finPass`, so every completed pass's output is on disk if the process dies — O(passes) instead of O(writes). `NLP_FLUSH_EVERY_WRITE=1` restores the old behaviour for bisecting a crash *within* one pass.

**2. `find_str_nocase` rebuilt an `icu::UnicodeString` for every element of a match list on every call**, even though every caller passes one of the static `const` tables emitted into the generated analyzer code. Now cached in a direct-mapped table keyed on the array address.

## Profile (before)

Compiled `-COMPILED` run of parse-en-us, x86 RelWithDebInfo, 37.5 KB input, ~7k stack samples:

| symbol | self |
|---|---|
| `ntdll!ZwWriteFile` | 25.5% |
| `ntdll!ZwQueryInformationFile` | 13.2% |
| `find_str_nocase` (+ICU under it) | ~18% inclusive |
| `Var::find` + `Ipair::getKey` + `Delt<Ipair>::getData` | ~1% |

`Arun::out` was 34.7% inclusive, `ostream::flush` 32.1%, `fflush` 32.0%.

That last row is worth noting: the string-keyed variable lookup (`Var::find`'s linear list scan with `_tcscmp`) looks like the obvious villain when reading the generated code, but it is about 1% of runtime.

## Results

Interleaved A/B, 8 runs per arm, parse-en-us. The machine had ~35% background load, so min and p25 are the meaningful columns:

| | min | p25 | median |
|---|---|---|---|
| flush every write (old) | 17.19s | 17.84s | 19.59s |
| flush per pass (new) | 11.69s | 11.72s | 13.03s |

**1.47x – 1.52x.**

After the fix, `find_str_nocase` self time went 13.4% → 4.5%. (A first attempt using `std::map` for that cache was a complete wash — the tree lookup cost as much as the transcoding it saved. The direct-mapped version is what paid off.)

## Correctness

All 18 analyzer output files are byte-identical before and after. Only `dbg.log` differs, because it contains the per-pass timings.

## Not in this PR

`run!_chkstk` is ~6% of self time. The generator emits one giant `matchRule<N>` per pass containing a `switch` over every rule, so the frame is sized for the union of all rules and every rule execution probes it. Confirmed the frames exceed a page: building with `/Gs1048576` crashes with an access violation. The fix is emitting one function per rule, which is a change in the analyzer code generator — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)