### PR TITLE
Never wait for ever on a debugger that has gone away (3.10.1)

### DIFF
--- a/lite/nlpdebug.cpp
+++ b/lite/nlpdebug.cpp
@@ -128,6 +128,15 @@ RunMode g_mode = MODE_STEP_PASS; // so arming stops at the first pass
 bool g_stopOnFailure = false;
 bool g_detached = false;
 
+// How long a blocking socket call waits before checking whether it should keep
+// waiting, and how many of those waits add up to "this client is not coming
+// back". Being stopped at a breakpoint is a normal state that lasts as long as
+// the user is thinking, so the total has to be generous: 30 minutes.
+const int NLPDEBUG_RECV_TIMEOUT_SECS = 30;
+const int NLPDEBUG_IDLE_LIMIT = 60;
+const int NLPDEBUG_ACCEPT_TIMEOUT_SECS = 120;
+int g_idleTicks = 0;
+
 // Set only while the analyzer is running over the input text. The hooks are
 // inert outside that window -- see NlpDebug::arm().
 bool g_armed = false;
@@ -201,6 +210,41 @@ std::string jnum(long n)
 
 // ---- socket plumbing --------------------------------------------------------
 
+// Put a receive timeout on a socket.
+//
+// Every blocking call in here needs one. A debugger client that dies WITHOUT
+// closing its socket leaves the connection Established as far as TCP is
+// concerned -- no data flows, so nothing errors, and recv() blocks forever. The
+// engine then sits paused for the life of the machine, holding the port, with
+// the editor still believing a session is live. That is worse than the thing
+// the design was trying to avoid: losing the debugger is supposed to let the
+// analysis carry on, not freeze it.
+//
+// Windows takes a DWORD of milliseconds; POSIX takes a struct timeval.
+void setRecvTimeout(nlp_socket_t sock, int seconds)
+{
+#ifdef _WIN32
+	DWORD ms = (DWORD)(seconds * 1000);
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&ms, sizeof(ms));
+#else
+	struct timeval tv;
+	tv.tv_sec = seconds;
+	tv.tv_usec = 0;
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void *)&tv, sizeof(tv));
+#endif
+}
+
+// Did the last recv/accept fail merely because it timed out?
+bool timedOut()
+{
+#ifdef _WIN32
+	int e = WSAGetLastError();
+	return e == WSAETIMEDOUT;
+#else
+	return errno == EAGAIN || errno == EWOULDBLOCK;
+#endif
+}
+
 bool sendLine(const std::string &line)
 {
 	if (g_client == NLP_INVALID_SOCKET) return false;
@@ -233,7 +277,20 @@ bool readLine(std::string &out)
 		}
 		char buf[4096];
 		int n = (int)recv(g_client, buf, sizeof(buf), 0);
-		if (n <= 0) return false;
+		if (n == 0) return false;            // clean close
+		if (n < 0)
+		{
+			if (!timedOut()) return false;    // a real error
+			// A timeout on its own means nothing -- the user is reading the
+			// screen and has not pressed anything yet. Only a client that says
+			// nothing for a very long time is treated as gone.
+			if (++g_idleTicks < NLPDEBUG_IDLE_LIMIT) continue;
+			*gerr << _T("[debug: no word from the debugger in ")
+					<< (NLPDEBUG_RECV_TIMEOUT_SECS * NLPDEBUG_IDLE_LIMIT / 60)
+					<< _T(" minutes; carrying on without it.]") << std::endl;
+			return false;
+		}
+		g_idleTicks = 0;
 		g_inbuf.append(buf, (size_t)n);
 	}
 }
@@ -742,6 +799,38 @@ bool NlpDebug::listen(int port)
 
 	*gout << _T("[debug: waiting for a client on 127.0.0.1:") << port << _T("]") << std::endl;
 
+	// Bounded, for the same reason readLine's recv is: a -DEBUG run whose client
+	// never arrives (a cancelled launch, a crashed editor) would otherwise sit
+	// here for the life of the machine holding the port, and the next run cannot
+	// have it. Two minutes is far longer than an editor takes to connect.
+	//
+	// select() rather than SO_RCVTIMEO: that option bounds recv on a CONNECTED
+	// socket, and on Windows it does not apply to accept() at all -- the first
+	// version of this waited out a two-minute timeout that never fired.
+	{
+		fd_set readable;
+		FD_ZERO(&readable);
+		FD_SET(g_listen, &readable);
+		struct timeval tv;
+		tv.tv_sec = NLPDEBUG_ACCEPT_TIMEOUT_SECS;
+		tv.tv_usec = 0;
+		// The first argument is ignored on Windows and must be max fd + 1 on POSIX.
+		int ready = select((int)g_listen + 1, &readable, 0, 0, &tv);
+		if (ready <= 0)
+		{
+			if (ready == 0)
+				*gerr << _T("[debug: no debugger connected within ")
+						<< NLPDEBUG_ACCEPT_TIMEOUT_SECS
+						<< _T(" seconds; running without it.]") << std::endl;
+			else
+				*gerr << _T("[debug: waiting for a debugger failed; running without it.]")
+						<< std::endl;
+			nlp_closesocket(g_listen);
+			g_listen = NLP_INVALID_SOCKET;
+			return false;
+		}
+	}
+
 	g_client = accept(g_listen, 0, 0);
 	if (g_client == NLP_INVALID_SOCKET)
 	{
@@ -750,6 +839,11 @@ bool NlpDebug::listen(int port)
 		g_listen = NLP_INVALID_SOCKET;
 		return false;
 	}
+
+	// The same guard on the connection itself, so a client that dies without
+	// closing cannot leave the engine blocked in recv for ever.
+	setRecvTimeout(g_client, NLPDEBUG_RECV_TIMEOUT_SECS);
+	g_idleTicks = 0;
 
 	active_ = true;
 	g_detached = false;

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.10.0"
+#define NLP_ENGINE_VERSION "3.10.1"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Both blocking calls in the debug server were unbounded, so a debugger that vanished left the engine **paused for the life of the machine** — holding its port, with the editor still believing the session was live. Starting a new one then reported *"'NLP++: debug rules (live)' is already running"* and there was no way forward but Task Manager.

Seen in the wild: an `nlp.exe` idling at 0.25% CPU holding `127.0.0.1:49176` in both `Listen` and `Established`, long after its adapter had gone.

## recv

A client that dies **without closing** its socket leaves the connection `Established` as far as TCP is concerned. No data flows, so nothing errors, and `recv()` blocks indefinitely.

The socket now carries `SO_RCVTIMEO`, and a timeout is only fatal after the client has said nothing for **30 minutes** — being stopped at a breakpoint is a normal state that lasts as long as the user is thinking, so the total has to be generous.

## accept

The same hole one step earlier: a `-DEBUG` run whose client never arrives — a cancelled launch, a crashed editor — sat in `accept()` for ever.

This one needs `select()`, **not** `SO_RCVTIMEO`. That option bounds `recv` on a *connected* socket, and on Windows it does not apply to `accept()` at all. The first version of this fix set a two-minute accept timeout that never fired, and the test caught it waiting out the full 200 seconds.

## What happens on giving up

The engine detaches and **finishes the analysis** — matching what the file already claimed it should do: *losing the debugger must never take the analysis down with it*. Before this it did something worse than either: it froze.

## Verified by reproducing the orphan

Attach, let the engine stop and report it, then go silent while holding the socket open:

```
0.3s connected
0.5s engine reported a stop: {"event":"stopped","reason":"passStart","pass":1,...}
0.5s now going silent, holding the socket open...

engine exited after 6.9s, code 0     (with test-shortened timeouts)
   -> the analysis still completed
```

Before the fix it never exited. The no-client case likewise now completes normally instead of hanging.

| Check | Result |
| --- | --- |
| 27-assertion regression suite | passes |
| debugged vs undebugged `final.tree` | byte-identical |
| gcc/Linux syntax check | clean (`select`/`timeval` path) |

## Known wart

The "no word from the debugger" notice goes to `gerr`, which is redirected into the per-pass dump while a pass is running, so it doesn't reach the console. The behaviour is right; only the diagnostic is swallowed. Left alone rather than reworking the engine's stream redirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
