### PR TITLE
Report the calls that led here (3.13.0)

### DIFF
--- a/.github/workflows/tests/rule-debugger/drive.py
+++ b/.github/workflows/tests/rule-debugger/drive.py
@@ -269,12 +269,15 @@ def blockShapes(nlp, fixture, workdir, LINES):
         dbg.request("setBreakpoints", **{"pass": 2, "lines": []})
 
         seen = []
-        for _ in range(60):
+        deep = None          # (depth, stack) at the innermost call
+        for _ in range(90):
             dbg.request("stepStatement")
             s = dbg.next_stop()
             if s is None or not s.get("statement") or s.get("depth") == 0:
                 break
             seen.append(s.get("line"))
+            if s.get("line") == LINES["shape:deepBody"] and deep is None:
+                deep = (s.get("depth"), dbg.request("stack").get("calls"))
 
         eq("a single-statement `if` body stops", seen.count(LINES["shape:one"]), 1)
         eq("a two-statement body still stops on both",
@@ -304,6 +307,29 @@ def blockShapes(nlp, fixture, workdir, LINES):
               LINES["shape:bareIf"] < LINES["shape:bareBody"]
               and seen.index(LINES["shape:bareIf"]) < seen.index(LINES["shape:bareBody"]),
               "stops were %r" % (seen,))
+
+        # ---- the calls that led here ------------------------------------
+        # A depth number alone says "you are somewhere three calls down" and
+        # leaves the user to work out where from. Each entry names what was
+        # called and the line it was called FROM, which is the half that makes
+        # a frame clickable.
+        #
+        # Nothing pops this list -- Ifunc::eval has several ways out and a pop
+        # on one would be missed by the others -- so it is indexed by depth and
+        # only the first `depth` entries are reported. Reading it three deep
+        # after shallower calls have already come and gone is what checks that.
+        check("the innermost call was reached", deep is not None)
+        if deep is not None:
+            depth, calls = deep
+            eq("three calls deep", depth, 3)
+            eq("one stack entry per call", len(calls or []), 3)
+            if calls and len(calls) == 3:
+                eq("outermost is the one the @POST made", calls[0].get("name"), "blockShapes")
+                eq("called from the @POST's line", calls[0].get("line"), LINES["shape:call"])
+                eq("then the call it made", calls[1].get("name"), "outer2")
+                eq("from the line that made it", calls[1].get("line"), LINES["shape:outerCall"])
+                eq("innermost is where we are", calls[2].get("name"), "inner2")
+                eq("from inside outer2", calls[2].get("line"), LINES["shape:innerCall"])
 
         # The counterpart: a body whose condition is false must stay silent.
         # Stopping on every branch whether taken or not would look like
@@ -336,7 +362,8 @@ def main():
     for want in ("_pair", "_zzz", "_num", "call", "fnbody",
                  "shape:call", "shape:one", "shape:never", "shape:twoA",
                  "shape:twoB", "shape:elsed", "shape:loop", "shape:while",
-                 "shape:bareIf", "shape:bareBody"):
+                 "shape:bareIf", "shape:bareBody",
+                 "shape:outerCall", "shape:innerCall", "shape:deepBody"):
         if want not in LINES:
             print("FAIL: could not find %s in the fixture" % want)
             return 1

--- a/.github/workflows/tests/rule-debugger/spec/numbers.nlp
+++ b/.github/workflows/tests/rule-debugger/spec/numbers.nlp
@@ -24,6 +24,15 @@ bumpRuns(L("by")) {
 	return G("runs");
 }
 
+# Two more levels, so the debugger's call stack has something to be wrong about.
+inner2(L("x")) {
+	G("deep") = L("x");			### shape: deepBody
+}
+
+outer2(L("x")) {
+	inner2(L("x"));				### shape: innerCall
+}
+
 # Every block shape, for the statement debugger to walk. A block holding
 # exactly ONE statement is kept as a bare statement rather than a one-element
 # list, and only the list path used to carry the pause point -- so a
@@ -49,6 +58,7 @@ blockShapes(L("n")) {
 	# the BODY's line as its own, so stepping never showed the test.
 	if (L("n") >= 1)				### shape: bareIf
 		G("bare") = 1;				### shape: bareBody
+	outer2(7);						### shape: outerCall
 	L("i") = 0;
 	while (L("i") < 2) {		### shape: while
 		L("i") = L("i") + 1;	### shape: loop

--- a/include/Api/lite/nlpdebug.h
+++ b/include/Api/lite/nlpdebug.h
@@ -126,6 +126,21 @@ public:
 	static void statement(Nlppp *nlppp, long line)
 		{ if (active_) statement_(nlppp, line); }
 
+	/**
+	 * A user-defined function is about to run its body.
+	 *
+	 * `pass` and `line` are the CALLER's, captured before Ifunc::eval swaps the
+	 * current pass to the one the function was defined in -- so they say where
+	 * the call was written, which is what a call stack is made of.
+	 *
+	 * There is deliberately no matching hook on the way out. The record is kept
+	 * indexed by call depth and rewritten by the next call at that depth, so a
+	 * body that returns early, errors, or exits the pass cannot leave the stack
+	 * drifted -- and Ifunc::eval has several ways out.
+	 */
+	static void callEnter(Nlppp *nlppp, const _TCHAR *name, long pass, long line)
+		{ if (active_) callEnter_(nlppp, name, pass, line); }
+
 	// The analyzer finished. Tells the client the run is over and closes.
 	static void runEnd()
 		{ if (active_) runEnd_(); }
@@ -138,6 +153,7 @@ private:
 	static void ruleMatched_(Nlppp *nlppp);
 	static void ruleFailed_(Nlppp *nlppp);
 	static void statement_(Nlppp *nlppp, long line);
+	static void callEnter_(Nlppp *nlppp, const _TCHAR *name, long pass, long line);
 	static void runEnd_();
 };
 

--- a/lite/ifunc.cpp
+++ b/lite/ifunc.cpp
@@ -38,6 +38,7 @@ All rights reserved.
 #include "parse.h"			// 08/22/02 AM.
 #include "chars.h"			// For deleting local strings. // 01/08/07 AM.
 #include "ifunc.h"
+#include "lite/nlpdebug.h"	// Statement-level debugger.
 #include "rfasem.h"
 
 #ifdef LINUX
@@ -610,6 +611,13 @@ long savepass = parse->currpass_;										// 08/22/02 AM.
 parse->currpass_ = pass_;													// 08/22/02 AM.
 long saveline = parse->line_;												// 02/02/05 AM.
 parse->line_ = line_;														// 02/02/05 AM.
+// Record the call for the debugger's stack. savepass/saveline are the CALLER's
+// -- taken before the swap above -- which is what a client needs to show the
+// line the call was made from. There is no matching hook on the way out: the
+// record is indexed by depth and rewritten on the next call at that depth, so a
+// body that returns early, throws, or exits the pass cannot leave the stack
+// drifted. See NlpDebug::callEnter.
+NlpDebug::callEnter(nlppp,name_,savepass,saveline);
 if (!body_->eval(nlppp, /*UP*/ sem))
 	{
 	std::_t_strstream gerrStr;

--- a/lite/nlpdebug.cpp
+++ b/lite/nlpdebug.cpp
@@ -41,7 +41,8 @@ All rights reserved.
 //   {"seq":17,"command":"stepOverStatement"}        next statement, running calls whole
 //   {"seq":18,"command":"stepOutStatement"}         run until this function returns
 //   {"seq":19,"command":"capabilities"}             what this build supports
-//   {"seq":20,"command":"detach"}                   let the run finish unhooked
+//   {"seq":20,"command":"stack"}                    the calls that led here
+//   {"seq":21,"command":"detach"}                   let the run finish unhooked
 //
 // Replies are {"seq":N,"ok":true,...} or {"seq":N,"ok":false,"error":"..."}.
 //
@@ -85,6 +86,7 @@ All rights reserved.
 #include <string>
 #include <vector>
 #include <map>
+#include <vector>
 #include <set>
 #include <sstream>
 #include <cctype>   // isspace, isdigit
@@ -172,6 +174,24 @@ long g_eltsMatched = -1;
 // rule's line or a statement's.
 long g_stmtLine = -1;
 long g_stmtDepth = 0;
+// One entry per live call, indexed by depth: g_calls[0] is the outermost call,
+// made at depth 1. Each says what was called and WHERE FROM -- the caller's pass
+// and line, captured before Ifunc::eval swaps the pass to the defining one.
+//
+// Nothing pops it. Ifunc::eval has several ways out (an early return, an error,
+// exitpass) and a pop placed on one of them would be missed by the others,
+// leaving a stack that drifts deeper the longer a run goes on. Instead a call at
+// depth d truncates to d-1 and appends, so the list is corrected by the next
+// call at that depth, and a reader only ever looks at the first `depth` entries
+// -- which are the ones that got there on the way to here.
+struct CallFrame
+{
+	std::string name;
+	long pass;
+	long line;
+};
+std::vector<CallFrame> g_calls;
+
 // The call depth the current step command was issued at. OVER and OUT compare
 // against this, which is why it is captured when the command arrives rather
 // than when the next statement does.
@@ -721,7 +741,32 @@ void stopAndServe(NlpDebugStop reason)
 			// Only features a client must know about BEFORE using them belong
 			// here. Everything else it can just try: an unknown command replies
 			// with an error rather than closing the connection.
-			reply(seq, "\"capabilities\":[\"statements\",\"variables\",\"nodeText\"]");
+			reply(seq, "\"capabilities\":[\"statements\",\"variables\",\"nodeText\",\"callStack\"]");
+			continue;
+		}
+		if (cmd == "stack")
+		{
+			// The calls that led here, outermost first. Only the first `depth`
+			// entries count: anything past that is a record of a call that has
+			// already returned, kept because nothing pops (see g_calls).
+			//
+			// Each entry names the function entered and the pass and line it was
+			// called FROM, which is what a client turns into a frame the user
+			// can click. The innermost frame -- where execution actually is --
+			// the client already has, from the stop itself.
+			std::ostringstream o;
+			o << "\"calls\":[";
+			long depth = g_stmtDepth;
+			if (depth > (long)g_calls.size()) depth = (long)g_calls.size();
+			for (long i = 0; i < depth; ++i)
+			{
+				if (i) o << ",";
+				o << "{\"name\":" << jstr(g_calls[(size_t)i].name)
+				  << ",\"pass\":" << jnum(g_calls[(size_t)i].pass)
+				  << ",\"line\":" << jnum(g_calls[(size_t)i].line) << "}";
+			}
+			o << "]";
+			reply(seq, o.str());
 			continue;
 		}
 		if (cmd == "state")
@@ -1135,6 +1180,20 @@ void NlpDebug::statement_(Nlppp *nlppp, long line)
 		g_stmtLine = -1;
 		return;
 	}
+}
+
+void NlpDebug::callEnter_(Nlppp *nlppp, const _TCHAR *name, long pass, long line)
+{
+	if (!g_armed) return;
+	long depth = nlppp ? nlppp->getDepth() : 0;   // already pushed by Ifunc::eval
+	if (depth < 1) return;
+	if ((long)g_calls.size() >= depth)
+		g_calls.resize((size_t)(depth - 1));
+	CallFrame frame;
+	frame.name = narrow(name);
+	frame.pass = pass;
+	frame.line = line;
+	g_calls.push_back(frame);
 }
 
 void NlpDebug::runEnd_()

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.12.3"
+#define NLP_ENGINE_VERSION "3.13.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
Reported from real use: the Call Stack pane said **"statement at line 537 — 4 calls deep"** and listed nothing else. The debugger knew how deep it was and not how it got there, so stepping into several levels left no way back out by eye, and no way to see the line any of the calls was made from.

The depth was all the engine had to give. It now records each call:

```
{"command":"stack"}
  -> {"ok":true,"calls":[
        {"name":"outer",  "pass":2,"line":23},
        {"name":"middle", "pass":2,"line":14},
        {"name":"deepest","pass":2,"line":9}]}
```

Outermost first. `pass` and `line` are the **caller's**, captured in `Ifunc::eval` before it swaps the current pass to the one the function was defined in — so they say where the call was written, which is what a frame is made of. The innermost frame, where execution actually is, the client already has from the stop itself.

### Nothing pops the list

`Ifunc::eval` has several ways out — an early return, an error, `exitpass` — and a pop placed on one would be missed by the others, leaving a stack that drifts deeper the longer a run goes on. Instead a call at depth *d* truncates the list to *d-1* and appends, so it is corrected by the next call at that depth, and a reader only ever looks at the first `depth` entries: the ones that got there on the way to here. Stale entries past that are records of calls that have already returned, and are ignored.

`"callStack"` joins the capabilities list, so a client can tell this engine from one that would answer "unknown command".

### Tests

The fixture grew two nested functions, and the suite reads the stack three deep **after shallower calls have already come and gone** — which is what exercises the truncation rather than just the appending. 68 assertions, passing locally on Windows.

Version **3.13.0** (a feature, not a fix). Needs [vscode-nlp#1199](https://github.com/VisualText/vscode-nlp/pull/1199) to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
