### PR TITLE
Version 4: NLP++ is debuggable (4.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ The NLP engine is the engine that runs text analyzers writtein in [NLP++](http:/
 1. Calling the nlp.exe command line executable (this is what the VSCode NLP++ Language Extension does)
 1. Calling from within C++ or another language that can call c++ functions
 
+## What's New in Version 4
+
+Version 4 is the release line in which **NLP++ became debuggable**. Version 3 was about how you build, deploy and install an analyzer; Version 4 is about watching one run.
+
+The debugging *experience* lives in the [NLP++ Language Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=dehilster.nlp) — breakpoints, stepping, variables and a call stack, in the editor. What the engine contributes is the machinery underneath it: a small debug server that the extension (or any other client) drives.
+
+### The debug server (`-DEBUG <port>`)
+
+Start the engine with `-DEBUG <port>` and it listens on a loopback socket, speaking newline-delimited JSON — one object per line, both directions. It runs until it reaches a pause point, sends an unsolicited `stopped` event, and blocks reading commands until one of them resumes it.
+
+- **Pause points:** a pass boundary; a rule about to be tried, one that matched, one that failed; and a statement about to run in an `@CODE`, `@POST` or `@DECL` body.
+- **Inspection:** the parse tree, the current node and the nodes after it, the rule being tried element by element, the matched elements behind `N(n)`, all five NLP++ variable kinds (`G()`, `L()`, `S()`, `X()`, `N()`), and the calls that led to where execution is.
+- **Stepping:** by rule, by match, by pass, and by statement — into a call, over one, or out of the current function.
+- **Capability handshake.** A client asks what a build supports (`capabilities`) rather than inferring it from this version string.
+- **It costs nothing when off.** Every hook is an inline test of one static `bool`, and the hooks are armed only while the analyzer runs over the input — never while the engine parses its own grammar.
+
+The message catalogue at the top of `lite/nlpdebug.cpp` is the authority on the protocol; the regression driver in `.github/workflows/tests/rule-debugger/` exercises it end to end.
+
+For a fuller narrative of the Version 4 work, see `docs/version-4/VERSION-4-OVERVIEW.md`.
+
 ## What's New in Version 3
 
 Version 3 is the release line in which NLP++ became **compilable, cloud-buildable, and installable from package managers**, while hardening the engine across all supported platforms. NLP++ is *glass-box*, **deterministic** NLP — the same input always produces the same output from rules you can read — and Version 3 makes that engine faster, easier to build, and easier to adopt.
@@ -83,6 +103,7 @@ Switch | Function
 -OUT | Output directory
 -WORK | Working director where the library and executable files are
 -DEV / -SILENT | -DEV generates logs, -SILENT suppresses logs/output files (off by default)
+-DEBUG | Port to serve the debug protocol on. The engine waits for a client, then stops at pass boundaries, rule attempts and statements so the client can step and inspect. Used by the VS Code extension's debugger; see "What's New in Version 4".
 [infile [outfile]] | when no -IN or -OUT specified
 
 # Calling NLP++ Analyzers from C++

--- a/docs/version-4/BLOG-version-4-wordpress.html
+++ b/docs/version-4/BLOG-version-4-wordpress.html
@@ -1,0 +1,226 @@
+<!--
+NOTE: hold publication until the debugger screenshots are in and the release has
+had a few days of real use. The version numbers are already 4.0.0.
+
+WORDPRESS POST — Gutenberg block format
+=======================================
+HOW TO USE:
+  1. In WordPress, create a new post.
+  2. Set the TITLE field to:
+       Inside Version 4 of the VisualText NLP++ Engine: Now You Can Watch It Run
+  3. Switch the editor to "Code editor" (top-right ⋮ menu → Code editor),
+     then paste everything BELOW this comment block.
+  4. Switch back to the Visual editor — the blocks will render natively.
+  Suggested excerpt:
+     NLP++ is deterministic, glass-box NLP. Version 4 adds a real debugger —
+     breakpoints, stepping, variables and a call stack inside a running analyzer —
+     plus a language server. The glass box now has a door.
+  Suggested tags: NLP++, VisualText, deterministic AI, explainable AI, debugger, language server, VS Code, Claude
+-->
+
+<!-- wp:paragraph {"className":"post-dateline"} -->
+<p class="post-dateline"><em>September 2026</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Version 3 was about how you <em>build, deploy, and install</em> an NLP++ analyzer — compiling to native code in one click, building in the cloud, installing from npm or pip. Version 4 is about something you do far more often than shipping: <strong>understanding what your analyzer just did.</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>For its whole life, NLP++ has been <strong>glass-box</strong> natural-language processing — rule-based, explainable, and <strong>deterministic</strong>: the same input yields the same output, every time, with rules a human can read and audit. That argument always had a gap in it, and it is worth naming honestly. You could read the rules. You could read the result. But you could not watch the decision being made. The only window into a run was a parse-tree dump on disk, read after the fact, from which you inferred backwards what must have happened.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Version 4 closes that gap. You can now set a breakpoint, run your analyzer, stop on the exact rule or the exact line, and look at what the engine is holding at that moment.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>The glass box now has a door.</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">A real debugger, in the editor you already use</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Press F5 in the VisualText extension and your analyzer runs under a debugger. Not a log, not a dump — a debugger, with everything that word normally implies:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+<!-- wp:list-item --><li><strong>Breakpoints</strong> on a rule, or on a line of imperative code inside an <code>@POST</code>, <code>@CODE</code> or <code>@DECL</code>.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li><strong>Stepping</strong> — over, into, out.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li><strong>Variables</strong> — every NLP++ kind: <code>G()</code> globals, <code>L()</code> locals, <code>S()</code> suggested, <code>X()</code> context, and <code>N()</code> matched elements, read at the moment you stopped.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li><strong>A call stack</strong> that names each function and opens at the line its call was written on.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li><strong>The nodes the rule is actually about</strong>, rather than the whole document tree.</li><!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>A rule that <em>failed</em> tells you how far it got before it stopped agreeing with the text — which is usually the entire question you were asking. And a rule that never fired at all says so, instead of leaving you staring at a breakpoint that silently never hits.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Two debuggers, and why they were not merged</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>There are two modes, and the difference between them is real rather than cosmetic.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Replay</strong> steps the per-pass parse trees a finished run already wrote to disk. Because the whole run is recorded rather than generated as you go, moving <em>backwards</em> costs nothing — Step Back and reverse-continue both work, so you can walk a node's history in either direction instead of re-running the analyzer to get back where you were. Its granularity is the pass.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Live</strong> drives a real <code>nlp</code> process stopped inside its rule-matching loop. It can stop between individual rule attempts and show you a partial match — but it is forward-only, because an engine cannot un-run.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>These could have been welded into one session with a config flag. They weren't, deliberately: a single debugger that silently lost Step Back depending on a setting would be worse than two that each tell you what they are.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Stepping through NLP++ code, including into functions</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><code>@POST</code>, <code>@CODE</code> and <code>@DECL</code> are ordinary imperative code, and Version 4 steps them line by line. A stop is reported <strong>before</strong> the line runs — which is the point, because the variables you read beside it are the state that line is about to act on, not its result.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Step Into enters a function call. The stop lands in the file the function was <em>written</em> in, not the caller's, its parameters read back as <code>L()</code> locals, and the globals it changes update as you step:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code>line 23   depth 1     L(): by = 10      G(): runs = 1
+line 24   depth 1                       G(): runs = 11</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:paragraph -->
+<p>The same three buttons mean different things depending on where you are, because an analyzer has two kinds of execution in it:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:table -->
+<figure class="wp-block-table"><table><thead><tr><th></th><th>at a rule</th><th>in a statement body</th></tr></thead><tbody>
+<tr><td><strong>Step Over</strong></td><td>next rule tried</td><td>next statement, calls run whole</td></tr>
+<tr><td><strong>Step Into</strong></td><td>next rule that matched</td><td>next statement, entering a call</td></tr>
+<tr><td><strong>Step Out</strong></td><td>next pass</td><td>until this function returns</td></tr>
+</tbody></table></figure>
+<!-- /wp:table -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What it took: a debug server inside the engine</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>None of this is scraped from output. The engine gained a small, documented protocol — start it with <code>nlp -DEBUG &lt;port&gt;</code> and it speaks newline-delimited JSON over a loopback socket. It runs until it reaches a pause point, sends a <code>stopped</code> event, and blocks reading commands until one of them resumes it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Two decisions in there are worth surfacing, because they are the sort of thing that decides whether a feature like this is usable or merely present.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>It costs nothing when off.</strong> Every hook is an inline test of one static boolean. An engine nobody is debugging pays for a branch.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>It is armed only for the analysis.</strong> Before the engine analyses anything it parses <em>its own grammar</em> with the same rule-matching code. An un-armed build stops hundreds of times on rules nobody wrote. That arming is asserted in the regression suite, because it is exactly the kind of property a later optimisation quietly removes.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And the engine is <em>asked</em> what it can do rather than having its version string interpreted:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code>{"command":"capabilities"}
+  -&gt; {"ok":true,"capabilities":["statements","variables","nodeText","callStack"]}</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:paragraph -->
+<p>A client pairs with whatever engine a user happens to have installed. A breakpoint is set long before anything could be tried and found missing, and a breakpoint that is accepted and then never fires is the worst outcome available — so when the engine turns out to be older, the breakpoint is withdrawn out loud with the reason.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">A language server, so NLP++ is not only a VS Code language</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Alongside the debugger, every language feature moved out of the extension and into a separate process speaking the <strong>Language Server Protocol</strong>: outline, hover, go-to-definition, find references, rename, completion, signature help, folding, semantic highlighting, quick fixes, structural diagnostics and formatting.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>For a VS Code user nothing changed — the same analysis produces the same answers. Two things did change underneath. Those features no longer compete with the tree views and analyzer commands for the extension host. And <strong>any editor that speaks LSP can now run them</strong>: point a client at <code>dist/server.js</code>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The move added no duplicate logic, because the analysis engines never depended on VS Code in the first place. The build enforces that: the server compiles under a Node-only configuration, where an accidental editor import fails the build rather than shipping.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The unglamorous half: finding out it was wrong</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>The honest part of this story is what happened when the debugger met a real analyzer for the first time.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Six bugs surfaced within hours. Every one was <strong>silent</strong> — nothing threw, nothing errored. The debugger simply told a slightly wrong story, which is the worst failure mode a debugging tool has:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+<!-- wp:list-item --><li>A block holding exactly <strong>one</strong> statement never stopped. Two statements in a body worked; one did not — and a single-statement <code>if</code> body is much the commonest shape in NLP++. The same flaw hit <code>if</code>, <code>else</code> and <code>while</code> alike.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li>A <code>while</code> loop's condition was reported once and never again, so stepping went from the bottom of the body straight back to its top, as though the loop had no test in it.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li>An <code>if</code> took its line number from its <em>body</em>, so with the body on the next line the test never appeared at all.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li>Starting the debugger opened on a tokenizer built into the engine, with every pane empty, because nothing the user had written had run yet.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li>Starting with a breakpoint set stopped somewhere else first — which looks exactly like a breakpoint being ignored.</li><!-- /wp:list-item -->
+<!-- wp:list-item --><li>And the call stack said "4 calls deep" while listing nothing at all.</li><!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>All six are fixed. More usefully: the layer where they lived had <strong>no tests</strong>, and CI was not running the debugger tests that did exist. Both are addressed — and the suites were checked the way a test suite has to be checked, by putting each shipped bug back and confirming the tests catch it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Why this is the version that matters</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Version 3 made a deterministic engine fast and easy to ship. Version 4 makes it <strong>inspectable while it runs</strong>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That is not a convenience feature. The case for glass-box NLP has always been that in critical-path systems — where "usually correct" is not good enough — you need to prove <em>why</em> a decision was made. Proving it by reading rules and inferring backwards from a dump is a very different proposition from stopping on the line, looking at the variables, and reading the call stack that led there.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Deterministic systems have always been auditable in principle. Now they are auditable in practice.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Built with an AI collaborator</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>As with Version 3, much of this was developed in collaboration with <strong>Claude</strong> (Anthropic's Claude Code) — visible in the commit history, including the six bug fixes above, each found by a person using the thing and fixed with a regression test that was verified to catch it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The symmetry Version 3 noted gets sharper here. A large language model helped build the tooling that makes a <strong>deterministic</strong> system auditable in motion. The LLM is the <em>development partner</em>; the runtime stays transparent and reproducible.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>You could always read the rules. Now you can watch them run.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p><strong>Get it:</strong> the <a href="https://marketplace.visualstudio.com/items?itemName=dehilster.nlp">VisualText extension</a> for VS Code, and the engine from <a href="https://github.com/VisualText/nlp-engine">VisualText/nlp-engine</a>.</p>
+<!-- /wp:paragraph -->

--- a/docs/version-4/BLOG-version-4.md
+++ b/docs/version-4/BLOG-version-4.md
@@ -1,0 +1,147 @@
+# Inside Version 4 of the VisualText NLP++ Engine: Now You Can Watch It Run
+
+*September 2026*
+
+Version 3 was about how you *build, deploy, and install* an NLP++ analyzer — compiling to native code in one click, building in the cloud, installing from npm or pip. Version 4 is about something you do far more often than shipping: **understanding what your analyzer just did.**
+
+For its whole life, NLP++ has been **glass-box** natural-language processing — rule-based, explainable, and **deterministic**: the same input yields the same output, every time, with rules a human can read and audit. That argument always had a gap in it, and it is worth naming honestly. You could read the rules. You could read the result. But you could not watch the decision being made. The only window into a run was a parse-tree dump on disk, read after the fact, from which you inferred backwards what must have happened.
+
+Version 4 closes that gap. You can now set a breakpoint, run your analyzer, stop on the exact rule or the exact line, and look at what the engine is holding at that moment.
+
+**The glass box now has a door.**
+
+## A real debugger, in the editor you already use
+
+Press F5 in the VisualText extension and your analyzer runs under a debugger. Not a log, not a dump — a debugger, with everything that word normally implies:
+
+- **Breakpoints** on a rule, or on a line of imperative code inside an `@POST`, `@CODE` or `@DECL`.
+- **Stepping** — over, into, out.
+- **Variables** — every NLP++ kind: `G()` globals, `L()` locals, `S()` suggested, `X()` context, and `N()` matched elements, read at the moment you stopped.
+- **A call stack** that names each function and opens at the line its call was written on.
+- **The nodes the rule is actually about**, rather than the whole document tree.
+
+<!-- SCREENSHOT 1 — the whole thing working.
+     Capture: the debugger stopped on a rule, with the pass file open and the
+     left-hand panes populated: Rule (line, builds, elements), Variables,
+     Globals, Current node, Nodes in play, Call Stack. This is the "it is a
+     real debugger" image, so favour a stop where several panes have content.
+     Suggested file: images/debugger-stopped-on-a-rule.png -->
+
+![The VisualText debugger stopped on an NLP++ rule, with the rule, variables, nodes and call stack panes filled in](images/debugger-stopped-on-a-rule.png)
+
+A rule that *failed* tells you how far it got before it stopped agreeing with the text — which is usually the entire question you were asking. And a rule that never fired at all says so, instead of leaving you staring at a breakpoint that silently never hits.
+
+<!-- SCREENSHOT 2 — variables.
+     Capture: the Variables pane expanded, showing G() / L() / S() / X() and
+     N() matched elements with real values at a stop. The point of the image is
+     that all five NLP++ kinds are there at once.
+     Suggested file: images/variables-at-a-stop.png -->
+
+![The Variables pane showing G, L, S, X and N values at a breakpoint](images/variables-at-a-stop.png)
+
+## Two debuggers, and why they were not merged
+
+There are two modes, and the difference between them is real rather than cosmetic.
+
+**Replay** steps the per-pass parse trees a finished run already wrote to disk. Because the whole run is recorded rather than generated as you go, moving *backwards* costs nothing — Step Back and reverse-continue both work, so you can walk a node's history in either direction instead of re-running the analyzer to get back where you were. Its granularity is the pass.
+
+**Live** drives a real `nlp` process stopped inside its rule-matching loop. It can stop between individual rule attempts and show you a partial match — but it is forward-only, because an engine cannot un-run.
+
+These could have been welded into one session with a config flag. They weren't, deliberately: a single debugger that silently lost Step Back depending on a setting would be worse than two that each tell you what they are.
+
+## Stepping through NLP++ code, including into functions
+
+`@POST`, `@CODE` and `@DECL` are ordinary imperative code, and Version 4 steps them line by line. A stop is reported **before** the line runs — which is the point, because the variables you read beside it are the state that line is about to act on, not its result.
+
+Step Into enters a function call. The stop lands in the file the function was *written* in, not the caller's, its parameters read back as `L()` locals, and the globals it changes update as you step:
+
+```
+line 23   depth 1     L(): by = 10      G(): runs = 1
+line 24   depth 1                       G(): runs = 11
+```
+
+<!-- SCREENSHOT 3 — stepping into a function.
+     Capture: stopped inside a @DECL function body, with the Call Stack showing
+     the frames that led there (function names, each opening at the line its
+     call was written on) and L() holding the function's parameter.
+     Suggested file: images/call-stack-inside-a-function.png -->
+
+![The Call Stack showing nested NLP++ function calls, each frame naming a function and its call line](images/call-stack-inside-a-function.png)
+
+The same three buttons mean different things depending on where you are, because an analyzer has two kinds of execution in it:
+
+| | at a rule | in a statement body |
+| --- | --- | --- |
+| **Step Over** | next rule tried | next statement, calls run whole |
+| **Step Into** | next rule that matched | next statement, entering a call |
+| **Step Out** | next pass | until this function returns |
+
+<!-- SCREENSHOT 4 — Nodes in play.
+     Capture: the "Nodes in play" pane at a MATCH, listing the nodes the rule
+     took as N(1), N(2)... with their text. Ideally next to the rule in the
+     editor so the labels line up with what is written in the rule.
+     Suggested file: images/nodes-in-play.png -->
+
+![The Nodes in play pane listing the nodes a rule matched, labelled N(1), N(2) and so on](images/nodes-in-play.png)
+
+## What it took: a debug server inside the engine
+
+None of this is scraped from output. The engine gained a small, documented protocol — start it with `nlp -DEBUG <port>` and it speaks newline-delimited JSON over a loopback socket. It runs until it reaches a pause point, sends a `stopped` event, and blocks reading commands until one of them resumes it.
+
+Two decisions in there are worth surfacing, because they are the sort of thing that decides whether a feature like this is usable or merely present.
+
+**It costs nothing when off.** Every hook is an inline test of one static boolean. An engine nobody is debugging pays for a branch.
+
+**It is armed only for the analysis.** Before the engine analyses anything it parses *its own grammar* with the same rule-matching code. An un-armed build stops hundreds of times on rules nobody wrote. That arming is asserted in the regression suite, because it is exactly the kind of property a later optimisation quietly removes.
+
+And the engine is *asked* what it can do rather than having its version string interpreted:
+
+```
+{"command":"capabilities"}
+  -> {"ok":true,"capabilities":["statements","variables","nodeText","callStack"]}
+```
+
+A client pairs with whatever engine a user happens to have installed. A breakpoint is set long before anything could be tried and found missing, and a breakpoint that is accepted and then never fires is the worst outcome available — so when the engine turns out to be older, the breakpoint is withdrawn out loud with the reason.
+
+## A language server, so NLP++ is not only a VS Code language
+
+Alongside the debugger, every language feature moved out of the extension and into a separate process speaking the **Language Server Protocol**: outline, hover, go-to-definition, find references, rename, completion, signature help, folding, semantic highlighting, quick fixes, structural diagnostics and formatting.
+
+For a VS Code user nothing changed — the same analysis produces the same answers. Two things did change underneath. Those features no longer compete with the tree views and analyzer commands for the extension host. And **any editor that speaks LSP can now run them**: point a client at `dist/server.js`.
+
+The move added no duplicate logic, because the analysis engines never depended on VS Code in the first place. The build enforces that: the server compiles under a Node-only configuration, where an accidental editor import fails the build rather than shipping.
+
+## The unglamorous half: finding out it was wrong
+
+The honest part of this story is what happened when the debugger met a real analyzer for the first time.
+
+Six bugs surfaced within hours. Every one was **silent** — nothing threw, nothing errored. The debugger simply told a slightly wrong story, which is the worst failure mode a debugging tool has:
+
+- A block holding exactly **one** statement never stopped. Two statements in a body worked; one did not — and a single-statement `if` body is much the commonest shape in NLP++. The same flaw hit `if`, `else` and `while` alike.
+- A `while` loop's condition was reported once and never again, so stepping went from the bottom of the body straight back to its top, as though the loop had no test in it.
+- An `if` took its line number from its *body*, so with the body on the next line the test never appeared at all.
+- Starting the debugger opened on a tokenizer built into the engine, with every pane empty, because nothing the user had written had run yet.
+- Starting with a breakpoint set stopped somewhere else first — which looks exactly like a breakpoint being ignored.
+- And the call stack said "4 calls deep" while listing nothing at all.
+
+All six are fixed. More usefully: the layer where they lived had **no tests**, and CI was not running the debugger tests that did exist. Both are addressed — and the suites were checked the way a test suite has to be checked, by putting each shipped bug back and confirming the tests catch it.
+
+## Why this is the version that matters
+
+Version 3 made a deterministic engine fast and easy to ship. Version 4 makes it **inspectable while it runs**.
+
+That is not a convenience feature. The case for glass-box NLP has always been that in critical-path systems — where "usually correct" is not good enough — you need to prove *why* a decision was made. Proving it by reading rules and inferring backwards from a dump is a very different proposition from stopping on the line, looking at the variables, and reading the call stack that led there.
+
+Deterministic systems have always been auditable in principle. Now they are auditable in practice.
+
+## Built with an AI collaborator
+
+As with Version 3, much of this was developed in collaboration with **Claude** (Anthropic's Claude Code) — visible in the commit history, including the six bug fixes above, each found by a person using the thing and fixed with a regression test that was verified to catch it.
+
+The symmetry Version 3 noted gets sharper here. A large language model helped build the tooling that makes a **deterministic** system auditable in motion. The LLM is the *development partner*; the runtime stays transparent and reproducible.
+
+You could always read the rules. Now you can watch them run.
+
+---
+
+**Get it:** the [VisualText extension](https://marketplace.visualstudio.com/items?itemName=dehilster.nlp) for VS Code, and the engine from [VisualText/nlp-engine](https://github.com/VisualText/nlp-engine).

--- a/docs/version-4/LINKEDIN-version-4.md
+++ b/docs/version-4/LINKEDIN-version-4.md
@@ -1,0 +1,43 @@
+# LinkedIn Post — NLP++ Engine Version 4
+
+---
+
+🔍 **NLP++ Engine v4 is here — now you can watch your analyzer run.**
+
+For years NLP++ has given you what LLMs can't: **explainable, rule-based, DETERMINISTIC** language analysis — same input, same output, every time, with rules you can audit. That's what makes it usable in **critical-path systems where statistical models simply can't go.**
+
+But there was a gap in that promise, and it's worth naming. You could read the rules. You could read the result. You **couldn't watch the decision being made** — the only window into a run was a parse-tree dump, read afterwards, from which you inferred backwards.
+
+**Version 4 closes it. The glass box now has a door.** 🚪
+
+🐛 **A real debugger.** Press F5 and your analyzer runs under breakpoints. Stop on a rule before it's tried, or on a line inside an `@POST`. Step over, into, out. A rule that *failed* tells you how far it got before it stopped agreeing with the text — usually the whole question you were asking.
+
+🔬 **Every variable, at the moment it matters.** `G()` globals, `L()` locals, `S()` suggested, `X()` context, `N()` matched elements — read exactly where you stopped, *before* the line runs. So what you see is the state that line is about to act on, not its result.
+
+📞 **Step into your functions.** A call stack that names each function and opens at the line its call was written on. Parameters read back as locals; globals update as you step.
+
+🎯 **The nodes the rule is actually about** — labelled `N(1)`, `N(2)`… the same names you'd write in the rule. Not the whole document tree.
+
+⏪ **And you can step BACKWARDS.** A replay mode walks the parse trees a finished run already wrote to disk, so reverse-stepping costs nothing. Walk a node's history in either direction instead of re-running to get back where you were.
+
+🔌 **NLP++ is no longer only a VS Code language.** Every language feature — outline, hover, go-to-definition, rename, diagnostics, formatting and more — now runs in a **Language Server**. Any LSP-speaking editor can use them.
+
+---
+
+One honest note, because it's the part I'd want to read. 📝
+
+The first time this debugger met a real analyzer, **six bugs surfaced within hours** — and every one was *silent*. Nothing threw. The debugger just told a slightly wrong story, which is the worst failure mode a debugging tool has. A single-statement `if` body was stepped straight over. A `while` loop never showed its own test. The call stack said "4 calls deep" and listed nothing.
+
+All fixed. More importantly: that layer had **no tests**, and CI wasn't running the ones that existed. Both fixed too — and the suites were checked the way test suites have to be checked, by **putting each bug back and confirming the tests catch it.**
+
+---
+
+Version 3 made a deterministic engine fast to run and easy to ship. Version 4 makes it **inspectable while it runs.** Deterministic systems have always been auditable in principle. Now they're auditable in practice. ✅
+
+Much of this was built in collaboration with **Claude (Anthropic's Claude Code)** — an LLM helping build the tooling that makes a *deterministic* system auditable in motion. The LLM is the development partner; the runtime stays transparent and reproducible.
+
+You could always read the rules. Now you can watch them run. 👀
+
+👉 Explore it: github.com/VisualText
+
+#NLP #NaturalLanguageProcessing #NLPplus #VisualText #ExplainableAI #GlassBoxAI #DeterministicAI #OpenSource #DeveloperTools #Debugging #LanguageServer #VSCode #AI #Claude

--- a/docs/version-4/VERSION-4-OVERVIEW.md
+++ b/docs/version-4/VERSION-4-OVERVIEW.md
@@ -1,0 +1,173 @@
+# VisualText NLP Engine — Version 4 Overview
+
+*An org-wide summary of the Version 4 work across the [VisualText](https://github.com/VisualText) repositories, with emphasis on the changes developed in collaboration with Claude (Anthropic's Claude Code / Claude Opus 5).*
+
+**Snapshot date:** September 2026 · **Engine:** v4.0.0 · **Extension:** v4.0.0
+
+> **Release status.** Engine and extension are both at **4.0.0**. The work shipped incrementally across the 3.10–3.13 (engine) and 3.13–3.17 (extension) lines and is live on the VS Code Marketplace; 4.0.0 is the point at which it is named. The announcement material in this folder is written and waiting on screenshots — see [Announcing it](#announcing-it).
+
+---
+
+## What "Version 4" means
+
+Version 3 was about **how you build, deploy, and install** an analyzer: one-click compiled analyzers, cloud builds, npm and pip packages. Version 4 is about **how you develop and understand one**. The headline shift is a single sentence:
+
+> **You can now watch an NLP++ analyzer run, and stop it wherever you like.**
+
+Concretely:
+
+1. **A real debugger.** Breakpoints, stepping, variables, and a call stack — inside a running analyzer. Stop on a rule before it is tried, on the statement in an `@POST` before it executes, or inside a `@DECL` function three calls deep, and read `G()`, `L()`, `S()`, `X()` and `N()` at that moment.
+2. **Two debuggers, honestly separated.** A **replay** debugger steps the per-pass parse trees a finished run already wrote to disk — so it can move *backwards*, which a live engine cannot. A **live** debugger drives a running `nlp` process stopped inside its rule-matching loop — so it can stop between individual rule attempts, which a dump cannot. They are offered as two modes rather than merged, because a single session that silently lost Step Back depending on a config value would be worse than two honest ones.
+3. **A language server.** Every language feature — outline, hover, go-to-definition, find references, rename, completion, signature help, folding, semantic highlighting, quick fixes, structural diagnostics and formatting — now runs in a separate process speaking LSP. The features themselves are not new; what is new is that they no longer compete with the tree views for the extension host, and that **any LSP-speaking editor can now run them**, not just VS Code.
+4. **A debug protocol in the engine.** The engine gained a small, documented, newline-delimited JSON server (`nlp -DEBUG <port>`) with a capability handshake, so a client can ask what a given build supports rather than inferring it from a version string.
+5. **Tests where there were none.** The debugger's two layers — the engine protocol and the DAP session — are now covered by suites that are checked against reintroduced bugs, and CI actually runs them. It did not before.
+
+> **Why it matters.** Version 3's case for NLP++ was that it is *glass-box*: explainable, rule-based, and **deterministic** — the same input always produces the same output, with rules a human can audit. That argument had a gap. You could read the rules and you could read the result, but you could not watch the decision being made; the only window into a run was a `.tree` dump read after the fact. Version 4 closes it. Auditing why a decision was made is no longer an act of inference — you can stop on the line and look. **The glass box now has a door.**
+
+---
+
+## The core engine — `nlp-engine`
+
+**Repo:** [VisualText/nlp-engine](https://github.com/VisualText/nlp-engine) · the C++ NLP++ engine.
+**Version journey:** v3.10.0 → v3.10.1 → v3.11.0 → v3.12.0 → v3.12.1 → v3.12.2 → v3.12.3 → v3.13.0 → **v4.0.0**.
+
+### 1. A debug server (`-DEBUG <port>`)
+
+Started with `-DEBUG`, the engine listens on a loopback port and speaks newline-delimited JSON, one object per line, in both directions. The engine runs until it reaches a pause point, sends an unsolicited `stopped` event, and blocks reading commands until one of them resumes it — strictly half-duplex, which is what makes it simple enough to reason about.
+
+The message catalogue lives at the top of `lite/nlpdebug.cpp` and is the authority.
+
+**Pause points**, each an inline test of one static `bool` so an un-attached engine pays essentially nothing:
+
+- a pass boundary (`passStart` / `passEnd`)
+- a rule about to be tried, one that matched, and one that failed
+- a statement about to run in an `@CODE`, `@POST` or `@DECL` body
+
+**Commands:** `continue`, `stepRule`, `stepMatch`, `stepPass`, `stepStatement`, `stepOverStatement`, `stepOutStatement`, `setBreakpoints`, `stopOnFailure`, `state`, `rule`, `node`, `tree`, `globals`, `locals`, `suggested`, `context`, `collect`, `stack`, `capabilities`, `detach`.
+
+### 2. Arming
+
+The hooks sit in the hottest loop in the engine, and the engine parses **its own grammar** with the same `Pat` code before it analyses anything. An un-armed build stops hundreds of times on rules nobody wrote. The debugger is therefore armed only for the analysis itself — and that is asserted in the regression suite, because it is exactly the kind of property a later optimisation removes without anyone noticing.
+
+### 3. Statement-level execution (v3.12.0)
+
+`@POST`, `@CODE` and `@DECL` are ordinary imperative code and all three run through the same `Istmt::eval` loop, so one hook covers them. A stop is reported **before** the statement runs — the state you read is the state that line is about to act on, not its result. `Ifunc::eval` already swapped the current pass to the one a function was *written* in, which is what makes a breakpoint inside a `@DECL` land in the right file.
+
+### 4. Four stepping fixes found by using it (v3.12.1 – v3.12.3)
+
+Each was found within hours of the feature reaching a real analyzer, and each was silent — nothing threw, the debugger simply told a slightly wrong story:
+
+| version | fix |
+| --- | --- |
+| 3.12.1 | A block holding exactly **one** statement is kept as a bare statement rather than a one-element list, and only the list path carried the pause point — so a single-statement `if` body, much the commonest shape in NLP++, was stepped straight over. Affected `if`, `else` and `while` alike. |
+| 3.12.2 | A loop's condition is re-evaluated inside `Iwhilestmt::eval`'s own loop, which never passes back through the statement hook — so the `while` line was reported once and never again. Stepping went from the bottom of the body straight back to its top, as though the loop had no test in it. |
+| 3.12.3 | An if-statement took its line from its **body** rather than from `if (cond)`. Identical whenever the body opens with a brace on the `if` line; write the body on the next line unbraced and the test never appeared at all. |
+| 3.12.1 | (Same change.) `parse->line_` was left pointing at whatever ran last inside a one-statement block, so an error raised in one was reported against the wrong line. |
+
+### 5. Call stacks (v3.13.0)
+
+The engine records each live call — the function entered, and the pass and line it was called **from**, captured before the current pass is swapped to the defining one.
+
+Nothing pops the list. `Ifunc::eval` has several ways out — an early return, an error, `exitpass` — and a pop placed on one would be missed by the others, leaving a stack that drifts deeper the longer a run goes on. Instead a call at depth *d* truncates the list to *d-1* and appends, so it is corrected by the next call at that depth and a reader only ever looks at the first `depth` entries. The suite reads the stack three deep *after* shallower calls have come and gone, which exercises the truncation rather than just the appending.
+
+### 6. Capability handshake
+
+```
+{"command":"capabilities"}
+  -> {"ok":true,"capabilities":["statements","variables","nodeText","callStack"]}
+```
+
+Asked rather than inferred from the version string. A client pairs with whatever engine the user happens to have installed, and a breakpoint is set long before anything could be tried and found missing — an accepted breakpoint that never fires is the worst of the available outcomes.
+
+---
+
+## The VS Code extension — `vscode-nlp`
+
+**Repo:** [VisualText/vscode-nlp](https://github.com/VisualText/vscode-nlp)
+**Version journey:** 3.13.0 → 3.14.x → 3.15.x → 3.16.x → 3.17.0 → **4.0.0**.
+
+### 1. The language server (3.13.0)
+
+Twelve providers moved out of the extension host into a Node process speaking LSP. The analysis engines were already free of any VS Code dependency, so the move added no duplicate logic — and the build enforces that by compiling the server under a Node-only config, where an accidental `vscode` import fails rather than ships.
+
+Three bugs surfaced during the migration, all of which would have been invisible in normal use: language features stopped answering for unsaved buffers when the server was scoped to saved files only; formatting could hang forever against an editor that does not implement `workspace/configuration`; and asking for the text of one line returned everything from that line to the end of the file.
+
+### 2. The replay debugger (3.13.0)
+
+F5 after a run steps the per-pass parse trees already on disk. Because the whole run is recorded rather than generated as you go, **Step Back and reverse-continue cost nothing** — you can walk a node's history in either direction instead of re-running the analyzer to get back where you were. Granularity is the pass.
+
+### 3. The live debugger (3.14.0 onward)
+
+Drives a real engine. What each release added:
+
+| version | |
+| --- | --- |
+| 3.14.0 | Rules debugged as they run — stop between individual rule attempts, see a rule that failed and how far it got. |
+| 3.14.1 | All five NLP++ variable kinds: `G()` globals, `L()` locals, `S()` suggested, `X()` context, `N()` matched elements. |
+| 3.14.5 | The text a rule is being matched against, sent by the engine from its own buffer. |
+| 3.15.0 | **Nodes in play** — at a match, exactly the nodes the rule took, labelled `N(1)`, `N(2)`… the same names you would write in the rule. At an attempt, the current node and the candidates after it. |
+| 3.15.1 | A breakpoint anywhere inside a rule stops on that rule. |
+| 3.16.0 | Breakpoints in `@CODE`, `@POST` and `@DECL`, and context-sensitive stepping. |
+| 3.16.1 | Starting the debugger lands on real code, not the built-in tokenizer. |
+| 3.16.2 | Starting with a breakpoint set takes you to the breakpoint. |
+| 3.17.0 | The Call Stack draws the calls that led here. |
+| 4.0.0 | The line is named Version 4. |
+
+### 4. Context-sensitive stepping
+
+An analyzer has two kinds of execution in it and one set of buttons:
+
+| | at a rule | in a statement body |
+| --- | --- | --- |
+| **Step Over** | next rule tried | next statement, calls run whole |
+| **Step Into** | next rule that matched | next statement, entering a call |
+| **Step Out** | next pass | until this function returns |
+
+---
+
+## Testing
+
+The debugger has two layers and both now have suites that are checked against **reintroduced bugs** rather than merely passing:
+
+- **Engine protocol** — a Python driver runs the fixture analyzer under `-DEBUG` across three engine sessions and asserts on what is reported at each pause point. **68 assertions.** Every block shape is walked, because they differ in the engine and not just on the page.
+- **DAP session** — the session is driven in process over a pair of streams against a fake engine: no VS Code, no Electron, no `nlp` binary. **44 assertions.**
+- **Engine client** — the wire: split reads, coalesced messages, correlation, waiters left hanging when the engine exits. **68 assertions.**
+
+Each of the shipped debugger bugs was put back and confirmed to fail the suite — 1, 2, 3 and 5 assertions respectively.
+
+**CI never ran the debugger or trace tests at all.** They existed in `package.json` and no workflow invoked them, which is how three bugs reached a release with a green tick. Now wired in.
+
+---
+
+## Known limits
+
+Stated plainly, because a debugger that is quietly wrong about something is worse than one that says so:
+
+- **Selecting an outer call frame does not rewind the panes.** The engine keeps one set of locals, the live one, so every scope reads current state whichever frame is selected.
+- **`if (cond) stmt;` written entirely on one line reports that line twice**, because two statements genuinely run there. Nothing short of column information could separate them.
+- **The replay debugger's granularity is the pass**, not the rule: between two snapshots the engine ran a whole pass, so there is no inspecting a partial match and no changing a value and continuing.
+- **Statement stepping applies to interpreted passes.** A natively compiled pass has no NLP++ line to stop on.
+- **No conditional breakpoints.**
+
+---
+
+## Announcing it
+
+The version numbers moved first, deliberately: the code was already published, so the bump names what users can already install rather than gating it. Two things are worth having in place before the blog and LinkedIn posts go out:
+
+1. **Screenshots.** `BLOG-version-4.md` carries four marked slots with notes on what to capture. A debugger article without pictures of the debugger is a hard sell.
+2. **Mileage.** A few days of real use. Six bugs surfaced in the first hours this met a real analyzer, every one of them silent — all fixed and all now covered by tests that were verified to catch them, but an announcement points attention at the newest surface.
+
+A **walkthrough** is the other thing worth writing: a debugger nobody knows how to start is invisible.
+
+### Version numbering
+
+4.0.0 is a **marketing major, not a semver one** — nothing in this line breaks compatibility, and the engine's protocol additions are all additive behind a capability handshake. The bump also resynchronises the two version lines, which had drifted to engine 3.13 against extension 3.17 under a single "Version 3" brand.
+
+---
+
+## Built with an AI collaborator
+
+As with Version 3, much of this line was developed in collaboration with **Claude** (Anthropic's Claude Code), visible in the commit history through `Co-Authored-By` trailers.
+
+The symmetry Version 3 pointed at gets sharper here. A large language model helped build the tooling that makes a **deterministic** system auditable in motion — breakpoints, a call stack, variables you can read at the moment a rule fires. The LLM is the development partner; the runtime stays transparent and reproducible. You can always read the rules, and now you can watch them run.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.13.0"
+#define NLP_ENGINE_VERSION "4.0.0"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &, bool &, int &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The name for what v3.10 through v3.13 built. **No behaviour changes** — the version number, the README, and the announcement material.

Version 3 was the line in which NLP++ became compilable, cloud-buildable and installable from package managers: how you *build, deploy and install* an analyzer. Version 4 is how you *develop and understand* one.

Glass-box NLP has always meant you could read the rules and audit the result. What you could not do was **watch the decision being made** — the only window into a run was a `.tree` dump read afterwards, from which you inferred backwards. Stopping on the line and reading the variables is a different proposition. The glass box now has a door.

### What's in this PR

- **`nlp/main.cpp`** — version to `4.0.0`.
- **`README.md`** — a brief "What's New in Version 4" section, and `-DEBUG` documented in the switches table. Brief by design: the debugging *experience* lives in the VS Code extension, and this README points there. What it documents is the machinery underneath — pause points, inspection and stepping commands, the capability handshake, and the fact that an engine nobody is debugging pays for one branch.
- **`docs/version-4/`** — the announcement material, in the shape of `docs/version-3/`: an org-wide overview, the blog article, a WordPress-ready Gutenberg version, and a LinkedIn post.

### On the timing

The blog carries **four marked slots for debugger screenshots** and is held until those are in and the release has had a few days of real use. The numbers move first because the code was already published — the bump names what users can already install rather than gating it.

Six bugs surfaced in the first hours this met a real analyzer, every one of them silent. All are fixed, and all are now covered by tests that were verified to catch them by putting each bug back. The overview says so plainly rather than omitting it, including a "Known limits" section.

### Version numbering

`4.0.0` is a **marketing major, not a semver one**: nothing in this line breaks compatibility and the protocol additions are additive behind the capability handshake. It also resynchronises the engine with the extension, which had drifted to 3.13 against 3.17 under a single "Version 3" brand.

Pairs with [vscode-nlp#1200](https://github.com/VisualText/vscode-nlp/pull/1200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
