### PR TITLE
perf: ASCII fast path for find_str_nocase, verified against the collator

### DIFF
--- a/lite/str.cpp
+++ b/lite/str.cpp
@@ -1165,6 +1165,44 @@ return false;
 
 
 /********************************************
+* FN:		STR_PRINTABLE_ASCII / ASCII_EQ_NOCASE
+* SUBJ:	Fast-path helpers for find_str_nocase.
+* NOTE:	"Printable" means 0x20-0x7E inclusive. See find_str_nocase for why
+*			control characters and bytes >= 0x80 must not take the fast path.
+********************************************/
+
+static bool str_printable_ascii(const _TCHAR *s)
+{
+if (!s)
+	return false;
+for (const unsigned char *p = (const unsigned char *)s; *p; ++p)
+	{
+	if (*p < 0x20 || *p > 0x7E)
+		return false;
+	}
+return true;
+}
+
+static bool ascii_eq_nocase(const _TCHAR *a, const _TCHAR *b)
+{
+const unsigned char *p = (const unsigned char *)a;
+const unsigned char *q = (const unsigned char *)b;
+for (; *p && *q; ++p, ++q)
+	{
+	unsigned char c1 = *p, c2 = *q;
+	if (c1 != c2)
+		{
+		if (c1 >= 'A' && c1 <= 'Z') c1 += 32;
+		if (c2 >= 'A' && c2 <= 'Z') c2 += 32;
+		if (c1 != c2)
+			return false;
+		}
+	}
+return *p == *q;		// both ended together
+}
+
+
+/********************************************
 * FN:		FIND_STR_NOCASE
 * CR:		06/07/00 AM.
 * SUBJ:	Find a string in an array of strings.
@@ -1222,6 +1260,8 @@ struct Cached
 	const _TCHAR **arr;
 	const _TCHAR *first;
 	std::vector<icu::UnicodeString> vals;
+	std::vector<const _TCHAR *> raw;		// original UTF-8, for the fast path
+	std::vector<bool> plain;				// entry is printable ASCII only
 	Cached() : arr(0), first(0) {}
 	};
 static const unsigned CACHE_SLOTS = 512;			// power of two
@@ -1233,14 +1273,49 @@ if (ent.arr != arr || ent.first != *arr)
 	ent.arr = arr;
 	ent.first = *arr;
 	ent.vals.clear();
+	ent.raw.clear();
+	ent.plain.clear();
 	for (const _TCHAR **p = arr; *p; ++p)
+		{
 		ent.vals.push_back(icu::UnicodeString::fromUTF8(icu::StringPiece(*p)));
+		ent.raw.push_back(*p);
+		ent.plain.push_back(str_printable_ascii(*p));
+		}
 	}
 
-icu::UnicodeString ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
+// OPT: when both sides are printable ASCII, PRIMARY-strength equality is
+// exactly byte-wise case-insensitive equality, so skip ICU entirely. This is
+// verified, not assumed: over all 9,025 pairs of printable ASCII characters
+// (0x20-0x7E) and a corpus of word/punctuation/spacing variants, the collator
+// and a byte-wise compare agreed on every single pair.
+//
+// Control characters are deliberately NOT included. They are primary-
+// IGNORABLE, so the collator considers "a" equal to "a"; 78 of 124
+// control-character cases disagreed with a byte-wise compare. Bytes >= 0x80
+// need real collation too, since PRIMARY strength folds accents ("cafe"
+// matches an accented "cafe"). Either one sends that comparison to ICU.
+//
+// The UTF-16 form of the needle is built lazily, so a lookup whose candidates
+// are all plain ASCII -- the overwhelmingly common case -- does no
+// transcoding at all. Profiling put UnicodeString::fromUTF8 at ~10% of a
+// compiled run before this.
+bool str_plain = str_printable_ascii(str);
+icu::UnicodeString ustr;
+bool ustr_built = false;
 
 for (size_t i = 0; i < ent.vals.size(); ++i)
 	{
+	if (str_plain && ent.plain[i])
+		{
+		if (ascii_eq_nocase(str, ent.raw[i]))
+			return true;
+		continue;
+		}
+	if (!ustr_built)
+		{
+		ustr = icu::UnicodeString::fromUTF8(icu::StringPiece(str));
+		ustr_built = true;
+		}
 	if (collator->compare(ent.vals[i],ustr) == icu::Collator::EComparisonResult::EQUAL)
 		return true;
 	}

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.9"
+#define NLP_ENGINE_VERSION "3.8.10"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Where the time is now

With the I/O and stack-frame work done in 3.8.7/3.8.9, a fresh profile of released 3.8.9 shows the compiled runtime is dominated by case-insensitive string matching:

```
run!find_str_nocase                    32.3% inclusive
  run!Arun::match_list                 28.6%
  icu::Collator::compare               13.2%
  icu::UnicodeString::fromUTF8         10.3%
  icu::RuleBasedCollator::doCompare     9.6%
```

For comparison, `ntdll!ZwWriteFile` — 25.5% back in 3.8.4 — is now 2.2%, and `_chkstk` is gone. A third of the run is matching a node's name against a rule element's match/fail/except list through an ICU collator at PRIMARY strength.

## The change

When both sides are printable ASCII, PRIMARY-strength equality is exactly byte-wise case-insensitive equality, so ICU can be skipped.

**That claim is verified, not assumed.** A test program built against the same ICU compared the collator against a byte-wise compare:

| corpus | pairs | mismatches |
|---|---|---|
| all printable-ASCII character pairs (0x20–0x7E) | 9,025 | **0** |
| word / punctuation / spacing variants | 1,521 | **0** |
| control characters (0x01–0x1F) | 124 | **78** |

That last row is why the guard is "printable ASCII" and not "ASCII". Control characters are primary-**ignorable** — the collator considers `"a\x01"` equal to `"a"`. Bytes ≥ 0x80 are excluded too, since PRIMARY strength also folds accents (so `"cafe"` matches an accented `"café"`, which may well be deliberate in an NLP engine). Either case sends that one comparison to ICU, so no matching behaviour changes.

The needle's UTF-16 form is also built lazily now, so a lookup whose candidates are all plain ASCII — overwhelmingly the common case — does no transcoding at all.

## Results

Interleaved A/B, 8 runs per arm, swapping both `nlp.exe` and `run.dll`:

| | min | p25 | median |
|---|---|---|---|
| ICU collator (3.8.9) | 7.78s | 8.10s | 8.75s |
| ASCII fast path | 7.02s | 7.49s | 8.09s |

**1.08x – 1.11x.** Smaller than the 32% inclusive figure might suggest, because much of that is `match_list`'s own work rather than ICU. The mechanism did engage: `RuleBasedCollator::doCompare`, `::compare` and `CollationFastLatin::compareUTF16` all drop out of the profile entirely, and `u_strFromUTF8WithSub` halves.

## Correctness

All 18 analyzer output files byte-identical. That's the strongest check available here — this function decides what the matcher matches, so any semantic drift would show up as different parse output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)