### PR TITLE
ci: build on merges to master so the vcpkg cache is actually shared

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -6,6 +6,16 @@ on:
     types: [opened, synchronize, reopened]
   # Build the tagged commit so the release binary carries the right version.
   push:
+    # Also build on merges to master. Without a run on the default branch,
+    # the vcpkg binary cache added alongside this is useless across PRs:
+    # GitHub Actions lets a run read caches from its own ref and from the
+    # DEFAULT branch only, and nothing ever ran on master -- so every PR
+    # missed, rebuilt ICU (~10 min on Windows, ~4 min on Linux), and saved a
+    # private copy no other PR could see. A master run seeds the shared entry
+    # that PR runs then hit. It also means something finally verifies the
+    # merge result, which nothing did before.
+    branches:
+      - master
     tags:
       - '*'
 
@@ -105,11 +115,13 @@ jobs:
       # each package's ABI hash itself, so a partial restore-keys hit is safe:
       # anything that does not match is simply rebuilt.
       - name: Resolve vcpkg commit for cache key
+        if: matrix.id != 'docker-ubuntu-20.04'
         id: vcpkgkey
         shell: bash
         run: echo "sha=$(git -C vcpkg rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Cache vcpkg binary packages
+        if: matrix.id != 'docker-ubuntu-20.04'
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/vcpkg-bincache
@@ -120,6 +132,7 @@ jobs:
 
       # vcpkg errors out if the binary-cache directory does not exist yet.
       - name: Create vcpkg binary cache dir
+        if: matrix.id != 'docker-ubuntu-20.04'
         shell: bash
         run: mkdir -p "${{ github.workspace }}/vcpkg-bincache"
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,6 +6,16 @@ on:
     types: [opened, synchronize, reopened]
   # Build the tagged commit so the release binary carries the right version.
   push:
+    # Also build on merges to master. Without a run on the default branch,
+    # the vcpkg binary cache added alongside this is useless across PRs:
+    # GitHub Actions lets a run read caches from its own ref and from the
+    # DEFAULT branch only, and nothing ever ran on master -- so every PR
+    # missed, rebuilt ICU (~10 min on Windows, ~4 min on Linux), and saved a
+    # private copy no other PR could see. A master run seeds the shared entry
+    # that PR runs then hit. It also means something finally verifies the
+    # merge result, which nothing did before.
+    branches:
+      - master
     tags:
       - '*'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -10,6 +10,16 @@ on:
   # version. (A `tags:` filter under `pull_request` is ignored by GitHub --
   # it must live under `push:`.)
   push:
+    # Also build on merges to master. Without a run on the default branch,
+    # the vcpkg binary cache added alongside this is useless across PRs:
+    # GitHub Actions lets a run read caches from its own ref and from the
+    # DEFAULT branch only, and nothing ever ran on master -- so every PR
+    # missed, rebuilt ICU (~10 min on Windows, ~4 min on Linux), and saved a
+    # private copy no other PR could see. A master run seeds the shared entry
+    # that PR runs then hit. It also means something finally verifies the
+    # merge result, which nothing did before.
+    branches:
+      - master
     tags:
       - '*'
 


### PR DESCRIPTION
The binary caching I added in #721 was only half working, and I'd rather say so than leave it looking done.

## What was wrong

GitHub Actions lets a run read caches from its own ref **and from the default branch** — nothing else. These workflows trigger only on `pull_request` and `push: tags`, so **nothing ever ran on master**. No shared entry was ever seeded, so every PR missed, rebuilt ICU from source, and saved a private copy no other PR could read.

Verified against the API after v3.8.9 — all ten entries under PR refs, none on `refs/heads/master`:

```
refs/pull/720/merge :: vcpkg-Windows-X64-...       73.0 MB
refs/pull/721/merge :: vcpkg-Windows-X64-...       73.0 MB
refs/pull/720/merge :: vcpkg-macOS-ARM64-...       82.3 MB
...
```

So #721 paid the cost of caching while delivering the benefit only within a single PR (second and later pushes). The `/MP` half of that PR works fine and is unaffected — the Windows compile step went 3m40s → 1m41s and stays there.

## The fix

Build on push to master. That seeds the entry PR runs then hit.

The trade, stated plainly: **one extra build per merge**, against removing a ~10-minute ICU rebuild (Windows; ~4 min on Linux) from every job on every PR run. It also means something finally verifies the merge result, which nothing did before.

## Also

Skips the cache steps on the `ubuntu-20.04` matrix entry. That one builds inside Docker and skips the non-Docker vcpkg step, so it was caching an empty directory — the 200-byte entry in the listing above.

## Expectations

The first master run after this merges is still a miss. The saving starts on the PR after that, so judge it there rather than on the merge itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)