### PR TITLE
An if-statement records its own line, not its body's (3.12.3)

### DIFF
--- a/.github/workflows/tests/rule-debugger/drive.py
+++ b/.github/workflows/tests/rule-debugger/drive.py
@@ -293,6 +293,18 @@ def blockShapes(nlp, fixture, workdir, LINES):
         # no test in it.
         eq("the loop's test is reported before every attempt",
            seen.count(LINES["shape:while"]), 3)
+        # An `if` with no braces and its body on the next line. The statement
+        # took its line from the BODY, so the two collided: stepping went from
+        # the statement before the `if` straight to the body, the test never
+        # appeared, and an error in the condition was reported a line late.
+        # Both lines have to show up, and separately.
+        eq("an unbraced `if` reports its own line", seen.count(LINES["shape:bareIf"]), 1)
+        eq("and its body reports the body's", seen.count(LINES["shape:bareBody"]), 1)
+        check("the test is reported before the body it guards",
+              LINES["shape:bareIf"] < LINES["shape:bareBody"]
+              and seen.index(LINES["shape:bareIf"]) < seen.index(LINES["shape:bareBody"]),
+              "stops were %r" % (seen,))
+
         # The counterpart: a body whose condition is false must stay silent.
         # Stopping on every branch whether taken or not would look like
         # stepping working while telling the author the wrong story.
@@ -323,7 +335,8 @@ def main():
     LINES = fixtureLines(fixture)
     for want in ("_pair", "_zzz", "_num", "call", "fnbody",
                  "shape:call", "shape:one", "shape:never", "shape:twoA",
-                 "shape:twoB", "shape:elsed", "shape:loop", "shape:while"):
+                 "shape:twoB", "shape:elsed", "shape:loop", "shape:while",
+                 "shape:bareIf", "shape:bareBody"):
         if want not in LINES:
             print("FAIL: could not find %s in the fixture" % want)
             return 1

--- a/.github/workflows/tests/rule-debugger/spec/numbers.nlp
+++ b/.github/workflows/tests/rule-debugger/spec/numbers.nlp
@@ -45,6 +45,10 @@ blockShapes(L("n")) {
 	} else {
 		G("elsed") = 1;			### shape: elsed
 	}
+	# No braces, and the body on its own line. The if-statement used to record
+	# the BODY's line as its own, so stepping never showed the test.
+	if (L("n") >= 1)				### shape: bareIf
+		G("bare") = 1;				### shape: bareBody
 	L("i") = 0;
 	while (L("i") < 2) {		### shape: while
 		L("i") = L("i") + 1;	### shape: loop

--- a/lite/postrfa.cpp
+++ b/lite/postrfa.cpp
@@ -4889,8 +4889,16 @@ else
 
 
 // Build if statement object.
+//
+// The line is the _IFPART's -- `if (cond)` -- and NOT pnif's, which is the
+// BODY. Those are the same line whenever the body opens with a brace on the
+// `if` line, which is why this went unnoticed; write the body on the next line
+// without braces and the statement recorded that next line as its own. Stepping
+// then went from the statement before the `if` straight to the body, never
+// showing the test, and an error in the condition was reported a line late.
+// Iwhilestmt is built from pncond for exactly this reason.
 Iifstmt *ifstmt = new Iifstmt(semcond, semif,
-										0, pnif->getLine());					// 03/12/02 AM.
+										0, pncond->getLine());				// 03/12/02 AM.
 RFASem *rfasem;
 rfasem = new RFASem(ifstmt);
 

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.12.2"
+#define NLP_ENGINE_VERSION "3.12.3"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Reported from real use: stepping went from 434 straight to 440, where 439 is

```
439    if (!L("first"))
440        L("file") << "\n";
```

The test never appeared. Step past the statement before it and you land inside the body, with no opportunity to stop where the condition that guards it is about to be evaluated.

### Cause

`postRFAifstmt` builds the statement from the rule

```
_IFSTMT <- _IFPART _xWILD [s one match=(_BLOCK _STMT _EXPR)]
```

and took its line from the **second** element — the body — rather than the first, the `if (cond)`. Those are the same line whenever the body opens with a brace on the `if` line, which is why it went unnoticed for so long. Write the body on the next line without braces and the statement records that next line as its own, colliding with the body's own report.

`Iwhilestmt` was already built from the condition node, which is why loops never showed this. One word, and the two now agree.

```
4  L("has") = 0;
5  if (L("has")) {          # false, body skipped
8  if (!L("has"))
9      G("unbraced") = 2;
```

| | stops |
| --- | --- |
| before | `4, 5, 9, 9, 10, …` — the test at 8 never reported |
| after | `4, 5, 8, 9, 10, …` |

An error raised inside such a condition was also reported a line late; the same word fixes that.

### Still true, and not a bug

`if (cond) stmt;` written entirely on one line reports that line twice, because two statements genuinely run there. Nothing short of column information could separate them.

### Tests

Pinned in the fixture with an unbraced `if` whose body is on the next line, asserting both lines appear, separately, and in order. Verified the other way round — against 3.12.2 the header's line is never reported (`expected 1, got 0`) and the body's is reported twice (`expected 1, got 2`). 59 assertions, passing locally on Windows.

Version **3.12.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
