### PR TITLE
perf: stop flushing per token while writing the final parse tree (1.10x)

### DIFF
--- a/lite/iarg.cpp
+++ b/lite/iarg.cpp
@@ -891,13 +891,13 @@ for (darg = darg->Right(); darg; darg = darg->Right())
 		{
 		if (trunc)																// 06/05/00 AM.
 			{
-			ofile << _T("...") << std::flush;
+			ofile << _T("...");
 			return;
 			}
 		ofile << std::endl;
 		count = 0;
 		}
-	ofile << sep << std::flush;
+	ofile << sep;
 	genArg(darg->getData(), ofile);
 	}
 }
@@ -930,42 +930,38 @@ _TCHAR cbuf[MAXLINE];	// For converting to C string. // FIX.	// 02/19/08 AM.
 switch (arg->getType())
 	{
 	case IASTR:
-//		ofile << arg->getStr() << std::flush;		// 07/11/99 AM.
+//		ofile << arg->getStr();		// 07/11/99 AM.
 		// This may not be sufficient....
 		cbuf[0] = '\0';																// 05/10/07 AM.
 		clean_str(arg->getStr(), /*UP*/ cbuf);								// 05/10/07 AM.
 		ofile << _T("\"");								// 02/17/00 AM.
 		Iarg::genName(cbuf, ofile);
-		ofile << _T("\"") << std::flush;					// 02/17/00 AM.
+		ofile << _T("\"");					// 02/17/00 AM.
 		break;
 	case IANUM:
 		if (cast)																// 10/01/01 AM.
 			ofile <<_T("((long long)")												// 10/01/01 AM.
 			<< arg->getNum()
-			<< _T(")")																// 09/09/01 AM.
-			<< std::flush;
+			<< _T(")");																// 09/09/01 AM.
 		else																		// 10/01/01 AM.
 		ofile
-			<< arg->getNum()
-			<< std::flush;
+			<< arg->getNum();
 		break;
 	case IAFLOAT:																// 08/17/01 AM.
 		if (cast)																// 10/01/01 AM.
 			ofile <<_T("((float)")												// 10/01/01 AM.
 				<< arg->getFloat()											// 08/17/01 AM.
-				<< _T(")")															// 09/09/01 AM.
-				<< std::flush;
+				<< _T(")");															// 09/09/01 AM.
 		else																		// 10/01/01 AM.
 		ofile
-				<< arg->getFloat()											// 08/17/01 AM.
-				<< std::flush;
+				<< arg->getFloat();											// 08/17/01 AM.
 		break;																	// 08/17/01 AM.
 	case IAOSTREAM:
-		ofile << _T("<ostream>") << std::flush;
+		ofile << _T("<ostream>");
 		break;
 	case IASEM:
 	case IAREF:																	// 05/26/02 AM.
-//		ofile << "<sem>" << std::flush;											// 05/21/01 AM.
+//		ofile << "<sem>";											// 05/21/01 AM.
 		if (!(sem = arg->getSem()))										// 05/21/01 AM.
 			return;																// 05/21/01 AM.
 		switch (sem->getType())												// 05/21/01 AM.
@@ -977,30 +973,27 @@ switch (arg->getType())
 				clean_str(sem->getName(), /*UP*/ cbuf);				// 05/10/07 AM.
 				ofile << _T("\"");													// 05/21/01 AM.
 				Iarg::genName(cbuf, ofile);								// 05/21/01 AM.
-				ofile << _T("\"") << std::flush;										// 05/21/01 AM.
+				ofile << _T("\"");										// 05/21/01 AM.
 				break;															// 05/21/01 AM.
 			case RSLONG:														// 05/21/01 AM.
 				if (cast)														// 10/01/01 AM.
 					ofile <<_T("((long long)")										// 10/01/01 AM.
 						<< sem->getLong()										// 05/21/01 AM.
-						<< _T(")")													// 09/09/01 AM.
-						<< std::flush;
+						<< _T(")");													// 09/09/01 AM.
 				else																// 10/01/01 AM.
 				ofile
-						<< sem->getLong()										// 05/21/01 AM.
-						<< std::flush;
+						<< sem->getLong();										// 05/21/01 AM.
 				break;															// 05/21/01 AM.
 			case RSFLOAT:														// 09/09/01 AM.
 				if (cast)														// 10/01/01 AM.
 					ofile <<_T("((float)")										// 10/01/01 AM.
 						<< sem->getFloat()									// 09/09/01 AM.
-						<< _T(")") << std::flush;										// 09/09/01 AM.
+						<< _T(")");										// 09/09/01 AM.
 				else																// 10/01/01 AM.
 				ofile 
-						<< sem->getFloat()									// 09/09/01 AM.
-						<< std::flush;												// 09/09/01 AM.
+						<< sem->getFloat();									// 09/09/01 AM.
 			case RSOSTREAM:													// 05/21/01 AM.
-				ofile << _T("<ostream>") << std::flush;							// 05/21/01 AM.
+				ofile << _T("<ostream>");							// 05/21/01 AM.
 				break;															// 05/21/01 AM.
 			case RSNODE:														// 05/21/01 AM.
 				if (!(node = sem->getNode()))								// 05/21/01 AM.
@@ -1009,8 +1002,7 @@ switch (arg->getType())
 					return;														// 05/21/01 AM.
 				ofile << _T("pnode:\"")											// 05/21/01 AM.
 						<< str(pn->getName())								// 05/21/01 AM.
-						<< _T("\"")													// 05/21/01 AM.
-						<< std::flush;												// 05/21/01 AM.
+						<< _T("\"");													// 05/21/01 AM.
 				break;															// 05/21/01 AM.
 			case RS_KBCONCEPT:												// 05/21/01 AM.
 				// TODO: NEED CG OBJECT TO GET KB CONCEPTS.			// 05/21/01 AM.
@@ -1021,16 +1013,14 @@ switch (arg->getType())
 				cg->conceptName(conc, buf);
 				ofile << _T("concept:\"")										// 05/21/01 AM.
 						<< buf
-						<< _T("\"")													// 05/21/01 AM.
-						<< std::flush;												// 05/21/01 AM.
+						<< _T("\"");													// 05/21/01 AM.
 				break;															// 05/21/01 AM.
 			case RS_KBPHRASE:													// 05/21/01 AM.
 			case RS_KBATTR:													// 05/21/01 AM.
 			case RS_KBVAL:														// 05/21/01 AM.
 				ofile << _T("kbobject:\"")										// 05/21/01 AM.
 						<< _T("<name>")										// 05/21/01 AM.
-						<< _T("\"")													// 05/21/01 AM.
-						<< std::flush;												// 05/21/01 AM.
+						<< _T("\"");													// 05/21/01 AM.
 				break;															// 05/21/01 AM.
 			case RSARGS:														// 08/08/02 AM.
 				break;
@@ -1078,14 +1068,14 @@ if (!name || !*name)
 	return;
 if (*(name+1))			// Length greater than one.
 	{
-	ofile << name << std::flush;
+	ofile << name;
 	return;
 	}
 
 // Handle special single char names.
   if (alphabetic(*name))		// 09/22/99 AM.
 	{
-	ofile << name << std::flush;
+	ofile << name;
 	return;
 	}
 else if (_istpunct((_TUCHAR)*name))
@@ -1108,7 +1098,7 @@ switch(*name)
 	case ' ':  ofile << _T("\\ ");		break;
 	default:	  ofile << name;		break;
 	}
-ofile << std::flush;
+ofile;
 }
 
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.8"
+#define NLP_ENGINE_VERSION "3.8.9"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## What I was chasing

After 3.8.7, a profile of a compiled parse-en-us run still had **~13% of self time in `ntdll!ZwWriteFile`**. My first guess was the write path itself — `lite/var.cpp` opens every NLP++ output file with `std::ios::app`, which on the MSVC CRT repositions to end-of-file before every write.

**That guess was wrong**, and worth recording. A standalone benchmark writing the same 6.1 MB through `std::ofstream` in 220k small `<<` calls:

```
ios::app, default buffer  (engine today)     0.034 s    170.5 MB/s
ios::app, 64 KB buffer                       0.033 s    179.4 MB/s
in|out|ate, default buffer                   0.031 s    192.2 MB/s
in|out|ate, 64 KB buffer                     0.029 s    204.5 MB/s
```

Append mode costs 13%, buffer size 5%, and the whole 6 MB costs 34 ms. So neither append mode nor buffering explains ~1.3s — buffered stream writes were never the problem.

## What it actually is

Going back to the stacks:

```
Parse::finExecute -> Parse::finalTree -> Tree<Pn>::Traverse
  -> operator<< -> Iarg::genArg -> std::flush      (11.5% inclusive)
```

`Parse::finalTree` writes a 3 MB `final.tree`, and [Iarg::genArg / genArgs](lite/iarg.cpp) flushed after nearly every fragment they emitted — **22 `std::flush` calls** on that path, so each node's attribute list costs a handful of `WriteFile` syscalls. It's the same defect as the `Arun::out` per-write flush fixed in 3.8.5, just in a different writer.

## Result

Removed. The stream still flushes when it closes, so the file on disk is unchanged.

Interleaved A/B, 8 runs per arm, swapping only `nlp.exe`:

| | min | p25 | median |
|---|---|---|---|
| flush per token | 7.69s | 7.73s | 8.12s |
| buffered | 7.00s | 7.00s | 7.16s |

**1.10x.**

## Correctness

All 18 analyzer output files byte-identical, `final.tree` included (3,085,335 bytes before and after).

`Iarg::genArg` is also used when writing generated `.nlp` rule files. That's a bulk writer too and it flushes on close, so the content is unaffected there as well — but flagging it since it's a second caller.

## Version

Assumes #718 (3.8.8) lands first. If it doesn't, this should be 3.8.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)