### PR TITLE
perf(build): unity + /MP for analyzer compiles (16x), guard three kbm headers

### DIFF
--- a/include/Api/kbm/con_s.h
+++ b/include/Api/kbm/con_s.h
@@ -1,3 +1,6 @@
+#ifndef KBM_CON_S_H
+#define KBM_CON_S_H
+
 /*******************************************************************************
 Copyright © 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
@@ -92,3 +95,5 @@ typedef struct con
    struct con *next;		/* if kind != PROXY, next hierarchy sibling.		*/
 								/* if kind == PROXY, then next elt of phrase.	*/
    } CON;
+
+#endif // KBM_CON_S_H

--- a/include/Api/kbm/ptr_s.h
+++ b/include/Api/kbm/ptr_s.h
@@ -1,3 +1,6 @@
+#ifndef KBM_PTR_S_H
+#define KBM_PTR_S_H
+
 /*******************************************************************************
 Copyright � 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
@@ -80,3 +83,5 @@ typedef struct ptr
    PVAL v;
    struct ptr *next;
    }PTR;
+
+#endif // KBM_PTR_S_H

--- a/include/Api/kbm/sym_s.h
+++ b/include/Api/kbm/sym_s.h
@@ -1,3 +1,6 @@
+#ifndef KBM_SYM_S_H
+#define KBM_SYM_S_H
+
 /*******************************************************************************
 Copyright © 1998-2009 by Text Analysis International, Inc.
 All rights reserved.
@@ -30,3 +33,5 @@ typedef struct sym
    struct sym *chain;		/* Ptr to next sym in conflict chain.	*/
    struct con *con;			/* Concept representing this word.		*/
    } SYM;
+
+#endif // KBM_SYM_S_H

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.5"
+#define NLP_ENGINE_VERSION "3.8.7"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);

--- a/scripts/compile-analyzer.ps1
+++ b/scripts/compile-analyzer.ps1
@@ -142,6 +142,44 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Build speed. The generated KB is one .cpp per table segment -- parse-en-us
+# emits 520 of them, 57 MB, and each expands to ~4.5 MB of identical engine
+# headers. Compiling them one at a time took ~15 minutes; batching them into
+# unity translation units and letting cl.exe use every core takes ~30 seconds.
+#
+# /MP matters on its own: `cmake --build --parallel N` with the Visual Studio
+# generator becomes msbuild /m:N, which parallelises PROJECTS. There is one
+# project here, so without /MP the whole thing compiles serially no matter
+# what --parallel says.
+#
+# Set -DNLP_UNITY_BUILD=OFF to fall back to one TU per file.
+option(NLP_UNITY_BUILD "Batch generated sources into unity translation units" ON)
+
+cmake_host_system_information(RESULT NLP_NPROC QUERY NUMBER_OF_LOGICAL_CORES)
+if(NOT NLP_NPROC OR NLP_NPROC LESS 1)
+    set(NLP_NPROC 4)
+endif()
+
+# Aim for ~2 batches per core so the pool stays fed, clamped so tiny analyzers
+# still spread across cores and huge ones do not build one enormous TU.
+function(nlp_set_unity target)
+    if(NOT NLP_UNITY_BUILD)
+        return()
+    endif()
+    get_target_property(_srcs `${target} SOURCES)
+    list(LENGTH _srcs _n)
+    math(EXPR _batch "`${_n} / (`${NLP_NPROC} * 2)")
+    if(_batch LESS 8)
+        set(_batch 8)
+    elseif(_batch GREATER 64)
+        set(_batch 64)
+    endif()
+    set_target_properties(`${target} PROPERTIES
+        UNITY_BUILD ON
+        UNITY_BUILD_BATCH_SIZE `${_batch})
+    message(STATUS "`${target}: `${_n} generated sources, unity batch `${_batch}")
+endfunction()
+
 # ICU comes via the vcpkg toolchain (passed on the cmake command line).
 # find_package picks the Debug or Release variant to match the active config,
 # which keeps the on-disk DLL deps in lockstep with the deployed icu*d?78.dll.
@@ -193,7 +231,7 @@ target_compile_definitions(nlp_kb PRIVATE
     # redefines INFINITY, triggering C4005 against ucrt's corecrt_math.h.
     MSVC_VERSION=`${MSVC_VERSION}
 )
-target_compile_options(nlp_kb PRIVATE /FI"StdAfx.h" /Zc:wchar_t)
+target_compile_options(nlp_kb PRIVATE /FI"StdAfx.h" /Zc:wchar_t /MP)
 
 target_link_directories(nlp_kb PRIVATE
     "$EngineLibDirCmake"
@@ -204,6 +242,8 @@ target_link_libraries(nlp_kb PRIVATE
     prim kbm consh words lite
     ICU::i18n ICU::uc ICU::data ICU::io
 )
+
+nlp_set_unity(nlp_kb)
 
 # --- Compiled analyzer (run.dll / rund.dll) -----------------------------
 # Engine looks for <appdir>/bin/rund.dll (Debug) or run.dll (Release) at
@@ -235,12 +275,14 @@ if(RUN_CPP)
         _WINDOWS
         MSVC_VERSION=`${MSVC_VERSION}
     )
-    target_compile_options(nlp_run PRIVATE /FI"StdAfx.h" /Zc:wchar_t)
+    target_compile_options(nlp_run PRIVATE /FI"StdAfx.h" /Zc:wchar_t /MP)
     target_link_directories(nlp_run PRIVATE "$EngineLibDirCmake")
     target_link_libraries(nlp_run PRIVATE
         prim kbm consh words lite
         ICU::i18n ICU::uc ICU::data ICU::io
     )
+
+    nlp_set_unity(nlp_run)
 endif()
 "@
 


### PR DESCRIPTION
Compiling a generated analyzer is dominated by re-parsing the same headers. parse-en-us emits **520 `kb/*.cpp` (57 MB)** plus 139 `run/*.cpp`, and an 80 KB generated source expands to **4.5 MB** of engine headers — roughly 45% of each TU's compile time is that header block, paid 520 times.

## Two fixes

**1. `UNITY_BUILD`** batches the generated sources so the header block is parsed once per batch instead of once per file.

```
0.71 s/file  ->  0.039 s/file   (batch 65)
```

**2. `/MP`.** This one is a plain bug. `cmake --build --parallel N` with the Visual Studio generator becomes `msbuild /m:N`, which parallelises **projects** — there is one project, so without `/MP` the sources compile serially regardless of what `--parallel` says. Measured on 20 files with `--parallel 4` on a 22-core box:

```
NO /MP    15.08s   (0.754 s/file -- the serial rate)
WITH /MP   4.29s   (0.214 s/file)
```

## Results

Clean 100-file CMake build, current config vs proposed: **61.79s → 3.87s (16x)**, with identical exported symbol sets (115 in both, diffed).

A full parse-en-us `kb` + `run` build (528 files, 57 MB) now takes **~30s** where it used to take 10–15 minutes — the figure the `compile-analyzer.yml` comment refers to when it says "long builds (10+ min for large analyzers like parse-en-us) look hung".

Batch size is derived from the core count (~2 batches per core, clamped to `[8,64]`) so small analyzers still spread across cores and large ones don't build one enormous TU. `-DNLP_UNITY_BUILD=OFF` falls back to one TU per file.

## Why the header guards are in here

`UNITY_BUILD` does not compile at all without them. [kbm/sym_s.h](include/Api/kbm/sym_s.h), [kbm/con_s.h](include/Api/kbm/con_s.h) and [kbm/ptr_s.h](include/Api/kbm/ptr_s.h) had no include guards, so a second inclusion inside one TU fails with `C2011: 'sym': 'struct' type redefinition`.

These headers ship inside `nlpengine-compile-libs`, so **the cloud compile service needs a release carrying this commit before it can turn unity on at its end.** Companion PRs for `nlp-compile-service` and `vscode-nlp` follow — all three generate the same CMakeLists and have to move together.

## Version

Assumes #718 (3.8.6) lands first. If it doesn't, this should be 3.8.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)