### PR TITLE
Stepping a loop lands on the test each time round (3.12.2)

### DIFF
--- a/.github/workflows/tests/rule-debugger/drive.py
+++ b/.github/workflows/tests/rule-debugger/drive.py
@@ -285,6 +285,14 @@ def blockShapes(nlp, fixture, workdir, LINES):
         # one-shot.
         eq("a single-statement `while` body stops once per iteration",
            seen.count(LINES["shape:loop"]), 2)
+        # Once on the way in, and once after each pass through the body. The
+        # last of those is the test that ends the loop, so it is reported
+        # before control leaves -- the condition is a line of the program and
+        # stepping should land on it. Without this the body's last statement
+        # steps straight back to the body's first, which reads as a loop with
+        # no test in it.
+        eq("the loop's test is reported before every attempt",
+           seen.count(LINES["shape:while"]), 3)
         # The counterpart: a body whose condition is false must stay silent.
         # Stopping on every branch whether taken or not would look like
         # stepping working while telling the author the wrong story.
@@ -315,7 +323,7 @@ def main():
     LINES = fixtureLines(fixture)
     for want in ("_pair", "_zzz", "_num", "call", "fnbody",
                  "shape:call", "shape:one", "shape:never", "shape:twoA",
-                 "shape:twoB", "shape:elsed", "shape:loop"):
+                 "shape:twoB", "shape:elsed", "shape:loop", "shape:while"):
         if want not in LINES:
             print("FAIL: could not find %s in the fixture" % want)
             return 1

--- a/.github/workflows/tests/rule-debugger/spec/numbers.nlp
+++ b/.github/workflows/tests/rule-debugger/spec/numbers.nlp
@@ -46,7 +46,7 @@ blockShapes(L("n")) {
 		G("elsed") = 1;			### shape: elsed
 	}
 	L("i") = 0;
-	while (L("i") < 2) {
+	while (L("i") < 2) {		### shape: while
 		L("i") = L("i") + 1;	### shape: loop
 	}
 }

--- a/lite/iwhilestmt.cpp
+++ b/lite/iwhilestmt.cpp
@@ -31,6 +31,7 @@ All rights reserved.
 #include "ivar.h"
 #include "lite/parse.h"														// 08/24/02 AM.
 #include "iwhilestmt.h"
+#include "lite/nlpdebug.h"	// Statement-level debugger.
 
 int Iwhilestmt::count_ = 0;
 
@@ -423,6 +424,20 @@ for (;;)				// EXECUTE THE WHILE-LOOP.
 	if (gui_.IsMessage(GUI_MESSAGE_ABORT))								// 12/08/00 DD.
 		break;																	// 12/08/00 DD.
 #endif
+	// Back to the top. The condition is about to be tested again, and that test
+	// IS the `while` line, so a client stepping through the body arrives back at
+	// the loop header rather than jumping from the last statement of the body
+	// straight to the first -- which reads as the loop having no test in it.
+	//
+	// Deliberately here and not before the condition at the top of the loop: the
+	// while statement is itself a statement in the enclosing list, which already
+	// reported it on the way in. Putting it here reports every test but the
+	// first, and the first has already been shown.
+	//
+	// Setting the line as well as reporting it also puts an error raised inside
+	// the condition on the `while` rather than on whatever the body ran last.
+	nlppp->parse_->line_ = line_;
+	NlpDebug::statement(nlppp,line_);
 	}											// END OF LOOP.
 	
 done:

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.12.1"
+#define NLP_ENGINE_VERSION "3.12.2"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Reported from real use: stepping through a `while` loop, the bottom of the body goes back to the **first line of the body** rather than to the `while`. The test that decides whether to go round again never appears, so the loop reads as having no condition in it — and there is no way to stop where the thing governing the loop is about to be evaluated.

### Cause

The condition is re-evaluated inside `Iwhilestmt::eval`'s own `for(;;)`, which never passes back through `Istmt::eval`'s loop over a statement list — and that loop is where the pause point lives. So the `while` line was reported once, on the way in, and never again however many times round it went.

Reporting it at the **bottom** of each iteration rather than at the top of the condition is what keeps the first one from doubling: the `while` statement is itself a statement in the enclosing list, which has already reported it on the way in. Every test but the first is reported here, and the first has already been shown.

```
4  L("i") = 0;
5  while (L("i") < 3) {
6      L("i") = L("i") + 1;
7      G("k") = L("i");
8  }
9  G("done") = 1;
```

| | stops |
| --- | --- |
| before | `4, 5, 6, 7, 6, 7, 6, 7, 9` |
| after | `4, 5, 6, 7, 5, 6, 7, 5, 6, 7, 5, 9` |

The last `5` is the test that ends the loop, reported before control leaves it — the condition is a line of the program and stepping should land on it.

Setting `parse->line_` alongside also puts an error raised inside the condition on the `while` rather than on whatever the body happened to run last.

### Tests

Pinned in the fixture, which already steps a loop: the test is expected once on the way in plus once per pass through the body. Verified the other way round — against 3.12.1 that one assertion fails, `expected 3, got 1`, and nothing else does. 56 assertions, passing locally on Windows.

Version **3.12.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
