### PR TITLE
Expose NLP++ variables over the debug server (3.10.0)

### DIFF
--- a/.github/workflows/tests/rule-debugger/drive.py
+++ b/.github/workflows/tests/rule-debugger/drive.py
@@ -142,9 +142,9 @@ def main():
               "passName was %r" % stop.get("passName"))
 
         # ---- a breakpoint on the rule that fires ----------------------------
-        # Line 29 is the head of `_num <- _xNUM`, the only rule in the fixture
+        # Line 35 is the head of `_num <- _xNUM`, the only rule in the fixture
         # that matches the input.
-        r = dbg.request("setBreakpoints", **{"pass": 2, "lines": [29]})
+        r = dbg.request("setBreakpoints", **{"pass": 2, "lines": [35]})
         check("setBreakpoints is accepted", r.get("ok") is True)
         dbg.request("continue")
         stop = dbg.next_stop()
@@ -152,12 +152,12 @@ def main():
         if stop is None:
             return 1
         eq("stopped for the breakpoint", stop.get("reason"), "breakpoint")
-        eq("stopped on the breakpoint's line", stop.get("line"), 29)
+        eq("stopped on the breakpoint's line", stop.get("line"), 35)
 
         # ---- the rule the engine reports is the one in the file -------------
         r = dbg.request("rule")
         rule = r.get("rule") or {}
-        eq("rule line", rule.get("line"), 29)
+        eq("rule line", rule.get("line"), 35)
         eq("rule builds _num", rule.get("builds"), "_num")
         eq("rule element count", len(rule.get("elements") or []), 1)
         eq("rule element name", (rule.get("elements") or [{}])[0].get("name"), "_xNUM")
@@ -173,49 +173,103 @@ def main():
         check("current node is reported", bool(node.get("name")),
               "node was %r" % node)
 
-        # ---- failures report how far the rule got ---------------------------
-        # _pair (line 18) matches _xNUM and then fails, because the node after
-        # "42" is whitespace. That is the case worth pinning: the count comes
-        # off the collect list, which is a sibling chain, and reading it as a
-        # child list instead returns whatever the first matched node spans --
-        # for a wildcard, most of the document.
+        # ---- variables -------------------------------------------------------
+        # Every NLP++ variable kind is one Dlist<Ipair> in the engine, so one
+        # serializer covers them all -- which also means one broken field name
+        # silently returns an empty list. These assert the plumbing per kind.
         #
-        # _zzz (line 24) is never reported at all. Its trigger is the literal
-        # "zzz", and the engine's rule hashing only tries a rule at nodes its
-        # trigger could match, so a rule that cannot fire is never attempted.
-        # Worth asserting: "my rule never appears in the debugger" is a thing
-        # an author will hit, and this is the reason.
+        # We are stopped at the _num rule ATTEMPT, before its @POST has run, so
+        # G("runs") is not set yet. Stepping to the match and on lets the actions
+        # execute; the values are then readable and the built node keeps "kind"
+        # as an attribute.
+        r = dbg.request("collect")
+        coll = r.get("collect")
+        check("collect is a list", isinstance(coll, list), "got %r" % (coll,))
+
+        r = dbg.request("globals")
+        check("globals is a list", isinstance(r.get("globals"), list))
+        r = dbg.request("locals")
+        check("locals is a list", isinstance(r.get("locals"), list))
+        r = dbg.request("suggested")
+        check("suggested is a list", isinstance(r.get("suggested"), list))
+        r = dbg.request("context")
+        check("context is a list", isinstance(r.get("context"), list))
+
+        # One traversal gathers both what the rules SET and how they FAILED.
+        # They cannot be two passes over the pass: each stepRule consumes part of
+        # the traversal, so a second loop would start after the nodes the first
+        # one walked past -- and _pair only gets an element in at the number.
+        #
+        # _pair (line 20) matches _xNUM at "42" and then fails, because the node
+        # after it is whitespace. That count comes off the collect list, which is
+        # a sibling chain; reading it as a child list returns whatever the first
+        # matched node spans -- for a wildcard, most of the document.
+        #
+        # _zzz (line 26) is never reported at all. Its trigger is the literal
+        # "zzz", and the engine only tries a rule at nodes its trigger could
+        # match, so a rule that cannot fire is never attempted. Worth pinning:
+        # "my rule never appears in the debugger" is a thing an author will hit.
         dbg.request("setBreakpoints", **{"pass": 2, "lines": []})
         dbg.request("stopOnFailure", value=True)
-        partial = 0
+
+        partial = 0          # best eltsMatched seen for _pair
+        worst = 0            # largest eltsMatched seen for ANY failure
         zzz_seen = False
-        worst = 0
+        names = {}
+        attrs_found = []
         ended = False
+
         for _ in range(400):
             dbg.request("stepRule")
             stop = dbg.next_stop()
             if stop is None:
                 ended = True
                 break
-            if stop.get("reason") != "failed":
-                continue
-            worst = max(worst, stop.get("eltsMatched", 0))
-            if stop.get("line") == 24:
-                zzz_seen = True
-            if stop.get("line") == 18:
-                # _pair is tried at every node its trigger could match. At the
-                # number it gets one element in before the whitespace after it
-                # fails; everywhere else it collects nothing. The best it ever
-                # does is the interesting number.
-                partial = max(partial, stop.get("eltsMatched", 0))
 
+            if stop.get("reason") == "failed":
+                worst = max(worst, stop.get("eltsMatched", 0))
+                if stop.get("line") == 20:
+                    partial = max(partial, stop.get("eltsMatched", 0))
+                if stop.get("line") == 26:
+                    zzz_seen = True
+
+            # Once _num's @POST has run, G("runs") is set and the node it built
+            # carries S("kind") as an attribute.
+            if not names.get("runs"):
+                globs = dbg.request("globals").get("globals") or []
+                names = dict((g.get("name"), g.get("value")) for g in globs)
+                if "runs" in names:
+                    tree = dbg.request("tree", depth=3).get("tree") or {}
+
+                    def walk(n):
+                        for a in n.get("attributes") or []:
+                            attrs_found.append((n.get("name"), a.get("name"), a.get("value")))
+                        for c in n.get("children") or []:
+                            walk(c)
+
+                    walk(tree)
+
+            if partial and names.get("runs") and attrs_found:
+                break
+
+        check("a global set by a rule is readable", "runs" in names,
+              "globals were %r (run ended: %s)" % (names, ended))
+        eq("the global has the value the rule set", names.get("runs"), "1")
+        check("a node carries the attribute its rule set",
+              any(nm == "_num" and k == "kind" for nm, k, _v in attrs_found),
+              "attributes found: %r" % (attrs_found,))
+        check("the attribute keeps its value",
+              any(k == "kind" and v == '"number"' for _nm, k, v in attrs_found),
+              "attributes found: %r" % (attrs_found,))
         check("a partly-matched rule reports its element count", partial == 1,
-              "best eltsMatched for line 18 was %r" % partial)
+              "best eltsMatched for line 20 was %r" % partial)
         check("a rule whose trigger cannot match is never attempted", not zzz_seen)
         # The bug this guards: counting the collect list as children of a root
         # rather than as siblings reported 526 for a two-element rule.
         check("no failure reports more elements than a rule can have", worst <= 4,
               "largest eltsMatched seen was %d" % worst)
+
+        dbg.request("stopOnFailure", value=False)
 
         # ---- the run finishes ------------------------------------------------
         if not ended:

--- a/.github/workflows/tests/rule-debugger/spec/numbers.nlp
+++ b/.github/workflows/tests/rule-debugger/spec/numbers.nlp
@@ -6,10 +6,12 @@
 #           line numbers stable: drive.py refers to them by number, which is
 #           the point -- a rule's line is what a breakpoint is set on.
 #
-#           line 18  _pair   matches _xNUM then FAILS (the next node is
+#           line 20  _pair   matches _xNUM then FAILS (the next node is
 #                            whitespace, not a number) -> eltsMatched == 1
-#           line 24  _zzz    never matches anything    -> eltsMatched == 0
-#           line 29  _num    MATCHES the "42" in the input
+#           line 26  _zzz    trigger appears nowhere, so it is never attempted
+#           line 35  _num    MATCHES the "42" in the input, and its @POST sets
+#                            G("runs") and S("kind") for the variable commands
+#                            to read back
 ###############################################
 
 @NODES _ROOT
@@ -25,6 +27,10 @@ _zzz <-
 	zzz [s]	### (1)
 	@@
 
+@POST
+	G("runs") = 1;
+	S("kind") = "number";
+	single();
 @RULES
 _num <-
 	_xNUM [s]	### (1)

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build/
 bin/
 lib/
 .vscode/
+
+# Python bytecode from the debug-server test driver
+__pycache__/
+*.pyc

--- a/lite/nlpdebug.cpp
+++ b/lite/nlpdebug.cpp
@@ -29,7 +29,12 @@ All rights reserved.
 //   {"seq":8,"command":"tree","depth":3}            parse tree from the root
 //   {"seq":9,"command":"node"}                      current node, its children and attributes
 //   {"seq":10,"command":"rule"}                     the rule being tried, element by element
-//   {"seq":11,"command":"detach"}                   let the run finish unhooked
+//   {"seq":11,"command":"globals"}                  G("x")
+//   {"seq":12,"command":"locals"}                   L("x")
+//   {"seq":13,"command":"suggested"}                S("x") -- vars on the suggested node
+//   {"seq":14,"command":"context"}                  X("x") -- vars on the select node
+//   {"seq":15,"command":"collect"}                  matched elements, what N(n,"x") indexes
+//   {"seq":16,"command":"detach"}                   let the run finish unhooked
 //
 // Replies are {"seq":N,"ok":true,...} or {"seq":N,"ok":false,"error":"..."}.
 //
@@ -64,6 +69,9 @@ All rights reserved.
 #include "ielt.h"
 #include "isugg.h"
 #include "ielement.h"
+#include "ipair.h"
+#include "iarg.h"
+#include "pat.h"   // Pat::collectNthnew, for N(n,"x")
 #include "pn.h"
 #include "lite/nlpdebug.h"
 
@@ -328,6 +336,55 @@ std::set<long> fieldNumArray(const std::string &msg, const std::string &key)
 
 // ---- state serialisation ----------------------------------------------------
 
+// One Dlist<Ipair> as a JSON array of {"name","value"}.
+//
+// This one shape covers EVERY kind of NLP++ variable, because the engine stores
+// them all the same way (see Ivar::getVar):
+//
+//   G("x")     parse->getVars()
+//   L("x")     nlppp->getLocals()
+//   S("x")     nlppp->getDsem()
+//   N(n,"x")   the nth collect element's node -> pn->getDsem()
+//   X("x")     the select node -> pn->getDsem()
+//
+// ...and a node's own attributes are the same list again. Values are rendered
+// with Iarg::genArg, the same call Pn::print uses for the ("name" value) pairs
+// in the .tree dumps, so a value reads identically in the debugger and in a dump.
+std::string varsJson(Dlist<Ipair> *dlist)
+{
+	std::ostringstream o;
+	o << "[";
+	bool first = true;
+	if (dlist)
+	{
+		for (Delt<Ipair> *delt = dlist->getFirst(); delt; delt = delt->Right())
+		{
+			Ipair *pair = delt->getData();
+			if (!pair) continue;
+			if (!first) o << ",";
+			first = false;
+
+			// A variable can hold several values; genArg writes one at a time.
+			std::_t_ostringstream vals;
+			Dlist<Iarg> *list = pair->getVals();
+			bool firstVal = true;
+			if (list)
+			{
+				for (Delt<Iarg> *d = list->getFirst(); d; d = d->Right())
+				{
+					if (!firstVal) vals << _T(" ");
+					firstVal = false;
+					Iarg::genArg(d->getData(), vals, false);
+				}
+			}
+			o << "{\"name\":" << jstr(narrow(pair->getKey()))
+			  << ",\"value\":" << jstr(narrow(vals.str().c_str())) << "}";
+		}
+	}
+	o << "]";
+	return o.str();
+}
+
 // One node as a JSON object. Children are included only while depth remains --
 // a full parse tree can be tens of thousands of nodes and the client asks for
 // what it can display.
@@ -347,7 +404,12 @@ std::string nodeJson(Node<Pn> *node, int depth)
 	  << ",\"passNum\":" << jnum(pn->getPassnum())
 	  << ",\"ruleLine\":" << jnum(pn->getRuleline())
 	  << ",\"fired\":" << (pn->getFired() ? "true" : "false")
-	  << ",\"built\":" << (pn->getBuilt() ? "true" : "false");
+	  << ",\"built\":" << (pn->getBuilt() ? "true" : "false")
+	  // The node's own attributes -- what N("x") and X("x") read, and what the
+	  // .tree dumps print as ("name" value). Sent at every depth: they are the
+	  // reason to look at a node in the first place, and there are only ever a
+	  // handful per node.
+	  << ",\"attributes\":" << varsJson(pn->getDsem());
 
 	if (depth > 0)
 	{
@@ -540,6 +602,82 @@ void stopAndServe(NlpDebugStop reason)
 			reply(seq, "\"tree\":" + nodeJson(root, depth));
 			continue;
 		}
+		// ---- variables --------------------------------------------------
+		//
+		// Each of these is one Dlist<Ipair>; see varsJson for where the engine
+		// keeps each kind. They are separate commands rather than one bundle so
+		// a client can expand a single scope without paying for the rest --
+		// globals in particular can be numerous in a long-running analyzer.
+		if (cmd == "globals")
+		{
+			reply(seq, "\"globals\":" + varsJson(g_parse ? g_parse->getVars() : 0));
+			continue;
+		}
+		if (cmd == "locals")
+		{
+			reply(seq, "\"locals\":" + varsJson(g_nlppp ? g_nlppp->getLocals() : 0));
+			continue;
+		}
+		if (cmd == "suggested")
+		{
+			// S("x"): the variables being built for the node this rule suggests.
+			reply(seq, "\"suggested\":" + varsJson(g_nlppp ? g_nlppp->getDsem() : 0));
+			continue;
+		}
+		if (cmd == "context")
+		{
+			// X("x"): the variables on the pass's select node.
+			Node<Pn> *select = g_nlppp ? g_nlppp->getSelect() : 0;
+			Pn *pn = select ? select->getData() : 0;
+			reply(seq, "\"context\":" + varsJson(pn ? pn->getDsem() : 0));
+			continue;
+		}
+		if (cmd == "collect")
+		{
+			// The rule elements matched so far, in order -- what N(n,"x") indexes.
+			//
+			// The collect list is a chain of WRAPPER nodes, not the matched tree
+			// nodes: a wrapper's Down() points into the parse tree mid-chain, so
+			// walking it as if it were a child list runs off across the whole
+			// document. Pat::collectNthnew is the engine's own answer to "which
+			// node is element n", and Ivar::getVar uses exactly this call to
+			// resolve N(n,"x") -- including its rule that an element matching a
+			// RANGE of nodes has no addressable N().
+			std::ostringstream o;
+			o << "\"collect\":[";
+			bool first = true;
+			Tree<Pn> *collect = g_nlppp ? g_nlppp->getCollect() : 0;
+			// Nothing collected yet is the normal state at a rule ATTEMPT, and
+			// asking for element 1 of an empty list is not a question the engine
+			// expects; check here as well as in collectNth so the debugger does
+			// not depend on that fix being present.
+			if (collect && collect->getRoot())
+			{
+				for (long ord = 1; ; ++ord)
+				{
+					Node<Pn> *nstart = 0, *nend = 0;
+					if (!Pat::collectNthnew(collect, ord, /*UP*/ nstart, nend)
+						 || !nstart || !nend)
+						break;
+					if (!first) o << ",";
+					first = false;
+					o << "{\"ord\":" << jnum(ord)
+					  << ",\"single\":" << (nstart == nend ? "true" : "false")
+					  << ",\"node\":" << nodeJson(nstart, 0);
+					if (nstart != nend)
+					{
+						// Say how far the element reached, since N() cannot name it.
+						Pn *pe = nend->getData();
+						if (pe) o << ",\"spanEnd\":" << jnum(pe->getEnd());
+					}
+					o << "}";
+				}
+			}
+			o << "]";
+			reply(seq, o.str());
+			continue;
+		}
+
 		if (cmd == "detach")
 		{
 			reply(seq, "");

--- a/lite/post.cpp
+++ b/lite/post.cpp
@@ -5612,6 +5612,12 @@ if (!collect || ord <= 0)
 Node<Pn> *colls;
 Node<Pn> *coll1;
 colls = collect->getRoot();
+// An empty collect list has no nth element. Without this, ord == 1 skips the
+// loop below -- whose test is what guards every LATER hop -- and falls straight
+// into coll1->Down() on a null pointer. Callers inside a match never saw it
+// because something has always been collected by then.
+if (!colls)
+	return false;
 while (--ord > 0)
 	{
 	if (!(colls = colls->Right()))

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.9.0"
+#define NLP_ENGINE_VERSION "3.10.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The debug server could say which rule was being tried and whether it matched, but nothing about the values involved. It could not even report a node's own attributes — the `("name" value)` pairs `.tree` dumps have always printed — so the live debugger showed *less* about a node than the post-mortem file does.

## One shape covers every kind

The engine keeps all five kinds of NLP++ variable as a `Dlist<Ipair>` ([`Ivar::getVar`](https://github.com/VisualText/nlp-engine/blob/master/lite/ivar.cpp)), so one serializer covers them all:

| NLP++ | Lives in |
| --- | --- |
| `G("x")` | `parse->getVars()` |
| `L("x")` | `nlppp->getLocals()` |
| `S("x")` | `nlppp->getDsem()` |
| `N(n,"x")` | the *n*th collect element's node → `pn->getDsem()` |
| `X("x")` | the select node → `pn->getDsem()` |

…and a node's attributes are the same list again. Values render with `Iarg::genArg`, the same call `Pn::print` uses for the `.tree` dumps, so a value reads identically in the debugger and in a dump.

New commands: `globals`, `locals`, `suggested`, `context`, `collect` — one per kind rather than one bundle, so expanding a single scope in the editor does not pay for the rest.

## `N(n,"x")` needs the engine's own lookup

The collect list is a chain of **wrapper** nodes, not the matched tree nodes: a wrapper's `Down()` points into the parse tree mid-chain, so walking it as a child list runs off across the document. The first version reported a four-element rule as having children numbering 514, 513, 512, 511.

`Pat::collectNthnew` is the engine's own answer, and it is what `Ivar::getVar` uses to resolve `N(n,"x")` — including its rule that an element matching a **range** of nodes has no addressable `N()`. The command now uses it and reports the single/range distinction rather than implying a range is addressable.

## A null dereference in `Pat::collectNth`

Asking for element 1 of an **empty** collect list crashed the engine:

```cpp
colls = collect->getRoot();          // may be null
while (--ord > 0)
    if (!(colls = colls->Right()))   // guards later hops only
        return false;
coll1 = colls;
nstart = coll1->Down();              // null deref when ord == 1
```

For `ord == 1` the loop body never runs, so a null root falls straight through. Every existing caller only asks during a match, where something has always been collected by then — the debugger's `collect` command is the first to ask on an empty list, which is the *normal* state at a rule attempt. Fixed with the same guard the loop already applies to later hops; the debugger also checks before calling, so it does not depend on the fix being present.

## Testing

The fixture's `_num` rule now has an `@POST` setting `G("runs")` and `S("kind")`, and six new assertions read them back: each command returns a list, the global a rule set is readable afterwards with the value it set, and the node the rule built carries `"kind"` as an attribute with the value the `.tree` dump shows.

The variable and failure checks share one traversal, because they have to — every `stepRule` consumes part of the pass, so a second loop would start after the nodes the first walked past, and `_pair` only gets an element in at the number.

**27 assertions, all passing.** The debugged and undebugged runs still produce byte-identical parse trees, and the corporate analyzer's `ana015.tree` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
