### PR TITLE
Stop on a block that holds exactly one statement (3.12.1)

### DIFF
--- a/.github/workflows/tests/rule-debugger/drive.py
+++ b/.github/workflows/tests/rule-debugger/drive.py
@@ -137,6 +137,9 @@ def fixtureLines(fixture):
                 lines["call"] = i
             if stripped.startswith('G("runs") = G("runs")'):
                 lines["fnbody"] = i
+            marker = text.split("### shape:")
+            if len(marker) == 2:
+                lines["shape:" + marker[1].strip()] = i
     return lines
 
 
@@ -241,6 +244,64 @@ def statements(nlp, fixture, workdir, LINES):
     return 0
 
 
+def blockShapes(nlp, fixture, workdir, LINES):
+    """Third session: which lines a walk through every block shape stops on.
+
+    A block holding exactly ONE statement is kept as a bare statement rather
+    than a one-element list, and only the list path carries the pause point.
+    So a single-statement `if` body -- much the commonest shape there is -- was
+    stepped straight over as though it were not there, and so was a
+    single-statement `while` body and a single-statement `else`. Every shape is
+    walked here because they differ in the engine, not just on the page.
+    """
+    started = attach(nlp, fixture, workdir)
+    if started is None:
+        return 1
+    proc, sock = started
+    dbg = Debugger(sock)
+    try:
+        dbg.request("setBreakpoints", **{"pass": 2, "lines": [LINES["shape:call"]]})
+        dbg.request("continue")
+        stop = dbg.next_stop()
+        check("the call into blockShapes is reached", stop is not None)
+        if stop is None:
+            return 1
+        dbg.request("setBreakpoints", **{"pass": 2, "lines": []})
+
+        seen = []
+        for _ in range(60):
+            dbg.request("stepStatement")
+            s = dbg.next_stop()
+            if s is None or not s.get("statement") or s.get("depth") == 0:
+                break
+            seen.append(s.get("line"))
+
+        eq("a single-statement `if` body stops", seen.count(LINES["shape:one"]), 1)
+        eq("a two-statement body still stops on both",
+           (seen.count(LINES["shape:twoA"]), seen.count(LINES["shape:twoB"])), (1, 1))
+        eq("a single-statement `else` body stops", seen.count(LINES["shape:elsed"]), 1)
+        # Once per iteration: the body is reached through the same path each
+        # time round, so a loop is also the check that the hook is not somehow
+        # one-shot.
+        eq("a single-statement `while` body stops once per iteration",
+           seen.count(LINES["shape:loop"]), 2)
+        # The counterpart: a body whose condition is false must stay silent.
+        # Stopping on every branch whether taken or not would look like
+        # stepping working while telling the author the wrong story.
+        eq("a body whose condition is false does not stop",
+           seen.count(LINES["shape:never"]), 0)
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+        try:
+            proc.wait(timeout=30)
+        except Exception:
+            proc.kill()
+    return 0
+
+
 def main():
     if len(sys.argv) != 4:
         print(__doc__)
@@ -252,7 +313,9 @@ def main():
     proc, sock = started
 
     LINES = fixtureLines(fixture)
-    for want in ("_pair", "_zzz", "_num", "call", "fnbody"):
+    for want in ("_pair", "_zzz", "_num", "call", "fnbody",
+                 "shape:call", "shape:one", "shape:never", "shape:twoA",
+                 "shape:twoB", "shape:elsed", "shape:loop"):
         if want not in LINES:
             print("FAIL: could not find %s in the fixture" % want)
             return 1
@@ -473,6 +536,9 @@ def main():
             proc.kill()
 
     if statements(nlp, fixture, workdir, LINES):
+        return 1
+
+    if blockShapes(nlp, fixture, workdir, LINES):
         return 1
 
     if FAILURES:

--- a/.github/workflows/tests/rule-debugger/spec/numbers.nlp
+++ b/.github/workflows/tests/rule-debugger/spec/numbers.nlp
@@ -24,6 +24,33 @@ bumpRuns(L("by")) {
 	return G("runs");
 }
 
+# Every block shape, for the statement debugger to walk. A block holding
+# exactly ONE statement is kept as a bare statement rather than a one-element
+# list, and only the list path used to carry the pause point -- so a
+# single-statement `if` body, much the commonest shape in NLP++, was stepped
+# straight over as though it were not there.
+blockShapes(L("n")) {
+	if (L("n") >= 1) {
+		G("one") = 1;			### shape: one
+	}
+	if (L("n") >= 99) {
+		G("never") = 1;			### shape: never
+	}
+	if (L("n") >= 1) {
+		G("twoA") = 1;			### shape: twoA
+		G("twoB") = 2;			### shape: twoB
+	}
+	if (L("n") >= 99) {
+		G("never") = 2;
+	} else {
+		G("elsed") = 1;			### shape: elsed
+	}
+	L("i") = 0;
+	while (L("i") < 2) {
+		L("i") = L("i") + 1;	### shape: loop
+	}
+}
+
 @@DECL
 
 @NODES _ROOT
@@ -43,6 +70,7 @@ _zzz <-
 	G("runs") = 1;
 	S("kind") = "number";
 	bumpRuns(10);
+	blockShapes(5);				### shape: call
 	single();
 @RULES
 _num <-

--- a/lite/rfasem.cpp
+++ b/lite/rfasem.cpp
@@ -33,6 +33,7 @@ All rights reserved.
 #include "istmt.h"						// 11/11/99 AM.
 #include "parse.h"	// For interning strings.	// 01/09/07 AM.
 #include "rfasem.h"
+#include "lite/nlpdebug.h"	// Statement-level debugger.
 
 /********************************************
 * FN:		Special Functions for Sem class.
@@ -590,7 +591,19 @@ switch (type_)
 		break;
 	case RSSTMT:
 		if (val_.stmt_)
+			{
+			// A block holding exactly ONE statement is kept as a bare RSSTMT and
+			// evaluated straight through, rather than as a one-element RSSTMTS
+			// list. Istmt::eval's loop over a list is where the current line is
+			// recorded and where the statement debugger pauses -- so without
+			// these two lines a single-statement `if` body, much the commonest
+			// shape there is, was stepped straight over as though the body were
+			// not there, and an error raised inside one was reported against
+			// whatever line happened to run last.
+			nlppp->getParse()->setLine(val_.stmt_->getLine());
+			NlpDebug::statement(nlppp, val_.stmt_->getLine());
 			return val_.stmt_->eval(nlppp, /*UP*/ val);
+			}
 		break;
 	case RSEXPR:
 		if (val_.expr_)

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.12.0"
+#define NLP_ENGINE_VERSION "3.12.1"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Reported from real use: stepping into a function, the debugger did not follow the `if` statements. It stopped on each `if` and jumped straight to the next one. In a function that is nothing but

```
if (L("num") >= 1 && L("num") <= 12) {
    pnmakevar(L("node"),"month",1);
}
```

repeated five times, that means **every line that does anything was invisible**.

### Cause

A block holding exactly ONE statement is kept as a bare `RSSTMT` rather than a one-element `RSSTMTS` list, and `RFASem::eval` evaluates it straight through. Only the list path runs `Istmt::eval`'s loop — which is where the current line is recorded and where the statement debugger pauses. Two statements in a block and it worked; one and it did not.

Measured before the fix, on a function holding one of each shape:

| shape | stops on the `if` | stops in the body |
| --- | --- | --- |
| braced, one statement | yes | **no** |
| braced, two statements | yes | yes, both |
| `if`/`else`, one statement each | yes | **no** |
| `while`, one-statement body | yes | **no** |

This is not an `if` problem. `if`, `else` and `while` all evaluate their block through `RFASem::eval`, so the fix in that one place covers all three. A single-statement `while` body now stops once per iteration:

```
 5  while (L("i") < 3) {
 6      L("i") = L("i") + 1;     <- 3 stops, one per iteration
```

It also means `parse->line_` was left pointing at whatever ran last while a one-statement block ran, so an error raised inside one was reported against the wrong line. Same two lines fix it.

### Tests

Every shape is walked in the fixture, because they differ in the engine and not just on the page: braced single, braced pair, single-statement `else`, a loop body, and a body whose condition is false and must stay silent. Verified the other way round too — against the previous binary **exactly the three new assertions fail and nothing else**:

```
FAIL a single-statement `if` body stops -- expected 1, got 0
FAIL a single-statement `else` body stops -- expected 1, got 0
FAIL a single-statement `while` body stops once per iteration -- expected 2, got 0
```

54 assertions, all passing locally on Windows.

### Known, not addressed

An **unbraced** body on its own line stops twice, because the if-statement records the body's line as its own:

```
5  if (L("n") >= 1)
6      G("b") = 2;      -> stops reported: 6, 6
```

Braced blocks — the reporter's code, and most NLP++ — are clean. Changing where a statement records its line reaches every error message in the interpreter, which is not worth doing behind a cosmetic double-step.

Version **3.12.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
