### PR TITLE
Step Out of a top-level statement lands on a rule, not the end of the run

### DIFF
--- a/.github/workflows/tests/rule-debugger/drive.py
+++ b/.github/workflows/tests/rule-debugger/drive.py
@@ -215,6 +215,20 @@ def statements(nlp, fixture, workdir, LINES):
                     check("on a line after the call",
                           (back.get("line") or 0) > LINES["call"],
                           "line was %r" % back.get("line"))
+
+                    # Step OUT again, now at depth 0. There is no function to
+                    # leave: what encloses an @POST is the rule stream, so this
+                    # has to land on a rule. Asking for a depth shallower than 0
+                    # is asking for something that never arrives, and the whole
+                    # analysis ran to the end -- Step Out behaving as Continue.
+                    dbg.request("stepOutStatement")
+                    out = dbg.next_stop()
+                    check("stepping out of a top-level statement does not run away",
+                          out is not None)
+                    if out is not None:
+                        check("it lands back among the rules",
+                              not out.get("statement"),
+                              "stopped at %r" % (out,))
     finally:
         try:
             sock.close()

--- a/lite/nlpdebug.cpp
+++ b/lite/nlpdebug.cpp
@@ -685,7 +685,17 @@ void stopAndServe(NlpDebugStop reason)
 		if (cmd == "stepOverStatement")
 			{ g_mode = MODE_STEP_STMT_OVER; g_stepDepth = g_stmtDepth; reply(seq, ""); return; }
 		if (cmd == "stepOutStatement")
-			{ g_mode = MODE_STEP_STMT_OUT;  g_stepDepth = g_stmtDepth; reply(seq, ""); return; }
+		{
+			// At depth 0 there is no function to step out OF: the body being
+			// stepped is an @CODE, @POST or @DECL region, and what encloses it
+			// is the rule stream. Asking for a shallower depth than 0 would be
+			// asking for something that never arrives, so the analysis would
+			// run to the end -- Step Out looking like Continue.
+			g_mode = g_stmtDepth > 0 ? MODE_STEP_STMT_OUT : MODE_STEP_RULE;
+			g_stepDepth = g_stmtDepth;
+			reply(seq, "");
+			return;
+		}
 
 		if (cmd == "setBreakpoints")
 		{


### PR DESCRIPTION
Found by using the statement stepping from #732 the way a user would.

At depth 0 there is no function to step out **of**. The body being stepped is an `@CODE`, `@POST` or `@DECL` region, and `MODE_STEP_STMT_OUT` waits for a depth shallower than the one the command arrived at — so from depth 0 it waited for a depth below zero, which never arrives. The analysis ran to completion: Step Out behaving as Continue, on the very button a user reaches for to leave a region they stepped into by accident.

What encloses an `@POST` is the rule stream, so at depth 0 the command now means the next rule attempt. Inside a function it is unchanged.

```
stopped: statement line 43 depth 0
stepOutStatement -> (before) the run terminated
                 -> (after)  step, line 32, a rule
```

Pinned in the driver at the point it already sits at depth 0, having just stepped out of `bumpRuns()`. 48 assertions, all passing locally on Windows.

No version bump: 3.12.0 is not tagged or released yet, so this is a fix to unreleased code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
