### PR TITLE
perf(codegen): emit one function per rule instead of one giant switch

### DIFF
--- a/lite/ifile.cpp
+++ b/lite/ifile.cpp
@@ -491,6 +491,20 @@ _TCHAR *algo = parse->getAlgo();											// 05/31/00 AM.
 // Point to the corresponding header file.					// 04/04/09 AM.
 *fcode << _T("#include \"pass") << id << ".h\"" << std::endl;	// 04/04/09 AM.
 
+// Rule bodies are emitted as one function per rule (Irule::genRule) so each
+// stack frame holds only what that rule needs. Every one of them has exactly
+// one call site, so the compiler happily inlines them all back into the
+// dispatcher and rebuilds the single huge frame -- measured on parse-en-us,
+// matchRule75 asked for 89,404 bytes of stack. Mark them noinline.
+// Guarded so unity/jumbo builds can concatenate pass files safely.
+*fcode << _T("#ifndef NLP_NOINLINE") << std::endl;
+*fcode << _T("#if defined(_MSC_VER)") << std::endl;
+*fcode << _T("#define NLP_NOINLINE __declspec(noinline)") << std::endl;
+*fcode << _T("#else") << std::endl;
+*fcode << _T("#define NLP_NOINLINE __attribute__((noinline))") << std::endl;
+*fcode << _T("#endif") << std::endl;
+*fcode << _T("#endif") << std::endl;
+
 *fcode << _T("// CODE GENERATION FOR PASS ") << id << _T(".") << std::endl << std::endl;
 
 _TCHAR codebuf[MAXSTR];

--- a/lite/irule.cpp
+++ b/lite/irule.cpp
@@ -2244,25 +2244,33 @@ bool Irule::genRule(Dlist<Irule> *rules, _TCHAR *rulebuf, Gen *gen)
 {
 std::_t_ofstream *fcode = gen->passc_;	// 04/03/09 AM.
 
-*fcode << _T("bool ") << rulebuf;
-Gen::nl(fcode);																// 04/04/03 AM.
-*fcode << _T("{");
-Gen::nl(fcode);																// 04/04/03 AM.
+// OPT: this used to emit every rule in the pass as a `case` of one big
+// `switch (ruleno)` inside a single matchRule<id>() function. MSVC lays out
+// the union of all the cases' locals in one frame, so the frame grew with the
+// pass: in parse-en-us, matchRule75 asked for 89,404 bytes and matchRule48 for
+// 46,472. Every single rule attempt then paid _chkstk touching ~22 stack pages
+// before doing any matching -- profiling a compiled run put matchRule75 plus
+// _chkstk at ~12% of total runtime.
+//
+// Emit one function per rule instead, so each frame holds only what that rule
+// needs, and leave matchRule<id>() as a thin dispatcher. Safe because the
+// generated rule bodies use no goto/continue, never touch `done` (only the
+// default arm does), and never use pcoll.
 
-*fcode << _T("NODE *pcoll=0;");
-Gen::nl(fcode);																// 04/04/03 AM.
+// Base name for the per-rule functions: rulebuf is a full signature,
+// "matchRule<id>(int ruleno,bool &done,Nlppp *nlppp)".
+_TCHAR base[MAXSTR];
+_tcscpy(base, rulebuf);
+_TCHAR *paren = _tcschr(base, '(');
+if (paren)
+	*paren = 0;
 
-*fcode << _T("switch (ruleno)");
-Gen::nl(fcode);																// 04/04/03 AM.
-
+int ii;
 _TCHAR *saveindent = gen->indent_;
 _TCHAR indent[64];
-_stprintf(indent, _T("%s\t"), saveindent);
-gen->indent_ = indent;
+_stprintf(indent, _T("%s	"), saveindent);
 
-*fcode << indent << _T("{");
-Gen::nl(fcode);																// 04/04/03 AM.
-
+// ONE FUNCTION PER RULE.
 Delt<Irule> *drule;
 Irule *rule;
 int ruleno=0;	// Rule has its count, but this is faster.
@@ -2271,45 +2279,66 @@ for (drule = rules->getFirst(); drule; drule = drule->Right())
 	rule = drule->getData();
 	gen->setRuleid(++ruleno);
 
-	// Gen code for rule.
-	*fcode << indent << _T("case ")
-			 //<< rule->getNum()	// Bug. Not set in recurse rule. // 05/31/00 AM.
-			 << ruleno					// Fix.								// 05/31/00 AM.
-			 << _T(":");
-	Gen::nl(fcode);															// 04/04/03 AM.
+	*fcode << _T("NLP_NOINLINE static bool ") << base << _T("_") << ruleno
+			 << _T("(Nlppp *nlppp)");
+	Gen::nl(fcode);
+	*fcode << _T("{");
+	Gen::nl(fcode);
+	*fcode << _T("NODE *pcoll=0;(void)pcoll;");
+	Gen::nl(fcode);
 
 	// Pretty-printing the rule also.									// 05/19/00 AM.
-	*fcode << indent << _T("\t") << _T("/* ");									// 04/04/03 AM.
-	rule->genRule(_T(" "), *fcode,												// 05/19/00 AM.
-						true);	// TRUNCATE LONG LISTS.					// 06/05/00 AM.
-	*fcode << _T(" */");															// 04/04/03 AM.
-	Gen::eol(fcode);															// 04/04/03 AM.
+	*fcode << _T("/* ");
+	rule->genRule(_T(" "), *fcode,											// 05/19/00 AM.
+					true);	// TRUNCATE LONG LISTS.					// 06/05/00 AM.
+	*fcode << _T(" */");
+	Gen::eol(fcode);
 
 	// Match trigger.
 	// Move left.
 	// Move right.
 	// If succeeded, perform check and post actions.
+	gen->indent_ = indent;
 	rule->gen(gen);
-	*fcode << indent << _T("\t") << _T("break;");
-	Gen::eol(fcode);															// 04/04/03 AM.
+	gen->indent_ = saveindent;
+
+	*fcode << _T("return false;");
+	Gen::nl(fcode);
+	*fcode << _T("}");
+	Gen::nl(fcode);
+	Gen::eol(fcode);
 	}
 
+// DISPATCHER.
+// Dispatch through a table of function pointers rather than a switch whose
+// arms call the per-rule functions directly. Each per-rule function has
+// exactly one call site, so MSVC inlines them straight back into the
+// dispatcher and rebuilds the very frame we are trying to split up (measured:
+// zero per-rule functions survived in run.dll, matchRule75 still asked for
+// 89,404 bytes). Taking their addresses forces them to be emitted as real
+// functions and makes the call indirect.
+*fcode << _T("static bool (* const ") << base << _T("_fns[])(Nlppp *) = {0,");
+for (ii = 1; ii <= ruleno; ++ii)
+	{
+	*fcode << base << _T("_") << ii;
+	if (ii < ruleno)
+		*fcode << _T(",");
+	}
+*fcode << _T("};");
+Gen::eol(fcode);
 
-*fcode << indent << _T("default:");
-Gen::nl(fcode);																// 04/04/03 AM.
-*fcode << gen->indent_ << _T("done = true;");
-Gen::nl(fcode);																// 04/04/03 AM.
-*fcode << gen->indent_ << _T("return false;");
-Gen::nl(fcode);																// 04/04/03 AM.
-*fcode << indent << _T("}");
-Gen::nl(fcode);																// 04/04/03 AM.
-
-//*fcode << "nlppp->node_ = node;" << std::endl;
-*fcode << _T("return false;");
-Gen::nl(fcode);																// 04/04/03 AM.
+*fcode << _T("bool ") << rulebuf;
+Gen::nl(fcode);
+*fcode << _T("{");
+Gen::nl(fcode);
+*fcode << _T("if (ruleno < 1 || ruleno > ") << ruleno
+		 << _T("){done = true;return false;}");
+Gen::nl(fcode);
+*fcode << _T("return ") << base << _T("_fns[ruleno](nlppp);");
+Gen::nl(fcode);
 *fcode << _T("}");
-Gen::nl(fcode);																// 04/04/03 AM.
-Gen::eol(fcode);																// 04/04/03 AM.
+Gen::nl(fcode);
+Gen::eol(fcode);
 gen->indent_ = saveindent;
 return true;
 }

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.7"
+#define NLP_ENGINE_VERSION "3.8.8"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Stacked on #717 — retarget to `master` once that merges.

## The problem

`Irule::genRule` emitted every rule in a pass as a `case` of a single `switch (ruleno)` inside one `matchRule<id>()`. MSVC lays out the union of all the cases' locals in one frame, so the frame grew with the pass. In parse-en-us:

```
matchRule75  89,404 bytes of stack
matchRule48  46,472 bytes
```

Every rule attempt paid `_chkstk` touching ~22 stack pages before doing any matching — 5.9% of self time in a profile of a compiled run.

This is not a case for turning off stack probes. Building with `/Gs1048576` crashes with an access violation, which is exactly what a frame that large means.

## The change

One function per rule, with `matchRule<id>()` reduced to a dispatcher. Safe because generated rule bodies use no `goto`/`continue`, never touch `done` (only the default arm does), and never use `pcoll` — verified across all 139 generated passes of parse-en-us.

Dispatch goes through a **table of function pointers**, not a switch calling each function directly. That detail matters: each per-rule function has exactly one call site, so the compiler inlines them all straight back into the dispatcher and rebuilds the frame. Measured — with a plain switch, zero per-rule functions survived in `run.dll` and `matchRule75` still asked for 89,404 bytes.

The per-rule functions are also marked `noinline`. MSVC doesn't need it once dispatch is indirect (verified), but it keeps the frame-size guarantee from resting on one compiler's inlining heuristics, and analyzers are compiled with gcc and clang too.

## Results

No generated dispatcher needs a stack probe at all. `_chkstk` disappears from the profile; `matchRule75` self time goes 6.4% → 0.6%.

Interleaved A/B, 8 runs per arm, swapping only `run.dll`:

| | min | p25 | median |
|---|---|---|---|
| one big switch | 7.63s | 7.73s | 8.03s |
| one fn per rule | 7.31s | 7.40s | 7.68s |

**1.04x – 1.05x.** Modest, because only the probe overhead goes away — the rule bodies still do the same work, just in their own frames.

An earlier measurement suggested 13%; that was noise from background load. Interleaving the two DLLs on a quiet machine gives the number above. Flagging it because the honest figure is the smaller one.

## Correctness

All 18 analyzer output files byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)