### PR TITLE
feat: "//" line comments in the analyzer sequence file (3.8.12)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -253,6 +253,8 @@ jobs:
           # fixture puts comments in all four -- .seq (where a leading "/"
           # already means "inactive pass"), .kb, .dict and .kbb -- and probes
           # the loaded KB to prove the entries around them survived intact.
+          # The .seq also takes "//" line comments, which collide with the same
+          # leading "/", so the fixture covers those too.
           FIX=.github/workflows/tests/block-comments-data
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
           ./bin/nlp -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
@@ -276,7 +278,7 @@ jobs:
           # .dict string values must keep their delimiters byte-for-byte.
           grep -qF '("note" "a /* b */ c")' "$TREE" || { echo "FAIL(data block comments): dict string lost its /* */"; exit 1; }
           grep -qF '("note" "lone * and / here")' "$TREE" || { echo "FAIL(data block comments): dict string lost its * or /"; exit 1; }
-          echo "[block comments] /* */ is skipped in .seq, .kb, .dict and .kbb"
+          echo "[block comments] /* */ and .seq // are skipped in .seq, .kb, .dict and .kbb"
 
       - name: Run-mode globals ($dev / $silent, Non-20.04)
         if: matrix.id != 'docker-ubuntu-20.04'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -191,6 +191,8 @@ jobs:
           # fixture puts comments in all four -- .seq (where a leading "/"
           # already means "inactive pass"), .kb, .dict and .kbb -- and probes
           # the loaded KB to prove the entries around them survived intact.
+          # The .seq also takes "//" line comments, which collide with the same
+          # leading "/", so the fixture covers those too.
           FIX=.github/workflows/tests/block-comments-data
           rm -rf "$FIX/logs" "$FIX/input/text.txt_log"
           ./bin/Release/nlp.exe -ANA "$FIX" -WORK ./ "$FIX/input/text.txt"
@@ -214,7 +216,7 @@ jobs:
           # .dict string values must keep their delimiters byte-for-byte.
           grep -qF '("note" "a /* b */ c")' "$TREE" || { echo "FAIL(data block comments): dict string lost its /* */"; exit 1; }
           grep -qF '("note" "lone * and / here")' "$TREE" || { echo "FAIL(data block comments): dict string lost its * or /"; exit 1; }
-          echo "[block comments] /* */ is skipped in .seq, .kb, .dict and .kbb"
+          echo "[block comments] /* */ and .seq // are skipped in .seq, .kb, .dict and .kbb"
 
       - name: Run-mode globals ($dev / $silent)
         shell: bash

--- a/.github/workflows/tests/block-comments-data/spec/analyzer.seq
+++ b/.github/workflows/tests/block-comments-data/spec/analyzer.seq
@@ -4,3 +4,8 @@
 dicttokz	nil	# tokenize against the dictionary
 /* one-liner */
 nlp	probe	/* trailing */	# dump what the KB actually loaded
+// "//" is a line comment here too, and a "/*" inside one stays text.
+   // Indented, and the engine must not read the leading "/" as an
+   // inactive pass named "/...".
+/nlp	probe	// a single leading slash still means INACTIVE -- probe must
+		// not run twice.

--- a/cs/include/consh/blockcom.h
+++ b/cs/include/consh/blockcom.h
@@ -50,12 +50,16 @@ All rights reserved.
 //						';' for .kb command files -- or 0 for none. Text from it to
 //						end of line is left exactly as-is, since the caller's own
 //						lexer already handles it.
+//	cppLineComment	True if the file also takes "//" to end of line -- the .seq
+//						file does. Treated exactly like lineComment: left as-is for
+//						the caller's lexer, and a "/*" inside one stays text.
 //
 // Returns true if anything was blanked.
 LIBCONSH_API bool strip_block_comments(
 	_TCHAR *buf,
 	bool &inBlock,
-	_TCHAR lineComment
+	_TCHAR lineComment,
+	bool cppLineComment = false
 	);
 
 #endif	// BLOCKCOM_H_

--- a/cs/libconsh/blockcom.cpp
+++ b/cs/libconsh/blockcom.cpp
@@ -29,7 +29,8 @@ All rights reserved.
 LIBCONSH_API bool strip_block_comments(
 	_TCHAR *buf,
 	bool &inBlock,
-	_TCHAR lineComment
+	_TCHAR lineComment,
+	bool cppLineComment
 	)
 {
 if (!buf)
@@ -83,6 +84,13 @@ while (*p)
 		{
 		// Leave the line comment alone -- the caller's lexer owns it. Skipping
 		// past it is what keeps a "/*" written inside one from opening a block.
+		while (*p && *p != '\n')
+			++p;
+		}
+	else if (cppLineComment && p[0] == '/' && p[1] == '/')
+		{
+		// Same deal as lineComment, for the files that take "//" as well.
+		// Checked before "/*" so that "//*" is a line comment, not a block.
 		while (*p && *p != '\n')
 			++p;
 		}

--- a/lite/ana.cpp
+++ b/lite/ana.cpp
@@ -266,8 +266,9 @@ if (len <= 0)
 // leading '/' on a sequence line already means "inactive pass", so parseSeq
 // would read "/*" as an inactive pass named "*". Blanking the comment first
 // leaves an all-white line, which parseSeq already ignores.
+// "//" is a line comment here too, so a "/*" written inside one is text.
 bool inBlock = false;
-strip_block_comments(buf, inBlock, '#');
+strip_block_comments(buf, inBlock, '#', true);					// 08/26/26 DD.
 if (inBlock)
 	{
 	// Everything after the "/*" was blanked, which would leave an analyzer
@@ -347,7 +348,9 @@ npasses_ = 0;				// COUNTING PASSES.							// 06/13/00 AM.
 while (*buf)	// For each line of file.
 	{
 	// Slash signifies an inactive pass.								// 01/07/99 AM.
-	if (*buf == '/')
+	// TWO slashes are a "//" line comment, not an inactive pass	// 08/26/26 DD.
+	// named "/...".  Leave those for next_token.					// 08/26/26 DD.
+	if (*buf == '/' && *(buf+1) != '/')								// 08/26/26 DD.
 		{
 		++buf;			// Skip the slash.					// OPT.	// 11/29/00 AM.
 		active = false;

--- a/lite/io.cpp
+++ b/lite/io.cpp
@@ -294,6 +294,8 @@ file_to_buffer(fname, buf,		// Suck in the file.
 *			buf is at lookahead char.  eol tells if end of current line seen.
 *			buf returned null only at end of buffer.
 *			Should also skip # signs!
+*			08/26/26 DD.  "//" starts a line comment too, same as "#".  The
+*			comment text is stored either way.
 *			A SPECIALIZED FUNCTION.
 * WARN:	MODIFIES GIVEN BUFFER.  Places NULLS for token delimiters.
 ********************************************/
@@ -324,8 +326,11 @@ if (*buf == '\n')		// At end of current line.
 	++buf;
 	return 0;
 	}
-else if (*buf == '#')	// Comment
+else if (*buf == '#'		// Comment
+	 || (*buf == '/' && *(buf+1) == '/'))	// C++ style.	// 08/26/26 DD.
 	{
+	if (*buf == '/')	// Step onto the 2nd slash; loop starts past it. // 08/26/26 DD.
+		++buf;																	// 08/26/26 DD.
 	found = false;			// Haven't found nonwhite yet.	// 09/02/99 AM.
 	while (*++buf && *buf != '\n'			// Find end of line.
 				&& *buf != '\r')					// 02/12/99 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.11"
+#define NLP_ENGINE_VERSION "3.8.12"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## What

`analyzer.seq` accepts `//` line comments.

## Why

It already took `#` line comments and, since 3.7.14, `/* */` blocks. It did not take `//`, and the failure mode was silent and total.

A leading `/` on a sequence line already means "inactive pass", so `parseSeq` read `// note` as an inactive pass named `/note`, hit `[Bad algorithm in sequence file=/]`, and `return`ed — abandoning the rest of the sequence. The analyzer then ran with **zero passes**, the error reached `logs/make_ana.log` and nowhere else, and `nlp.exe` still exited 0.

| form | before | after |
|---|---|---|
| `# ...` line / trailing | ok | ok |
| `/* ... */` incl. multi-line | ok | ok |
| `/nlp foo` (inactive pass) | ok | ok |
| `// ...` full line | **whole sequence dropped** | ok |
| `   // ...` indented | **whole sequence dropped** | ok |
| `// a /* inside a // comment` | rest of file blanked | ok |

## How

- `lite/io.cpp` `next_token` — `//` handled exactly like `#`, comment text stored either way. `next_token` has a single caller, `parseSeq`, so nothing outside the `.seq` reader is affected.
- `lite/ana.cpp` `parseSeq` — a leading `/` means "inactive pass" only when the next char is not another `/`.
- `cs/libconsh/blockcom.{h,cpp}` — new opt-in `cppLineComment` arg, defaulting false so the `.kb`, `.dict` and `.kbb` callers are untouched. Without it a `/*` written inside a `//` comment still opened a block and blanked the file from there on.

## Version

3.8.11 → **3.8.12** in `nlp/main.cpp`. Patch bump: a parser fix plus one newly accepted comment syntax in `.seq`.

## Testing

The existing `block-comments-data` fixture (already byte-compares `out.txt`) gains `//` lines, an indented one, one containing `/*`, and an inactive `/nlp probe` — so losing the single-slash meaning would double `probe`'s output and fail CI too.

Verified locally against a rebuilt `bin/Release/nlp.exe`:

- `block-comments` and `block-comments-data` pass their exact-output assertions
- `fnname-digits`, `shadowing`, `str-array`, `json-builtins`, `regexp-glob` all still build and produce correct output
- an 8-case scratch matrix over the table above, each asserting the number of passes actually interned

## Not addressed

Two adjacent problems left alone, worth their own issues:

- `Ana::genSeqfile` (the seq writer) drops every comment but the header one, rewrites the rest as `#`, and omits the newline on passes that have no comment — a GUI round-trip still mangles a hand-commented file.
- The `[Bad algorithm in sequence file=...]` abort remains invisible on the console, with a 0 exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
