### PR TITLE
Add a rule-level debug server to the engine (3.9.0)

### DIFF
--- a/include/Api/lite/nlpdebug.h
+++ b/include/Api/lite/nlpdebug.h
@@ -1,0 +1,128 @@
+/*******************************************************************************
+Copyright (c) 2026 by Text Analysis International, Inc.
+All rights reserved.
+*******************************************************************************/
+// nlpdebug.h
+//
+// Rule-level debug server for NLP++.
+//
+// WHAT THIS IS FOR. The .tree dumps an analyzer already writes give a snapshot
+// per pass, which is enough to step through a run one pass at a time. What they
+// cannot show is what happened INSIDE a pass: which rules were tried at a node,
+// which of them failed and how far each got before failing, and what the tree
+// looked like part-way through. That is the question an NLP++ author actually
+// has when a rule does not fire. This server answers it by letting the engine
+// stop between rule attempts and be interrogated.
+//
+// HOW IT IS WIRED. Nothing happens unless nlp is started with -debug <port>.
+// The engine then listens on 127.0.0.1:<port>, waits for one client to attach,
+// and from then on stops at the pause points below. The hooks are placed in
+// Pat::matchRules / Pat::matchRule (lite/pat.cpp) and around pass execution.
+//
+// COST WHEN OFF. Every hook is an inline test of one static bool, so a normal
+// run pays a single predictable branch per rule attempt and nothing else. That
+// matters: matchRules is the hottest loop in the engine and an analyzer can try
+// millions of rules on one input.
+//
+// PROTOCOL. Newline-delimited JSON over TCP, in both directions. Deliberately
+// NOT the Debug Adapter Protocol: DAP is a large spec with a JSON-RPC framing
+// layer, and putting it in the engine would mean a dependency and a lot of
+// surface to maintain in C++. The editor-side adapter already speaks DAP and
+// translates, so what crosses this socket is only what the engine actually
+// knows. See nlpdebug.cpp for the message catalogue.
+
+#ifndef NLP_LITE_NLPDEBUG_H
+#define NLP_LITE_NLPDEBUG_H
+
+#include "lite/global.h"
+
+class Nlppp;
+class Parse;
+class Irule;
+
+// Why the engine stopped. Sent to the client as the "reason" of a stopped event.
+enum NlpDebugStop
+{
+	NLPDEBUG_ENTRY,        // attached, about to run the first pass
+	NLPDEBUG_STEP,         // a step command completed
+	NLPDEBUG_BREAKPOINT,   // a rule on a breakpoint line was reached
+	NLPDEBUG_RULE_MATCHED, // a rule matched (step-to-match, or a match breakpoint)
+	NLPDEBUG_RULE_FAILED,  // a rule failed (only when the client asked to see failures)
+	NLPDEBUG_PASS_START,   // a new pass began
+	NLPDEBUG_PAUSE         // the client asked to pause
+};
+
+class LITE_API NlpDebug
+{
+public:
+	// Start listening on 127.0.0.1:port and block until a client attaches.
+	// Returns false if the socket could not be opened, in which case the engine
+	// runs normally rather than refusing to start -- a debugger that cannot
+	// attach should not stop someone from getting their analysis done.
+	static bool listen(int port);
+
+	// Close the connection and stop hooking. Safe to call when never started.
+	static void shutdown();
+
+	// Arm the pause points for the actual text analysis, and disarm afterwards.
+	//
+	// This matters more than it looks. Before it analyses anything the engine
+	// parses its OWN grammar -- the .nlp pass files are themselves read with Pat
+	// and a bootstrap rule set -- so the very same hooks fire hundreds of times
+	// on rules the user never wrote, with pass numbers that mean nothing to them.
+	// Arming around parse->execute() is what makes a stop correspond to the
+	// analyzer the user is actually debugging.
+	static void arm();
+	static void disarm();
+
+	// True once a client is attached. Read directly by the inline hooks below;
+	// public so they can stay inline.
+	static bool active_;
+
+	static bool active() { return active_; }
+
+	// ---- pause points -------------------------------------------------------
+	//
+	// Each is a guarded wrapper around the real implementation so that a
+	// non-debug run does not even make a call.
+
+	// A pass is about to run / has finished.
+	static void passStart(Parse *parse, long passNum, const _TCHAR *passFile)
+		{ if (active_) passStart_(parse, passNum, passFile); }
+	static void passEnd(Parse *parse, long passNum)
+		{ if (active_) passEnd_(parse, passNum); }
+
+	// About to try `rule` at the current node. `ord` is its position in the
+	// candidate list at this node, which is what makes "step to the next rule"
+	// meaningful to a user reading the pass file top to bottom.
+	static void ruleAttempt(Nlppp *nlppp, long ord)
+		{ if (active_) ruleAttempt_(nlppp, ord); }
+
+	// The rule matched, before its actions run, so the client can see the tree
+	// as it was when the match was decided.
+	static void ruleMatched(Nlppp *nlppp)
+		{ if (active_) ruleMatched_(nlppp); }
+
+	// The rule failed. How far it got is read off the collect tree inside the
+	// hook -- that count is the single most useful number when a rule does not
+	// fire, because it says WHERE the rule stopped agreeing with the text.
+	//
+	// MUST be called before matchCleanup(), which empties the collect tree.
+	static void ruleFailed(Nlppp *nlppp)
+		{ if (active_) ruleFailed_(nlppp); }
+
+	// The analyzer finished. Tells the client the run is over and closes.
+	static void runEnd()
+		{ if (active_) runEnd_(); }
+
+private:
+	// Real implementations, out of line so the header stays cheap to include.
+	static void passStart_(Parse *parse, long passNum, const _TCHAR *passFile);
+	static void passEnd_(Parse *parse, long passNum);
+	static void ruleAttempt_(Nlppp *nlppp, long ord);
+	static void ruleMatched_(Nlppp *nlppp);
+	static void ruleFailed_(Nlppp *nlppp);
+	static void runEnd_();
+};
+
+#endif // NLP_LITE_NLPDEBUG_H

--- a/include/Api/lite/pn.h
+++ b/include/Api/lite/pn.h
@@ -78,6 +78,11 @@ public:
 	long getUstart();	// [UNICODE]	// 06/15/22 AM.
 	long getUend();		// [UNICODE]	// 06/15/22 AM.
 	enum Pntype getType();
+	// Spelling of a node type ("node", "alpha", "punct", ...), the same table
+	// Pn::print writes into the .tree dumps. Exposed so the debug server names
+	// types identically to those dumps rather than keeping a second copy that
+	// could drift from enum Pntype.
+	static const _TCHAR *typeName(enum Pntype);
 	_TCHAR *getText();					// START OF NODE'S TEXT IN INPUT BUFFER.
 	_TCHAR *getName();					// GET NAME OF NODE.
 	int getFlags();					// 11/03/98 AM.

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -44,6 +44,7 @@ All rights reserved.
 #include "lite/code.h"				// 06/04/00 AM.
 #include "inline.h"					// 06/06/00 AM.
 #include "lite/nlppp.h"
+#include "lite/nlpdebug.h"
 #include "chars.h"					// 06/02/00 AM.
 #include "xml.h"						// 03/28/05 AM.
 #include "pat.h"
@@ -338,6 +339,9 @@ bool ftimepass = parse->eana_->getFtimepass();
 parse->iniPass(num,prefix,flogfiles,ftimepass,true,sfile,salgo,		// 05/20/00 AM.
 			/*DU*/fout,sout,s_time,pretname);
 
+// Rule-level debugger. No-op unless a client is attached (see nlpdebug.h).
+NlpDebug::passStart(parse,num,sfile);
+
 // if (pass->getActive())	// Need to get active flag.
 if (pass->htab)																// 06/20/00 AM.
 //	Pat::Execute(parse,code,arr_select,seltype,must,htab,rules);// 06/20/00 AM.
@@ -347,8 +351,13 @@ else
 //	Pat::Execute(parse,code,arr_select,seltype,rules);
 	if (!																			// 01/26/02 AM.
 	Pat::Execute(parse, pass))												// 06/21/00 AM.
+		{
+		NlpDebug::passEnd(parse,num);										// Debugger.
 		return false;															// 01/26/02 AM.
+		}
 	}
+
+NlpDebug::passEnd(parse,num);												// Debugger.
 
 parse->finPass(num,flogfiles,fout,sout,
 										pretname,ftimepass,s_time);		// 05/20/00 AM.

--- a/lite/nlp.cpp
+++ b/lite/nlp.cpp
@@ -55,6 +55,7 @@ LIBPRIM_API DWORD run_silent(_TCHAR* strCMD);	// 09/15/08 AM.
 
 #include "ana.h"
 #include "parse.h"
+#include "lite/nlpdebug.h"
 #include "tok.h"
 #include "line.h"
 #include "pat.h"					// 12/03/98 AM.
@@ -1905,7 +1906,11 @@ parse->setDatum(datum);														// 03/13/03 AM.
 
 if (parse->getText())
 	{
+	// Rule-level debugger: only the analysis proper is debuggable, not the
+	// engine's own parse of the grammar files (see NlpDebug::arm).
+	NlpDebug::arm();
 	parse->execute();					// PERFORM TEXT ANALYSIS.
+	NlpDebug::disarm();
 	}
 
 cleanAnalyze(parse);
@@ -2026,7 +2031,11 @@ parse->setDatum(datum);														// 03/13/03 AM.
 
 if (parse->getText())
 	{
+	// Rule-level debugger: only the analysis proper is debuggable, not the
+	// engine's own parse of the grammar files (see NlpDebug::arm).
+	NlpDebug::arm();
 	parse->execute();					// PERFORM TEXT ANALYSIS.
+	NlpDebug::disarm();
 	}
 
 cleanAnalyze(parse);

--- a/lite/nlpdebug.cpp
+++ b/lite/nlpdebug.cpp
@@ -1,0 +1,739 @@
+/*******************************************************************************
+Copyright (c) 2026 by Text Analysis International, Inc.
+All rights reserved.
+*******************************************************************************/
+// nlpdebug.cpp
+//
+// Rule-level debug server. See nlpdebug.h for what this is for and how it is
+// wired in; this file is the transport, the protocol and the state dump.
+//
+// MESSAGE CATALOGUE
+//
+// Both directions are newline-delimited JSON objects, UTF-8, one per line.
+//
+// Engine -> client (unsolicited events):
+//   {"event":"stopped","reason":"entry|step|breakpoint|matched|failed|passStart|pause",
+//    "pass":15,"passName":"moneyAttributes","line":17,"ruleOrd":3,
+//    "node":"_money","nodeStart":163,"nodeEnd":166,"eltsMatched":2}
+//   {"event":"output","text":"..."}
+//   {"event":"terminated"}
+//
+// Client -> engine (each carries a "seq"; the reply echoes it):
+//   {"seq":1,"command":"continue"}                  run until a breakpoint
+//   {"seq":2,"command":"stepRule"}                  stop at the next rule tried
+//   {"seq":3,"command":"stepMatch"}                 stop at the next rule that matches
+//   {"seq":4,"command":"stepPass"}                  stop at the start of the next pass
+//   {"seq":5,"command":"setBreakpoints","pass":15,"lines":[17,23]}
+//   {"seq":6,"command":"stopOnFailure","value":true}  also stop when a rule fails
+//   {"seq":7,"command":"state"}                     current pass/rule/node
+//   {"seq":8,"command":"tree","depth":3}            parse tree from the root
+//   {"seq":9,"command":"node"}                      current node, its children and attributes
+//   {"seq":10,"command":"rule"}                     the rule being tried, element by element
+//   {"seq":11,"command":"detach"}                   let the run finish unhooked
+//
+// Replies are {"seq":N,"ok":true,...} or {"seq":N,"ok":false,"error":"..."}.
+//
+// WHY A HAND-ROLLED JSON WRITER. The engine has no JSON dependency and this
+// file emits perhaps a dozen shapes, all of them ours. Pulling in a library to
+// serialise them would be a bigger change to the build than the debugger is to
+// the engine. Only strings need real care, and escapeJson below does that.
+//
+// THREADING. There is none. The engine stops inside a hook and reads commands
+// on the same thread, so there is no shared state and no lock. The cost is that
+// an asynchronous "pause" cannot arrive mid-pass -- the client can only pause at
+// the next hook, which for a running analyzer is microseconds away.
+
+#include "StdAfx.h"
+#include "machine.h"
+#include "u_out.h"
+#include "lite/lite.h"
+#include "lite/global.h"
+#include "dlist.h"
+#include "inline.h"
+#include "io.h"
+#include "chars.h"
+#include "string.h"
+#include "node.h"
+#include "tree.h"
+#include "parse.h"
+#include "htab.h"
+#include "slist.h"
+#include "lite/nlppp.h"
+#include "gen.h"
+#include "irule.h"
+#include "ielt.h"
+#include "isugg.h"
+#include "ielement.h"
+#include "pn.h"
+#include "lite/nlpdebug.h"
+
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+#include <sstream>
+#include <cctype>   // isspace, isdigit
+#include <cstdio>   // sprintf
+#include <cstdlib>  // strtol
+#include <cstring>  // memset
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+typedef SOCKET nlp_socket_t;
+#define NLP_INVALID_SOCKET INVALID_SOCKET
+#define nlp_closesocket closesocket
+#pragma comment(lib, "Ws2_32.lib")
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+typedef int nlp_socket_t;
+#define NLP_INVALID_SOCKET (-1)
+#define nlp_closesocket close
+#endif
+
+bool NlpDebug::active_ = false;
+
+namespace
+{
+
+// ---- connection state -------------------------------------------------------
+
+nlp_socket_t g_listen = NLP_INVALID_SOCKET;
+nlp_socket_t g_client = NLP_INVALID_SOCKET;
+std::string g_inbuf; // bytes read but not yet consumed as a whole line
+
+// How the engine should behave until the next stop.
+enum RunMode
+{
+	MODE_RUN,        // only breakpoints stop us
+	MODE_STEP_RULE,  // stop at the next rule attempt
+	MODE_STEP_MATCH, // stop at the next rule that matches
+	MODE_STEP_PASS   // stop at the start of the next pass
+};
+
+RunMode g_mode = MODE_STEP_PASS; // so arming stops at the first pass
+bool g_stopOnFailure = false;
+bool g_detached = false;
+
+// Set only while the analyzer is running over the input text. The hooks are
+// inert outside that window -- see NlpDebug::arm().
+bool g_armed = false;
+
+// pass number -> lines with a breakpoint on them.
+std::map<long, std::set<long> > g_breakpoints;
+
+// Where we are, refreshed at each hook so a state/tree/node request can be
+// answered without the hook having to pass anything along.
+Parse *g_parse = 0;
+Nlppp *g_nlppp = 0;
+long g_pass = 0;
+std::string g_passName;
+long g_ruleOrd = 0;
+long g_eltsMatched = -1;
+
+// ---- narrow-string helpers --------------------------------------------------
+
+// The engine is _TCHAR-based and may be built for UNICODE; the wire is UTF-8.
+// TCHAR2A is the codebase's own conversion and is the identity in narrow builds.
+std::string narrow(const _TCHAR *s)
+{
+	if (!s) return std::string();
+#ifdef UNICODE
+	LPCSTR p = CTCHAR2CA(s);
+	return p ? std::string(p) : std::string();
+#else
+	return std::string(s);
+#endif
+}
+
+std::string escapeJson(const std::string &in)
+{
+	std::string out;
+	out.reserve(in.size() + 8);
+	for (size_t i = 0; i < in.size(); ++i)
+	{
+		unsigned char c = (unsigned char)in[i];
+		switch (c)
+		{
+		case '"':  out += "\\\""; break;
+		case '\\': out += "\\\\"; break;
+		case '\b': out += "\\b";  break;
+		case '\f': out += "\\f";  break;
+		case '\n': out += "\\n";  break;
+		case '\r': out += "\\r";  break;
+		case '\t': out += "\\t";  break;
+		default:
+			if (c < 0x20)
+			{
+				// Control characters must be escaped; anything >= 0x20 passes
+				// through, which keeps already-valid UTF-8 intact.
+				char buf[8];
+				sprintf(buf, "\\u%04x", c);
+				out += buf;
+			}
+			else
+				out += (char)c;
+		}
+	}
+	return out;
+}
+
+std::string jstr(const std::string &s) { return "\"" + escapeJson(s) + "\""; }
+std::string jnum(long n)
+{
+	std::ostringstream o;
+	o << n;
+	return o.str();
+}
+
+// ---- socket plumbing --------------------------------------------------------
+
+bool sendLine(const std::string &line)
+{
+	if (g_client == NLP_INVALID_SOCKET) return false;
+	std::string payload = line;
+	payload += "\n";
+	size_t sent = 0;
+	while (sent < payload.size())
+	{
+		int n = (int)send(g_client, payload.data() + sent, (int)(payload.size() - sent), 0);
+		if (n <= 0) return false;
+		sent += (size_t)n;
+	}
+	return true;
+}
+
+// Block until a whole line arrives. Returns false if the peer went away, which
+// the caller treats as a detach rather than an error: losing the debugger must
+// never take the analysis down with it.
+bool readLine(std::string &out)
+{
+	for (;;)
+	{
+		size_t nl = g_inbuf.find('\n');
+		if (nl != std::string::npos)
+		{
+			out = g_inbuf.substr(0, nl);
+			g_inbuf.erase(0, nl + 1);
+			if (!out.empty() && out[out.size() - 1] == '\r') out.erase(out.size() - 1);
+			return true;
+		}
+		char buf[4096];
+		int n = (int)recv(g_client, buf, sizeof(buf), 0);
+		if (n <= 0) return false;
+		g_inbuf.append(buf, (size_t)n);
+	}
+}
+
+// ---- a deliberately small JSON reader ---------------------------------------
+//
+// The engine only ever parses messages this file documents: flat objects whose
+// values are strings, numbers, booleans, or an array of numbers. Rather than
+// carry a parser for the whole grammar, these pull one named field out of a
+// line. Anything unrecognised is ignored, so an older engine and a newer client
+// degrade to the commands they share instead of failing to talk at all.
+
+std::string fieldRaw(const std::string &msg, const std::string &key)
+{
+	std::string needle = "\"" + key + "\"";
+	size_t k = msg.find(needle);
+	if (k == std::string::npos) return std::string();
+	size_t colon = msg.find(':', k + needle.size());
+	if (colon == std::string::npos) return std::string();
+	size_t i = colon + 1;
+	while (i < msg.size() && isspace((unsigned char)msg[i])) ++i;
+	if (i >= msg.size()) return std::string();
+
+	if (msg[i] == '"')
+	{
+		std::string out;
+		++i;
+		while (i < msg.size() && msg[i] != '"')
+		{
+			if (msg[i] == '\\' && i + 1 < msg.size())
+			{
+				++i;
+				switch (msg[i])
+				{
+				case 'n': out += '\n'; break;
+				case 't': out += '\t'; break;
+				case 'r': out += '\r'; break;
+				default:  out += msg[i]; break;
+				}
+			}
+			else
+				out += msg[i];
+			++i;
+		}
+		return out;
+	}
+	// number, boolean, or array: take up to the next delimiter
+	size_t start = i;
+	int depth = 0;
+	while (i < msg.size())
+	{
+		char c = msg[i];
+		if (c == '[') ++depth;
+		else if (c == ']') { if (depth == 0) break; --depth; }
+		else if ((c == ',' || c == '}') && depth == 0) break;
+		++i;
+	}
+	std::string out = msg.substr(start, i - start);
+	while (!out.empty() && isspace((unsigned char)out[out.size() - 1])) out.erase(out.size() - 1);
+	return out;
+}
+
+std::string fieldStr(const std::string &msg, const std::string &key)
+{
+	return fieldRaw(msg, key);
+}
+
+long fieldNum(const std::string &msg, const std::string &key, long dflt)
+{
+	std::string raw = fieldRaw(msg, key);
+	if (raw.empty()) return dflt;
+	return strtol(raw.c_str(), 0, 10);
+}
+
+bool fieldBool(const std::string &msg, const std::string &key, bool dflt)
+{
+	std::string raw = fieldRaw(msg, key);
+	if (raw == "true") return true;
+	if (raw == "false") return false;
+	return dflt;
+}
+
+// "[17, 23, 48]" -> {17,23,48}
+std::set<long> fieldNumArray(const std::string &msg, const std::string &key)
+{
+	std::set<long> out;
+	std::string raw = fieldRaw(msg, key);
+	size_t i = 0;
+	while (i < raw.size())
+	{
+		while (i < raw.size() && !isdigit((unsigned char)raw[i]) && raw[i] != '-') ++i;
+		if (i >= raw.size()) break;
+		char *end = 0;
+		long v = strtol(raw.c_str() + i, &end, 10);
+		out.insert(v);
+		i = (size_t)(end - raw.c_str());
+	}
+	return out;
+}
+
+// ---- state serialisation ----------------------------------------------------
+
+// One node as a JSON object. Children are included only while depth remains --
+// a full parse tree can be tens of thousands of nodes and the client asks for
+// what it can display.
+std::string nodeJson(Node<Pn> *node, int depth)
+{
+	if (!node) return "null";
+	Pn *pn = node->getData();
+	if (!pn) return "null";
+
+	std::ostringstream o;
+	o << "{\"name\":" << jstr(narrow(pn->getName()))
+	  << ",\"type\":" << jstr(narrow(Pn::typeName(pn->getType())))
+	  << ",\"start\":" << jnum(pn->getStart())
+	  << ",\"end\":" << jnum(pn->getEnd())
+	  << ",\"ustart\":" << jnum(pn->getUstart())
+	  << ",\"uend\":" << jnum(pn->getUend())
+	  << ",\"passNum\":" << jnum(pn->getPassnum())
+	  << ",\"ruleLine\":" << jnum(pn->getRuleline())
+	  << ",\"fired\":" << (pn->getFired() ? "true" : "false")
+	  << ",\"built\":" << (pn->getBuilt() ? "true" : "false");
+
+	if (depth > 0)
+	{
+		o << ",\"children\":[";
+		bool first = true;
+		for (Node<Pn> *c = node->Down(); c; c = c->Right())
+		{
+			if (!first) o << ",";
+			first = false;
+			o << nodeJson(c, depth - 1);
+		}
+		o << "]";
+	}
+	else
+	{
+		// Say how many were withheld so the client can offer to expand.
+		long n = 0;
+		for (Node<Pn> *c = node->Down(); c; c = c->Right()) ++n;
+		o << ",\"childCount\":" << jnum(n);
+	}
+	o << "}";
+	return o.str();
+}
+
+// The rule being tried, element by element. With eltsMatched from a failure this
+// is what shows an author exactly which element stopped agreeing with the text.
+std::string ruleJson(Irule *rule)
+{
+	if (!rule) return "null";
+	std::ostringstream o;
+	o << "{\"line\":" << jnum(rule->getLine())
+	  << ",\"num\":" << jnum(rule->getNum());
+
+	Isugg *sugg = rule->getSugg();
+	if (sugg)
+		o << ",\"builds\":" << jstr(narrow(sugg->getName()));
+
+	o << ",\"elements\":[";
+	Dlist<Ielt> *phrase = rule->getPhrase();
+	bool first = true;
+	if (phrase)
+	{
+		for (Delt<Ielt> *e = phrase->getFirst(); e; e = e->Right())
+		{
+			Ielt *elt = e->getData();
+			if (!elt) continue;
+			if (!first) o << ",";
+			first = false;
+			o << "{\"name\":" << jstr(narrow(elt->getName()))
+			  << ",\"min\":" << jnum(elt->getMin())
+			  << ",\"max\":" << jnum(elt->getMax()) << "}";
+		}
+	}
+	o << "]}";
+	return o.str();
+}
+
+std::string currentStateJson()
+{
+	std::ostringstream o;
+	o << "\"pass\":" << jnum(g_pass)
+	  << ",\"passName\":" << jstr(g_passName)
+	  << ",\"ruleOrd\":" << jnum(g_ruleOrd);
+
+	Irule *rule = g_nlppp ? g_nlppp->getRule() : 0;
+	o << ",\"line\":" << jnum(rule ? rule->getLine() : 0);
+
+	Node<Pn> *node = g_nlppp ? g_nlppp->getNode() : 0;
+	Pn *pn = node ? node->getData() : 0;
+	if (pn)
+	{
+		o << ",\"node\":" << jstr(narrow(pn->getName()))
+		  << ",\"nodeStart\":" << jnum(pn->getStart())
+		  << ",\"nodeEnd\":" << jnum(pn->getEnd());
+	}
+	if (g_eltsMatched >= 0)
+		o << ",\"eltsMatched\":" << jnum(g_eltsMatched);
+	return o.str();
+}
+
+const char *reasonName(NlpDebugStop reason)
+{
+	switch (reason)
+	{
+	case NLPDEBUG_ENTRY:        return "entry";
+	case NLPDEBUG_STEP:         return "step";
+	case NLPDEBUG_BREAKPOINT:   return "breakpoint";
+	case NLPDEBUG_RULE_MATCHED: return "matched";
+	case NLPDEBUG_RULE_FAILED:  return "failed";
+	case NLPDEBUG_PASS_START:   return "passStart";
+	case NLPDEBUG_PAUSE:        return "pause";
+	}
+	return "step";
+}
+
+// ---- the stop loop ----------------------------------------------------------
+
+void reply(long seq, const std::string &body)
+{
+	std::ostringstream o;
+	o << "{\"seq\":" << jnum(seq) << ",\"ok\":true";
+	if (!body.empty()) o << "," << body;
+	o << "}";
+	sendLine(o.str());
+}
+
+void replyError(long seq, const std::string &msg)
+{
+	std::ostringstream o;
+	o << "{\"seq\":" << jnum(seq) << ",\"ok\":false,\"error\":" << jstr(msg) << "}";
+	sendLine(o.str());
+}
+
+// Announce a stop, then serve requests until the client resumes us. Returns when
+// the engine should carry on.
+void stopAndServe(NlpDebugStop reason)
+{
+	if (!NlpDebug::active_) return;
+
+	{
+		std::ostringstream o;
+		o << "{\"event\":\"stopped\",\"reason\":\"" << reasonName(reason) << "\","
+		  << currentStateJson() << "}";
+		if (!sendLine(o.str()))
+		{
+			// Client vanished. Detach and let the analysis finish.
+			NlpDebug::shutdown();
+			return;
+		}
+	}
+
+	for (;;)
+	{
+		std::string line;
+		if (!readLine(line))
+		{
+			NlpDebug::shutdown();
+			return;
+		}
+		if (line.empty()) continue;
+
+		long seq = fieldNum(line, "seq", 0);
+		std::string cmd = fieldStr(line, "command");
+
+		if (cmd == "continue")      { g_mode = MODE_RUN;        reply(seq, ""); return; }
+		if (cmd == "stepRule")      { g_mode = MODE_STEP_RULE;  reply(seq, ""); return; }
+		if (cmd == "stepMatch")     { g_mode = MODE_STEP_MATCH; reply(seq, ""); return; }
+		if (cmd == "stepPass")      { g_mode = MODE_STEP_PASS;  reply(seq, ""); return; }
+
+		if (cmd == "setBreakpoints")
+		{
+			long pass = fieldNum(line, "pass", 0);
+			g_breakpoints[pass] = fieldNumArray(line, "lines");
+			reply(seq, "\"count\":" + jnum((long)g_breakpoints[pass].size()));
+			continue;
+		}
+		if (cmd == "stopOnFailure")
+		{
+			g_stopOnFailure = fieldBool(line, "value", false);
+			reply(seq, "");
+			continue;
+		}
+		if (cmd == "state")
+		{
+			reply(seq, currentStateJson());
+			continue;
+		}
+		if (cmd == "rule")
+		{
+			reply(seq, "\"rule\":" + ruleJson(g_nlppp ? g_nlppp->getRule() : 0));
+			continue;
+		}
+		if (cmd == "node")
+		{
+			Node<Pn> *node = g_nlppp ? g_nlppp->getNode() : 0;
+			reply(seq, "\"node\":" + nodeJson(node, 1));
+			continue;
+		}
+		if (cmd == "tree")
+		{
+			int depth = (int)fieldNum(line, "depth", 3);
+			// Parse::getTree() is declared as an opaque TREE* (void*) in the
+			// public header; the cast is how the rest of lite reaches it.
+			Node<Pn> *root = 0;
+			if (g_parse)
+			{
+				Tree<Pn> *tree = (Tree<Pn> *)g_parse->getTree();
+				if (tree) root = tree->getRoot();
+			}
+			reply(seq, "\"tree\":" + nodeJson(root, depth));
+			continue;
+		}
+		if (cmd == "detach")
+		{
+			reply(seq, "");
+			g_detached = true;
+			NlpDebug::shutdown();
+			return;
+		}
+
+		replyError(seq, "unknown command: " + cmd);
+	}
+}
+
+bool breakpointHere(long pass, long line)
+{
+	std::map<long, std::set<long> >::const_iterator it = g_breakpoints.find(pass);
+	if (it == g_breakpoints.end()) return false;
+	return it->second.find(line) != it->second.end();
+}
+
+} // namespace
+
+// ---- lifecycle --------------------------------------------------------------
+
+bool NlpDebug::listen(int port)
+{
+#ifdef _WIN32
+	WSADATA wsa;
+	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+	{
+		*gerr << _T("[debug: WSAStartup failed; running without the debugger.]") << std::endl;
+		return false;
+	}
+#endif
+
+	g_listen = socket(AF_INET, SOCK_STREAM, 0);
+	if (g_listen == NLP_INVALID_SOCKET)
+	{
+		*gerr << _T("[debug: could not create socket; running without the debugger.]") << std::endl;
+		return false;
+	}
+
+	int yes = 1;
+	setsockopt(g_listen, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
+
+	struct sockaddr_in addr;
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons((unsigned short)port);
+	// Loopback only. This gives an attached client the ability to read the text
+	// being analysed, so it must not be reachable from off the machine.
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	if (bind(g_listen, (struct sockaddr *)&addr, sizeof(addr)) != 0 ||
+		 ::listen(g_listen, 1) != 0)
+	{
+		*gerr << _T("[debug: could not listen on port ") << port
+				<< _T("; running without the debugger.]") << std::endl;
+		nlp_closesocket(g_listen);
+		g_listen = NLP_INVALID_SOCKET;
+		return false;
+	}
+
+	*gout << _T("[debug: waiting for a client on 127.0.0.1:") << port << _T("]") << std::endl;
+
+	g_client = accept(g_listen, 0, 0);
+	if (g_client == NLP_INVALID_SOCKET)
+	{
+		*gerr << _T("[debug: accept failed; running without the debugger.]") << std::endl;
+		nlp_closesocket(g_listen);
+		g_listen = NLP_INVALID_SOCKET;
+		return false;
+	}
+
+	active_ = true;
+	g_detached = false;
+	g_mode = MODE_STEP_PASS;
+	return true;
+}
+
+void NlpDebug::shutdown()
+{
+	active_ = false;
+	if (g_client != NLP_INVALID_SOCKET)
+	{
+		if (!g_detached) sendLine("{\"event\":\"terminated\"}");
+		nlp_closesocket(g_client);
+		g_client = NLP_INVALID_SOCKET;
+	}
+	if (g_listen != NLP_INVALID_SOCKET)
+	{
+		nlp_closesocket(g_listen);
+		g_listen = NLP_INVALID_SOCKET;
+	}
+#ifdef _WIN32
+	WSACleanup();
+#endif
+}
+
+// ---- pause points -----------------------------------------------------------
+
+void NlpDebug::passStart_(Parse *parse, long passNum, const _TCHAR *passFile)
+{
+	if (!g_armed) return;
+	g_parse = parse;
+	g_nlppp = 0;
+	g_pass = passNum;
+	g_passName = narrow(passFile);
+	g_ruleOrd = 0;
+	g_eltsMatched = -1;
+
+	if (g_mode == MODE_STEP_PASS)
+		stopAndServe(NLPDEBUG_PASS_START);
+}
+
+void NlpDebug::passEnd_(Parse *parse, long passNum)
+{
+	if (!g_armed) return;
+	// Nothing to stop for, but drop the stale pointers so a later request
+	// cannot walk a tree that has been rebuilt underneath it.
+	(void)parse;
+	(void)passNum;
+	g_nlppp = 0;
+	g_eltsMatched = -1;
+}
+
+void NlpDebug::ruleAttempt_(Nlppp *nlppp, long ord)
+{
+	if (!g_armed) return;
+	g_nlppp = nlppp;
+	g_ruleOrd = ord;
+	g_eltsMatched = -1;
+	if (nlppp && nlppp->getParse()) g_parse = nlppp->getParse();
+
+	Irule *rule = nlppp ? nlppp->getRule() : 0;
+	long line = rule ? rule->getLine() : 0;
+
+	if (breakpointHere(g_pass, line))
+	{
+		stopAndServe(NLPDEBUG_BREAKPOINT);
+		return;
+	}
+	if (g_mode == MODE_STEP_RULE)
+		stopAndServe(NLPDEBUG_STEP);
+}
+
+void NlpDebug::ruleMatched_(Nlppp *nlppp)
+{
+	if (!g_armed) return;
+	g_nlppp = nlppp;
+	g_eltsMatched = -1;
+	if (g_mode == MODE_STEP_MATCH)
+		stopAndServe(NLPDEBUG_RULE_MATCHED);
+}
+
+void NlpDebug::ruleFailed_(Nlppp *nlppp)
+{
+	if (!g_armed) return;
+	g_nlppp = nlppp;
+	// How many rule elements matched before the rule gave up.
+	//
+	// The collected elements are a SIBLING LIST hanging off the collect tree's
+	// root -- makeCollect() appends to it and matchCleanup() calls it "the list
+	// of collect nodes" -- so the count walks Right() from the root. Descending
+	// into the root's children instead counts whatever that first matched node
+	// happens to span, which for a wildcard is most of the document.
+	//
+	// This is read here rather than passed in because the caller must invoke the
+	// hook before matchCleanup() empties the list, and doing the counting here
+	// keeps that ordering requirement in one place.
+	g_eltsMatched = 0;
+	if (nlppp && nlppp->getCollect())
+	{
+		for (Node<Pn> *c = nlppp->getCollect()->getRoot(); c; c = c->Right())
+			++g_eltsMatched;
+	}
+	// Failures are the common case -- most rules do not match most nodes -- so
+	// stopping on them is opt-in. When it is on, the client gets the element
+	// count with the stop, which is the whole point of watching failures.
+	if (g_stopOnFailure)
+		stopAndServe(NLPDEBUG_RULE_FAILED);
+}
+
+void NlpDebug::arm()
+{
+	g_armed = true;
+}
+
+void NlpDebug::disarm()
+{
+	g_armed = false;
+}
+
+void NlpDebug::runEnd_()
+{
+	sendLine("{\"event\":\"terminated\"}");
+	shutdown();
+}

--- a/lite/nlppp.cpp
+++ b/lite/nlppp.cpp
@@ -294,6 +294,7 @@ Irule		*Nlppp::getRule()	{return rule_;}
 Tree<Pn> *Nlppp::getCollect()	{return collect_;}
 Parse		*Nlppp::getParse()	{return parse_;  }
 Node<Pn>	*Nlppp::getSelect()	{return select_; }
+Node<Pn>	*Nlppp::getNode()	{return node_;   }
 Node<Pn>	*Nlppp::getFirst()	{return first_;  }
 Node<Pn>	*Nlppp::getLast()		{return last_;		}
 Node<Pn>	*Nlppp::getStart()	{return start_;	}

--- a/lite/parse.cpp
+++ b/lite/parse.cpp
@@ -49,6 +49,7 @@ All rights reserved.
 #include "consh/cg.h"
 //#include "iarg.h"				// 05/23/01 AM.
 #include "parse.h"
+#include "lite/nlpdebug.h"
 #include "lite/nlp.h"		// FOR DEBUGGING!!!	// 10/10/99 AM.
 #include "var.h"											// 09/26/00 AM.
 #include "lite/nlppp.h"										// 05/17/00 AM.
@@ -759,10 +760,26 @@ bool ftimepass = eana_->getFtimepass();								// 10/13/99 AM.
 iniPass(num,prefix,flogfiles,ftimepass,pass->getActive(),sfile,salgo,				// 05/20/00 AM.
 			/*DU*/fout,sout,s_time,pretname);
 
+// Rule-level debugger. Named the same way the .tree header names a pass, so a
+// stop and a dump agree; pretname cannot be reused because it is only filled in
+// when logging or timing is on. No-op unless a client is attached and armed.
+if (pass->getActive())
+	{
+	_TCHAR *dbgname = sfile;
+	if (salgo && *salgo
+		 && strcmp_i(salgo, _T("nlp"))
+		 && strcmp_i(salgo, _T("rec")))
+		dbgname = salgo;
+	NlpDebug::passStart(this,num,dbgname);
+	}
+
 if (pass->getActive() && algo)	// Execute active pass.			// 01/08/99 AM.
 	{
 	if (!algo->Execute(this, pass)) // Algorithm, do your thing.// 01/26/02 AM.
+		{
+		NlpDebug::passEnd(this,num);										// Debugger.
 		return false;															// 01/26/02 AM.
+		}
 	}
 else if (!strcmp_i(str(salgo),_T("folder")))							// 02/03/05 DD.
 	;																				// 02/03/05 DD.
@@ -776,7 +793,10 @@ else if (!algo && pass->getActive())									// 01/15/99 AM.
 	}
 
 if (pass->getActive())
+	{
+	NlpDebug::passEnd(this,num);											// Debugger.
 	finPass(num,flogfiles,fout,sout,pretname,ftimepass,s_time);		// 05/20/00 AM.
+	}
 return true;
 }
 

--- a/lite/pat.cpp
+++ b/lite/pat.cpp
@@ -36,7 +36,8 @@ All rights reserved.
 #include "lite/nlppp.h"			// 11/19/99 AM.
 #include "gen.h"	// Linux.	// 04/26/07 AM.
 #include "irule.h"
-#include "ielt.h"				// 12/17/98 AM.
+#include "ielt.h"
+#include "lite/nlpdebug.h"				// 12/17/98 AM.
 #include "ifile.h"			// 12/17/98 AM.
 #include "lite/Arun.h"		// 06/08/00 AM.
 #include "var.h"				// 08/31/00 AM.
@@ -814,8 +815,10 @@ Node<Pn> *node = nlppp->node_;	// SAVE NODE.		// 11/20/99 AM.
 
 
 Delt<Irule> *rule;
+long dbg_ord = 0;		// Position of the rule in this node's candidate list.
 for (rule = rules; rule; rule = rule->Right())
 	{
+	++dbg_ord;
 	nlppp->node_ = node;		// RESTORE NODE.	// 11/20/99 AM.
 	nlppp->rmost_ = 0;		// Reset.		// RECOPT2.	// 07/23/06 AM.
 	updateRestart(nlppp,node);	// Reset.	// RECOPT2.	// 07/24/06 AM.
@@ -830,12 +833,16 @@ for (rule = rules; rule; rule = rule->Right())
 	nlppp->first_ = nlppp->last_ = 0;			// 11/19/99 AM.
 	nlppp->succeed_ = nlppp->fail_ = false;							// 06/10/00 AM.
 
+	// Rule-level debugger. No-op unless a client is attached (see nlpdebug.h).
+	NlpDebug::ruleAttempt(nlppp,dbg_ord);
+
 	if (matchRule(nlppp)								// 11/19/99 AM.
 		 && nlppp->first_	// Requiring rule to match one node. // 11/23/98 AM.
 		 && checkActions(nlppp))					// 11/19/99 AM.
 		{
 //		if (Debug())
 //			*gout << "\n  [Matched rule.]\n" << std::endl;
+		NlpDebug::ruleMatched(nlppp);
 		rules = rule;		// UP: Return the matched rule to caller. 11/1/98 AM.
 		nlppp->node_ = node;		// RESTORE NODE.	// 11/20/99 AM.
 		return true;
@@ -844,6 +851,9 @@ for (rule = rules; rule; rule = rule->Right())
 		{
 //		if (nlppp->span_ > nlppp->maxspan_)								// 02/04/05 AM.
 //			nlppp->maxspan_ = nlppp->span_;								// 02/04/05 AM.
+		// Must run before matchCleanup(), which empties the collect tree the
+		// debugger reads to report how far the rule got.
+		NlpDebug::ruleFailed(nlppp);
 		// Clean up for next rule.
 		endRestart(nlppp);	// RECOPT2.	// 07/17/06 AM.
 		matchCleanup(nlppp->collect_);								// 11/11/98 AM.
@@ -876,8 +886,10 @@ bool Pat::matchRules(
 Node<Pn> *node = nlppp->node_;				// SAVE NODE.		// 11/20/99 AM.
 
 Selt<Irule> *rule;
+long dbg_ord = 0;		// Position of the rule in this node's candidate list.
 for (rule = rules; rule; rule = rule->Right())
 	{
+	++dbg_ord;
 	nlppp->node_ = node;							// RESTORE NODE.	// 11/20/99 AM.
 	nlppp->rmost_ = 0;		// Reset.		// RECOPT2.	// 07/23/06 AM.
 	updateRestart(nlppp,node);	// Reset.	// RECOPT2.	// 07/24/06 AM.
@@ -895,12 +907,16 @@ for (rule = rules; rule; rule = rule->Right())
 	nlppp->noop_ = false;													// 08/12/02 AM.
 //	nlppp->span_ = 0;															// 02/04/05 AM.
 
+	// Rule-level debugger. No-op unless a client is attached (see nlpdebug.h).
+	NlpDebug::ruleAttempt(nlppp,dbg_ord);
+
 	if (matchRule(nlppp)													// 11/19/99 AM.
 		 && nlppp->first_	// Requiring rule to match 1 node.	// 11/23/98 AM.
 		 && checkActions(nlppp))								// 11/19/99 AM.
 		{
 //		if (Debug())
 //			*gout << "\n  [Matched rule.]\n" << std::endl;
+		NlpDebug::ruleMatched(nlppp);
 		rules = rule;	// UP: Return matched rule to caller.	// 11/01/98 AM.
 		nlppp->node_ = node;						// RESTORE NODE.	// 11/20/99 AM.
 		return true;
@@ -909,6 +925,9 @@ for (rule = rules; rule; rule = rule->Right())
 		{
 //		if (nlppp->span_ > nlppp->maxspan_)								// 02/04/05 AM.
 //			nlppp->maxspan_ = nlppp->span_;								// 02/04/05 AM.
+		// Must run before matchCleanup(), which empties the collect tree the
+		// debugger reads to report how far the rule got.
+		NlpDebug::ruleFailed(nlppp);
 		// Clean up for next rule.
 		endRestart(nlppp);	// RECOPT2.	// 07/17/06 AM.
 		matchCleanup(nlppp->collect_);								// 11/11/98 AM.

--- a/lite/pn.cpp
+++ b/lite/pn.cpp
@@ -322,6 +322,17 @@ long			Pn::getEnd()		{return End;    }
 long			Pn::getUstart()		{return Ustart; }	// [UNICODE]
 long			Pn::getUend()		{return Uend; }	// [UNICODE]
 enum Pntype Pn::getType()		{return Type;   }
+
+// Spelling of a node type, from the same table Pn::print uses. Bounds-checked
+// because enum Pntype and Pntype_s are kept in step by hand (see the WARNING on
+// both), and a debugger is exactly where an out-of-range read would surface.
+const _TCHAR *Pn::typeName(enum Pntype t)
+{
+const int n = (int) (sizeof(Pntype_s) / sizeof(Pntype_s[0]));
+if ((int) t < 0 || (int) t >= n)
+	return _T("?");
+return Pntype_s[t];
+}
 _TCHAR		  *Pn::getText()		{return Text;   }
 _TCHAR		  *Pn::getName()		{return name_;  }
 int         Pn::getFlags()		{return flags_; }

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,10 +15,12 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.8.12"
+#define NLP_ENGINE_VERSION "3.9.0"
 
-bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &);
+bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);
+
+#include "lite/nlpdebug.h"
 
 #ifdef LINUX
 int main(
@@ -42,14 +44,21 @@ int _tmain(
 	bool silent = false;    // No log/debug output files.
 	bool compileKB = false; // Compile only the KB to C++.
 	bool compileAna = false; // Compile only the analyzer to C++.
+	int debugPort = 0;       // -debug <port>: rule-level debug server. 0 = off.
 
 	/////////////////////////////////////////////////
 	// GET APP INFORMATION
 	/////////////////////////////////////////////////
 
 	// Get analyzer name, input and output filenames from command line.
-	if (!cmdReadArgs(argc, argv, analyzerpath, input, output, workdir, develop, compile, compiled, silent, compileKB, compileAna))
+	if (!cmdReadArgs(argc, argv, analyzerpath, input, output, workdir, develop, compile, compiled, silent, compileKB, compileAna, debugPort))
 		exit(1);
+
+	// Rule-level debugger. Blocks until a client attaches, so it is only started
+	// for an actual analysis run -- attaching to a compile would wait forever on
+	// a process that never reaches a rule.
+	if (debugPort > 0 && !compile && !compileKB && !compileAna)
+		NlpDebug::listen(debugPort);
 
 	NLP_ENGINE *nlpEngine = new NLP_ENGINE(workdir);
 	if (compile)
@@ -81,6 +90,8 @@ int _tmain(
 	{
 		nlpEngine->analyze(analyzerpath, input, output, develop, silent, compile, compiled, compileKB, compileAna);
 	}
+	NlpDebug::runEnd();
+	NlpDebug::shutdown();
 	delete nlpEngine;
 }
 
@@ -104,7 +115,8 @@ bool cmdReadArgs(
 	bool &compiled,	   // true - compiled ana. false=interp(DEFAULT).
 	bool &silent,	   // true == only output files specified by analyzer.
 	bool &compileKB,   // true - compile only the KB to C++.
-	bool &compileAna   // true - compile only the analyzer to C++.
+	bool &compileAna,  // true - compile only the analyzer to C++.
+	int &debugPort	   // -debug <port>: rule-level debug server. 0 = off.
 )
 {
 	_TCHAR *ptr;
@@ -114,6 +126,7 @@ bool cmdReadArgs(
 	bool f_in = false;
 	bool f_out = false;
 	bool f_work = false;
+	bool f_debug = false;
 	bool flag = false;
 	bool compiledck = false; // If compiled/interp arg seen.
 	bool doubledash = false;
@@ -125,6 +138,7 @@ bool cmdReadArgs(
 	silent = false;	   // Produce debug files, etc. by default.		// 06/16/02 AM.
 	compileKB = false; // Don't compile KB-only by default.
 	compileAna = false; // Don't compile analyzer-only by default.
+	debugPort = 0;	  // No debug server unless -debug <port> is given.
 
 	for (--argc, parg = &(argv[1]); argc > 0; --argc, ++parg)
 	{
@@ -181,6 +195,8 @@ bool cmdReadArgs(
 				f_out = flag = true; // Expecting output file.
 			else if (!strcmp_i(ptr, _T("work")))
 				f_work = flag = true;			// Expecting output file.
+			else if (!strcmp_i(ptr, _T("debug")))
+				f_debug = flag = true;			// Expecting a TCP port.
 			else if (!strcmp_i(ptr, _T("dev"))) // 12/25/98 AM.
 			{
 				if (silent)
@@ -284,6 +300,18 @@ bool cmdReadArgs(
 				workdir = ptr;
 				f_work = flag = false;
 			}
+			else if (f_debug)
+			{
+				debugPort = _ttoi(ptr);
+				if (debugPort <= 0 || debugPort > 65535)
+				{
+					std::_t_cerr << _T("[") << argv[0]
+								 << _T(": -debug needs a TCP port between 1 and 65535.]") << std::endl;
+					cmdHelpargs(argv[0]);
+					return false;
+				}
+				f_debug = flag = false;
+			}
 		}
 		else // Got a "floating" value.
 		{
@@ -324,6 +352,7 @@ void cmdHelpargs(_TCHAR *name)
 				 << _T("           [-OUT outdir] output directory") << std::endl
 				 << _T("           [-WORK workdir] working directory") << std::endl
 				 << _T("           [-DEV][-SILENT] -DEV generates logs, -SILENT suppresses logs/output files (off by default)") << std::endl
+				 << _T("           [-DEBUG port] wait for a rule debugger on 127.0.0.1:port, then run under it") << std::endl
 				 << _T("           [infile [outfile]] when no -IN or -OUT specified") << std::endl
 				 << std::endl
 				 << _T("Directories in the nlp.exe files:") << std::endl


### PR DESCRIPTION
The `.tree` dumps an analyzer writes give one snapshot per pass, which is enough to step through a run a pass at a time (that is what the extension's replay debugger does). What they cannot show is what happened **inside** a pass: which rules were tried at a node, which failed and how far each got before failing, and what the tree looked like part-way through. That is the question an author has when a rule does not fire.

```
nlp -ANA <analyzer> -IN <text> -DEBUG 9777
```

listens on 127.0.0.1:9777, waits for a client, and runs under it. Loopback only — an attached client can read the text being analysed.

## What it exposes

**Pause points:** pass start/end, before each rule attempt, on match (before the rule's actions run, so the tree is as it was when the match was decided), and on failure.

**Commands:** `continue`, `stepRule`, `stepMatch`, `stepPass`, `setBreakpoints` by pass and line, `stopOnFailure`, and `state` / `rule` / `node` / `tree` queries.

A failure reports how many rule elements matched before the rule gave up — the number that says *where* a rule stopped agreeing with the text.

## Protocol

Newline-delimited JSON over TCP, catalogued at the top of `nlpdebug.cpp`. Deliberately **not** DAP: that is a large spec with its own framing layer, and carrying it in C++ would mean a dependency and a lot of surface to maintain. The editor-side adapter already speaks DAP and translates, so what crosses this socket is only what the engine actually knows.

## Cost when off

Every hook is an inline test of one static bool, so a normal run pays one predictable branch per rule attempt. `matchRules` is the hottest loop in the engine, so this was the constraint the design started from.

Verified: running the corporate analyzer without `-DEBUG` produces **byte-identical** `ana004.tree` and `ana015.tree`.

## Where the hooks go

Both `Pat::matchRules` overloads (the `Delt` list and the `Selt` hashed path) carry the same three hooks, so stepping behaves the same whichever way a pass is dispatched. Passes are hooked in `Parse::stepExecute` — the interpreted driver for every pass type, which numbers and names passes exactly as the `.tree` headers do — and in `Arun::patExecute` for compiled analyzers.

The hooks are **armed only around `parse->execute()`**. Before it analyses anything the engine parses its own grammar with `Pat` and a bootstrap rule set, so without arming the debugger stops hundreds of times on rules the user never wrote. Not a theoretical concern: the first working version did exactly that, reporting `_LIT` rules at line 0.

## Also in here

- **`Pn::typeName()`** — the node-type spelling, from the same table `Pn::print` writes into the `.tree` dumps. `Pntype_s` is file-static, and a second copy would drift from `enum Pntype`.
- **`Nlppp::getNode()`** — declared in `nlppp.h` beside its siblings but never defined. Every internal caller is a friend class reading `node_` directly, so the gap never failed to link until something outside the friend list asked for it.

## Portability

Built and run on Windows/MSVC; every touched file also compiles clean under gcc 13 with the Linux defines. Two things MSVC hid:

- `_tcstol` has no definition here — it comes from MSVC's `<tchar.h>`, and `my_tchar.h` exists precisely because those symbols *"failed to compile on Linux and macOS"*. The flag parser uses `_ttoi`, which that header supplies.
- `nlpdebug.cpp`'s includes follow `pat.cpp`'s order. `thtab.h`, reached via `ielt.h`, calls `c_str()` from inside a template; gcc rejects the unqualified call unless `io.h` has already declared it, while MSVC accepts either order.

## Verified

Against the corporate analyzer on `Sold.txt`, the live reports match both the analyzer source and the post-mortem dumps:

| Reported | Cross-check |
| --- | --- |
| pass 4 `join` line 13 builds `_num` from `_xNUM . _xNUM` | matches `join.nlp:13` |
| pass 4 line 117 builds `_rank`, matched at node `1 [28-28]` | `ana004.tree` records that node as pass 4 ruleline 117 |
| breakpoint on pass 15 `moneyAttributes` line 35 | one of the four lines the tree confirms fired |

Version bumped to 3.9.0 (new feature, new public API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
